### PR TITLE
Add Ollama support, strategy builder, data grounding & open-source prep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ GROWW_REDIRECT_URL=http://localhost:8765/groww/callback
 #   openai              — OpenAI GPT API key
 #   gemini              — Google Gemini API key (Google AI Studio)
 #   claude_subscription — Claude Pro/Max subscription via CLI (no key needed)
+#   ollama              — Ollama locally-hosted models (free, no key needed)
 #   openai_subscription — ChatGPT Plus/Team via session token (unofficial)
 #   gemini_subscription — Vertex AI / Google Workspace (GCP project)
 # ─────────────────────────────────────────────────────────────
@@ -77,6 +78,18 @@ FYERS_REDIRECT_URL=http://127.0.0.1:8765/fyers/callback
 # Free tier: 100 req/day — https://newsapi.org/
 # NEWSAPI_KEY=your_newsapi_key_here
 NEWSAPI_ENABLED=1
+
+# ── Ollama / Local LLM (optional) ───────────────────────────
+# Run any model locally for free: brew install ollama && ollama pull llama3.1
+# AI_PROVIDER=ollama
+# OLLAMA_MODEL=llama3.1
+# OLLAMA_BASE_URL=http://localhost:11434/v1
+
+# ── Custom OpenAI-compatible endpoint (optional) ────────────
+# Works with: Groq, Together AI, OpenRouter, LM Studio, vLLM, etc.
+# AI_PROVIDER=openai
+# OPENAI_BASE_URL=https://api.groq.com/openai/v1
+# OPENAI_API_KEY=gsk_...
 
 # ── Telegram Bot (optional) ─────────────────────────────────
 # Create via @BotFather on Telegram

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,20 @@
 # ── Secrets ──────────────────────────────────────────────────
 .env
 *.env
+!.env.example
+*.key
+*.pem
+*.secret
 
 # ── Broker tokens (stored locally) ───────────────────────────
 ~/.trading_platform/
 *.json.token
+*_token.json
+*_credentials.json
+
+# ── Telegram bot data ────────────────────────────────────────
+telegram_chat_id.txt
+*.chat_id
 
 # ── Python ───────────────────────────────────────────────────
 __pycache__/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this software in your work, please cite it as below."
+type: software
+title: "India Trade CLI"
+abstract: "AI-powered multi-agent stock & options analysis platform for Indian markets (NSE/BSE/NFO)."
+authors:
+  - family-names: "Indian"
+    given-names: "Archie"
+    alias: "ArchieIndian"
+repository-code: "https://github.com/ArchieIndian/india-trade-cli"
+license: MIT
+keywords:
+  - trading
+  - stocks
+  - options
+  - NSE
+  - BSE
+  - India
+  - AI
+  - LLM
+  - multi-agent
+  - backtesting

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Archie Indian
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,36 +4,47 @@ AI-powered multi-agent stock & options analysis platform for Indian markets (NSE
 
 > **Philosophy:** Every trade must be justified. Analyze first, debate second, execute third.
 
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+
 ---
 
-## Architecture
+## What It Does
+
+A terminal-first trading assistant that runs **7 AI analyst agents** on any Indian stock, makes them **debate** bull vs bear, then produces a **fund-manager-grade synthesis** with concrete trade plans.
 
 ```
 analyze RELIANCE
         |
-  [7 Analyst Agents]  ← pure Python, parallel
+  [7 Analyst Agents]  <- pure Python, parallel
   Technical | Fundamental | Options | News(LLM) | Sentiment | Sector Rotation | Risk Manager
         |
-  [Analyst Scorecard]  ← weighted composite score + conflict detection
+  [Analyst Scorecard]  <- weighted composite score + conflict detection
         |
-  [Multi-Round Debate]  ← 5 LLM calls
-  Bull R1 → Bear R1 → Bull Rebuttal → Bear Rebuttal → Facilitator
+  [Multi-Round Debate]  <- 5 LLM calls
+  Bull R1 -> Bear R1 -> Bull Rebuttal -> Bear Rebuttal -> Facilitator
         |
-  [Fund Manager Synthesis]  ← 1 LLM call
+  [Fund Manager Synthesis]  <- 1 LLM call
   Verdict: BUY/SELL/HOLD + confidence + rationale
         |
-  [Risk Management Team]  ← pure Python
+  [Risk Management Team]  <- pure Python
   Aggressive | Neutral | Conservative trade plans
         |
   [Trade Plan]
   Entry orders, stop-loss, targets, position sizing, scaling logic
 ```
 
-**Standard mode: 8 LLM calls.** Deep mode (`deep-analyze`): 11 LLM calls — every analyst is LLM-powered.
+**Standard mode: 8 LLM calls.** Deep mode (`deep-analyze`): 11 LLM calls with every analyst LLM-powered.
 
 ---
 
 ## Quick Start
+
+### Prerequisites
+
+- **Python 3.11+**
+- **One AI provider** (Gemini free tier works great, or Claude/OpenAI)
+- **No broker account needed** for analysis (yfinance provides free NSE/BSE data)
 
 ### 1. Clone & install
 
@@ -41,328 +52,264 @@ analyze RELIANCE
 git clone https://github.com/ArchieIndian/india-trade-cli.git
 cd india-trade-cli
 python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -e .
 ```
 
 ### 2. Run
 
 ```bash
-python -m app.main
+trade
+# or: python -m app.main
 ```
 
 First run prompts you to:
-1. Choose a broker (or Demo for mock data)
-2. Choose an AI provider
+1. Choose a broker (pick **Demo** to skip, or **No Broker** for real data via yfinance)
+2. Choose an AI provider (Gemini is free and works well)
 
-**No broker needed for analysis** — yfinance provides free Indian market data automatically.
+That's it. You're in the REPL. Type `analyze RELIANCE` to see it work.
 
----
-
-## Broker Setup
-
-### Fyers (Recommended — free, real-time data)
-
-Fyers is the primary supported broker with full API integration including WebSocket for real-time quotes.
-
-1. **Create account** at [fyers.in](https://fyers.in)
-2. **Create API app** at [myapi.fyers.in](https://myapi.fyers.in)
-   - App Name: anything (e.g. "TradeCLI")
-   - Redirect URL: `http://127.0.0.1:8765/fyers/callback` (must be exact)
-3. **Get credentials**: App ID (format `XXXX-100`) + Secret ID
-4. **Login in the platform**:
-   ```
-   python -m app.main
-   > Choose: [5] Fyers
-   > Enter App ID: HFT99GVTDY-100
-   > Enter Secret Key: (paste, won't show — that's normal for secrets)
-   ```
-5. Browser opens → login with Fyers credentials → copy `auth_code` from redirect URL → paste back
-
-Token is saved for 12 hours. Next login auto-resumes if token is valid.
-
-**WebSocket**: Auto-connects on login for real-time quotes (instant instead of 1-3s REST calls).
-
-### Other Brokers (WIP)
-
-Basic implementations exist for these brokers but are not fully tested. Fyers is the recommended primary broker:
-
-| Broker | Status | Notes |
-|--------|--------|-------|
-| **Fyers** | **Fully supported** | Free API, WebSocket, options chain |
-| Zerodha | Basic implementation | Requires Kite Connect (paid) |
-| Angel One | Basic implementation | Free SmartAPI, TOTP login |
-| Upstox | Basic implementation | Free API, OAuth redirect |
-| Groww | Basic implementation | No historical data API |
-| Mock/Demo | Fully supported | Synthetic data, no login needed |
-
-### No broker needed
-
-The platform works without any broker login:
+### 3. No-broker mode (recommended for first try)
 
 ```bash
-python -m app.main --no-broker
+trade --no-broker
 ```
 
-- **yfinance** provides free real NSE/BSE data (~15 min delayed)
-- All analysis, backtesting, multi-timeframe, and AI features work with real data
-- Account commands (funds, holdings) show demo data with a warning
-- Options data uses NSE public API when available
-- Connect a broker later via `login` command in the REPL
+Uses yfinance for real NSE/BSE data (~15 min delayed). All analysis, backtesting, and AI features work. Connect a broker later via the `login` command.
 
 ---
 
 ## AI Provider Setup
 
-Choose one AI provider for the analysis brain:
+You need one AI provider for the analysis brain. The platform guides you through setup on first run, or you can configure manually:
 
 | Provider | Cost | Setup |
 |----------|------|-------|
-| **Claude subscription** | Free (your plan) | Install `claude` CLI: `npm i -g @anthropic-ai/claude-code` → `claude login` |
 | **Gemini** | Free tier available | Get key at [aistudio.google.com](https://aistudio.google.com) |
+| **Claude (subscription)** | Free with Pro/Max plan | Install CLI: `npm i -g @anthropic-ai/claude-code` then `claude login` |
 | Claude API | Pay per token | Key from [console.anthropic.com](https://console.anthropic.com) |
 | OpenAI GPT-4o | Pay per token | Key from [platform.openai.com](https://platform.openai.com) |
 
-Switch anytime: `provider gemini` or `provider claude_subscription`
+**Switch anytime:** `provider gemini` or `provider claude_subscription`
+
+### Manual config (optional)
+
+Copy the example env file and fill in your keys:
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+```
+
+Or use the interactive credential manager:
+
+```bash
+trade
+> credentials setup
+```
+
+All credentials are stored in your OS keychain (macOS Keychain / Linux Secret Service / Windows Credential Locker) — never in plain text files.
 
 ---
 
-## Optional: NewsAPI Setup
+## Broker Setup (Optional)
 
-Provides better stock-specific news. Free tier (100 requests/day). Without it, RSS feeds (ET Markets, MoneyControl) are used automatically.
+### Fyers (Recommended - free, real-time data)
 
-1. Get free key at [newsapi.org](https://newsapi.org)
-2. Save it:
+1. Create account at [fyers.in](https://fyers.in)
+2. Create API app at [myapi.fyers.in](https://myapi.fyers.in)
+   - Redirect URL: `http://127.0.0.1:8765/fyers/callback` (must be exact)
+3. Login in the platform:
    ```
-   > credentials setup
-   > Enter NEWSAPI_KEY: 7665663ab8c04212ac8c26321a9d5cae
+   trade
+   > login
+   > Choose: Fyers
+   > Enter App ID and Secret Key when prompted
    ```
-3. Toggle: `NEWSAPI_ENABLED=0` in env to disable, `1` to enable (default)
+4. Browser opens for Fyers login. Token saved for 12 hours.
+
+**WebSocket**: Auto-connects on login for real-time quotes.
+
+### Other Brokers
+
+| Broker | Status | Notes |
+|--------|--------|-------|
+| **Fyers** | **Fully supported** | Free API, WebSocket, options chain |
+| Zerodha | Basic | Requires Kite Connect subscription |
+| Angel One | Basic | Free SmartAPI, TOTP login |
+| Upstox | Basic | Free API, OAuth |
+| Groww | Basic | No historical data API |
+| Mock/Demo | Full | Synthetic data, no login needed |
 
 ---
 
-## Optional: Telegram Bot
+## Telegram Bot (Optional)
 
-Push alerts, quotes, and briefs to your phone via Telegram.
+Push alerts, quotes, and full analyses to your phone.
 
-1. Open Telegram → search `@BotFather` → send `/newbot` → get token
-2. Save token: `credentials setup` → enter `TELEGRAM_BOT_TOKEN`
-3. Start bot: `telegram` command in REPL (runs in background)
-4. Send `/start` to your bot on Telegram
+```
+trade
+> telegram setup
+```
 
-**13 bot commands**: `/quote`, `/analyze`, `/brief`, `/flows`, `/earnings`, `/events`, `/macro`, `/alert`, `/alerts`, `/memory`, `/pnl`, `/help`
+The guided wizard walks you through:
+1. Creating a bot via @BotFather
+2. Validating your token
+3. Connecting your chat
 
-Alerts auto-push to Telegram when triggered.
+**14 bot commands**: `/quote`, `/analyze`, `/deepanalyze`, `/brief`, `/flows`, `/earnings`, `/events`, `/macro`, `/alert`, `/alerts`, `/memory`, `/pnl`, `/help`
+
+Alerts auto-push to Telegram when triggered. The REPL shows a status badge when Telegram commands are running.
 
 ---
 
 ## All CLI Commands
 
-### Core Analysis
-```
-analyze RELIANCE                   Full multi-agent analysis (8 LLM calls)
-analyze RELIANCE --explain-save    Analyze + explain simply + save PDF
-deep-analyze RELIANCE              Deep mode — every analyst is LLM (11 calls)
-ai <message>                       Chat with AI (freeform questions)
-morning-brief                      Daily market context + AI narrative
-mtf RELIANCE                       Multi-timeframe analysis (weekly/daily/hourly)
-```
+### Analysis (AI-powered)
+| Command | Description |
+|---------|-------------|
+| `analyze RELIANCE` | Multi-agent analysis (7 analysts + debate + trade plans) |
+| `deep-analyze RELIANCE` | Full LLM mode (11 calls, every analyst uses AI) |
+| `ai <message>` | Chat with AI — follow-ups keep context, `clear` to reset |
+| `morning-brief` | Daily market context + AI narrative |
+| `mtf RELIANCE` | Multi-timeframe analysis (weekly/daily/hourly) |
+
+### Strategy Builder (experimental)
+| Command | Description |
+|---------|-------------|
+| `strategy new` | Describe a strategy in plain English, AI interviews you, generates code, backtests |
+| `strategy new --simple` | Same but explained like you're 17 (no jargon) |
+| `strategy list` | List all saved strategies with backtest stats |
+| `strategy backtest <name> --period 2y` | Re-backtest a saved strategy |
+| `strategy run <name> RELIANCE --paper` | Generate latest signal, paper trade if BUY |
+| `strategy show <name>` | View generated Python code |
+| `strategy delete <name>` | Remove a saved strategy |
+
+Supports single-symbol strategies (RSI, MACD, EMA crossover, etc.) and multi-symbol pairs strategies (z-score spread trading with both legs tracked). The AI gives data-backed recommendations for each parameter.
 
 ### Market Data
-```
-earnings                 Quarterly results calendar (NIFTY 50)
-earnings RELIANCE TCS    Earnings for specific stocks
-flows                    FII/DII flow intelligence with signals
-events                   Event-driven strategy recommendations
-patterns                 Active India-specific market patterns
-macro                    USD/INR, crude, gold, US 10Y snapshot
-macro RELIANCE           Macro impact on a specific stock
-```
+| Command | Description |
+|---------|-------------|
+| `earnings` | Quarterly results calendar (NIFTY 50) |
+| `earnings RELIANCE TCS` | Earnings for specific stocks |
+| `flows` | FII/DII flow intelligence with signals |
+| `events` | Event-driven strategy recommendations |
+| `patterns` | Active India-specific market patterns |
+| `macro` | USD/INR, crude, gold, US 10Y snapshot |
+| `macro RELIANCE` | Macro impact on a specific stock |
 
 ### Backtesting & Simulation
-```
-backtest RELIANCE rsi              RSI overbought/oversold
-backtest RELIANCE ma 20 50         EMA crossover
-backtest RELIANCE macd             MACD signal crossover
-backtest RELIANCE bb               Bollinger Bands
-walkforward RELIANCE rsi           Walk-forward test (rolling windows)
-whatif nifty -3                    What if NIFTY drops 3%? (uses real beta)
-whatif RELIANCE -10                What if RELIANCE drops 10%?
-whatif RELIANCE -5 HDFCBANK 3      Custom multi-stock scenario
-```
+| Command | Description |
+|---------|-------------|
+| `backtest RELIANCE rsi` | RSI overbought/oversold |
+| `backtest RELIANCE ma 20 50` | EMA crossover |
+| `backtest RELIANCE macd` | MACD signal crossover |
+| `backtest RELIANCE bb` | Bollinger Bands |
+| `walkforward RELIANCE rsi` | Walk-forward test (rolling windows) |
+| `whatif nifty -3` | What if NIFTY drops 3%? (uses real beta) |
 
 ### Risk & Portfolio
-```
-risk-report              VaR/CVaR portfolio risk analysis
-greeks                   Portfolio Greeks (net Delta, Theta, Vega)
-pairs                    Pair trading opportunities scan
-pairs HDFCBANK ICICIBANK Analyze a specific pair
-```
+| Command | Description |
+|---------|-------------|
+| `risk-report` | VaR/CVaR portfolio risk analysis |
+| `greeks` | Portfolio Greeks (net Delta, Theta, Vega) |
+| `pairs` | Pair trading opportunities scan |
+| `pairs HDFCBANK ICICIBANK` | Analyze a specific pair |
 
 ### Paper Trading
-```
-paper-execute                      Execute last trade plan (neutral risk)
-paper-execute aggressive           Execute aggressive risk plan
-paper-execute conservative         Execute conservative risk plan
-```
+| Command | Description |
+|---------|-------------|
+| `paper-execute` | Execute last trade plan (neutral risk) |
+| `paper-execute aggressive` | Execute aggressive plan |
+| `paper-execute conservative` | Execute conservative plan |
 
 ### Memory & Learning
-```
-memory                   Recent trade analyses
-memory stats             Performance statistics
-memory RELIANCE          Past analyses for a symbol
-memory outcome ID WIN 1250   Record trade outcome
-profile                  Your personal trading style profile
-drift                    Model drift detection
-audit <ID>               Post-mortem analysis of a trade
-```
+| Command | Description |
+|---------|-------------|
+| `memory` | Recent trade analyses |
+| `memory stats` | Performance statistics |
+| `memory RELIANCE` | Past analyses for a symbol |
+| `memory outcome ID WIN 1250` | Record trade outcome |
+| `profile` | Your personal trading style profile |
+| `drift` | Model drift detection |
+| `audit <ID>` | Post-mortem analysis of a trade |
 
 ### Alerts
-```
-alert RELIANCE above 2800                     Price alert
-alert NIFTY RSI above 70                      Technical alert
-alert RELIANCE above 2800 AND RSI above 70    Conditional (AND logic)
-alert list / alerts                           List active alerts
-alert remove <ID>                             Remove an alert
-```
+| Command | Description |
+|---------|-------------|
+| `alert RELIANCE above 2800` | Price alert |
+| `alert NIFTY RSI above 70` | Technical alert |
+| `alert RELIANCE above 2800 AND RSI above 70` | Conditional alert |
+| `alerts` | List active alerts |
+| `alert remove <ID>` | Remove an alert |
 
 ### Portfolio & Trading
-```
-funds                    Available cash and margin
-holdings                 Long-term delivery holdings
-positions                Open intraday/F&O positions
-orders                   Today's orders and status
-portfolio                Unified view — all brokers
-```
+| Command | Description |
+|---------|-------------|
+| `funds` | Available cash and margin |
+| `holdings` | Long-term delivery holdings |
+| `positions` | Open intraday/F&O positions |
+| `orders` | Today's orders and status |
+| `portfolio` | Unified view across all brokers |
 
 ### Output & Export
-```
-save-pdf                           Save previous output as PDF
-explain                            Explain previous output simply
-explain-save                       Explain + save as PDF
---pdf                              Flag: append to any command
---explain                          Flag: append to any command
---explain-save                     Flag: explain + PDF in one shot
-```
+| Command | Description |
+|---------|-------------|
+| `save-pdf` | Save previous output as PDF |
+| `explain` | Explain previous output simply |
+| `explain-save` | Explain + save as PDF |
+| `--pdf` | Flag: append to any command |
+| `--explain` | Flag: append to any command |
+| `--explain-save` | Flag: explain + PDF in one shot |
 
 ### Account & Config
-```
-login                    Connect to a broker
-connect                  Add a second broker
-disconnect               Remove a secondary broker
-brokers                  List all connected brokers
-logout                   Disconnect all brokers
-profile                  Your trading style profile
-provider                 Show/switch AI provider
-telegram                 Start Telegram bot (background)
-clear                    Reset AI conversation history
-credentials              Manage API keys
-```
+| Command | Description |
+|---------|-------------|
+| `login` | Connect to a broker |
+| `connect` | Add a second broker |
+| `disconnect` | Remove a secondary broker |
+| `brokers` | List all connected brokers |
+| `logout` | Disconnect all brokers |
+| `provider` | Show/switch AI provider |
+| `telegram` / `telegram setup` | Start bot / run guided setup |
+| `credentials` | Manage API keys |
 
 ---
 
-## Project Structure
+## Configuration
 
-```
-india-trade-cli/
-├── agent/                    # AI layer
-│   ├── core.py               # TradingAgent + 6 LLM providers
-│   ├── multi_agent.py         # 7 analysts, scorecard, debate, synthesis
-│   ├── deep_agent.py          # Full LLM mode (11 calls)
-│   ├── tools.py               # 45+ tool definitions for LLM function calling
-│   └── prompts.py             # System prompt + command templates
-├── brokers/                  # Broker integrations
-│   ├── base.py                # Unified BrokerAPI abstract interface
-│   ├── fyers.py               # Fyers API v3 (official SDK) ← primary
-│   ├── zerodha.py             # Zerodha Kite Connect (WIP)
-│   ├── upstox.py              # Upstox API v2 (WIP)
-│   ├── angelone.py            # Angel One SmartAPI (WIP)
-│   ├── groww.py               # Groww Partner API (WIP)
-│   ├── mock.py                # Mock broker (paper trading)
-│   └── session.py             # Multi-broker session manager
-├── market/                   # Market data
-│   ├── quotes.py              # Quotes: WebSocket → broker REST → yfinance
-│   ├── websocket.py           # Fyers WebSocket for real-time ticks
-│   ├── history.py             # Historical OHLCV: broker → yfinance → mock
-│   ├── options.py             # NSE options chain
-│   ├── indices.py             # NIFTY 50, BANKNIFTY, India VIX, sectors
-│   ├── news.py                # NewsAPI + RSS feeds (toggle-able)
-│   ├── events.py              # Earnings calendar, RBI, expiry dates
-│   ├── sentiment.py           # FII/DII data + market breadth
-│   ├── earnings.py            # Earnings agent + surprise prediction
-│   ├── flow_intel.py          # FII/DII flow intelligence + signals
-│   ├── macro.py               # Currency/commodity linkage analysis
-│   └── yfinance_provider.py   # Free NSE/BSE data via Yahoo Finance
-├── analysis/                 # Analysis engines
-│   ├── technical.py           # RSI, MACD, EMAs, Bollinger, ATR, pivots
-│   ├── fundamental.py         # PE, ROE, ROCE from Screener.in
-│   ├── options.py             # Greeks, payoff, iron condor, butterfly, calendar
-│   └── multi_timeframe.py     # Weekly/daily/hourly confluence analysis
-├── engine/                   # Trading logic
-│   ├── trader.py              # Trader Agent + 3 risk personas
-│   ├── backtest.py            # Backtester + walk-forward testing
-│   ├── simulator.py           # What-if with real beta
-│   ├── memory.py              # Trade memory (situation-outcome pairs)
-│   ├── patterns.py            # India-specific market patterns
-│   ├── event_strategies.py    # Event-driven strategy recommendations
-│   ├── risk_metrics.py        # VaR, CVaR, correlation, HHI
-│   ├── drift.py               # Model drift detection
-│   ├── pairs.py               # Pair trading / relative value
-│   ├── audit.py               # Decision audit trail
-│   ├── profile.py             # Personal trading style profile
-│   ├── alerts.py              # Price + technical + conditional alerts + real-time
-│   ├── paper.py               # Paper trading engine
-│   ├── paper_execute.py       # Execute trade plans in paper mode
-│   ├── output.py              # PDF export + simple explainer (--explain-save)
-│   ├── portfolio.py           # Portfolio tracker + aggregated Greeks
-│   └── strategy.py            # Strategy recommendation engine
-├── bot/                      # Telegram bot
-│   └── telegram_bot.py       # 13 commands + alert push notifications
-├── app/                      # Application layer
-│   ├── main.py                # Entry point
-│   ├── repl.py                # Command REPL (35+ commands, tab-complete)
-│   └── commands/              # Command handlers
-├── config/                   # Configuration
-│   └── credentials.py        # OS keychain credential management
-├── web/                      # Web API (FastAPI)
-│   └── api.py                # REST + WebSocket endpoints
-└── requirements.txt
+### Environment Variables
+
+```bash
+# AI Provider (choose one)
+AI_PROVIDER=gemini              # or: anthropic, openai, claude_subscription
+GEMINI_API_KEY=AIza...          # if using gemini
+ANTHROPIC_API_KEY=sk-ant-...    # if using anthropic
+OPENAI_API_KEY=sk-...           # if using openai
+
+# Trading Capital & Risk
+TOTAL_CAPITAL=200000            # your trading capital in INR
+DEFAULT_RISK_PCT=2              # max risk per trade (%)
+TRADING_MODE=PAPER              # PAPER or LIVE
+
+# News (optional)
+NEWSAPI_KEY=...                 # free at newsapi.org
+NEWSAPI_ENABLED=1               # set to 0 to disable
+
+# Telegram (optional)
+TELEGRAM_BOT_TOKEN=...          # from @BotFather
 ```
 
----
+### Position Sizing
 
-## Data Flow Priority
-
-Quotes and prices are fetched in this priority order:
-
-1. **WebSocket** (instant) — real-time ticks from Fyers, auto-connected on login
-2. **Broker REST API** (1-3s) — fallback when no WebSocket tick cached
-3. **yfinance** (~15 min delayed) — free fallback when no broker logged in
-4. **Mock data** (synthetic) — last resort, random walk
-
----
-
-## Position Sizing
-
-The Trader Agent calculates position size using this formula:
+The Trader Agent calculates position size using:
 
 ```
-Max Risk = Capital × Risk% × VIX Adjustment
+Max Risk = Capital x Risk% x VIX Adjustment
 Shares   = Max Risk / Stop-Loss Distance (per share)
 ```
 
-Example (TCS at ₹2,360, VIX > 20):
-```
-Capital     = ₹200,000 (TOTAL_CAPITAL env var)
-Risk/trade  = 2% (DEFAULT_RISK_PCT env var)
-VIX factor  = 0.5 (VIX > 20 → halve position size for safety)
-Max risk    = ₹200,000 × 2% × 0.5 = ₹2,000
-SL distance = 1.5 × ATR ≈ ₹180/share
-Shares      = ₹2,000 / ₹180 = 11 shares
-Deployed    = 11 × ₹2,360 = ₹25,960 (13% of capital)
-```
-
-VIX adjustment (automatic):
+VIX-based auto-adjustment:
 | VIX Level | Position Size |
 |-----------|--------------|
 | < 15 | 100% (normal) |
@@ -370,89 +317,176 @@ VIX adjustment (automatic):
 | 20-25 | 65% |
 | > 25 | 50% (halved) |
 
-To change defaults, set in `.env` or shell:
-```bash
-export TOTAL_CAPITAL=500000    # your actual trading capital in INR
-export DEFAULT_RISK_PCT=2      # max risk per trade (%)
+### Data Flow Priority
+
+Quotes are fetched in this order:
+1. **WebSocket** (instant) - real-time ticks from Fyers
+2. **Broker REST API** (1-3s) - fallback
+3. **yfinance** (~15 min delayed) - free fallback when no broker
+4. **Mock data** (synthetic) - last resort
+
+---
+
+## Project Structure
+
+```
+india-trade-cli/
+|-- agent/                    # AI layer
+|   |-- core.py               # TradingAgent + 6 LLM providers
+|   |-- multi_agent.py        # 7 analysts, scorecard, debate, synthesis
+|   |-- deep_agent.py         # Full LLM mode (11 calls)
+|   |-- tools.py              # 45+ tool definitions for LLM function calling
+|   +-- prompts.py            # System prompt + command templates
+|-- brokers/                  # Broker integrations
+|   |-- base.py               # Unified BrokerAPI abstract interface
+|   |-- fyers.py              # Fyers API v3 (official SDK)
+|   |-- zerodha.py            # Zerodha Kite Connect
+|   |-- upstox.py             # Upstox API v2
+|   |-- angelone.py           # Angel One SmartAPI
+|   |-- groww.py              # Groww Partner API
+|   |-- mock.py               # Mock broker (paper trading)
+|   +-- session.py            # Multi-broker session manager
+|-- market/                   # Market data
+|   |-- quotes.py             # Quotes: WebSocket -> broker REST -> yfinance
+|   |-- websocket.py          # Fyers WebSocket for real-time ticks
+|   |-- history.py            # Historical OHLCV
+|   |-- options.py            # NSE options chain
+|   |-- indices.py            # NIFTY 50, BANKNIFTY, India VIX, sectors
+|   |-- news.py               # NewsAPI + RSS feeds
+|   |-- events.py             # Earnings calendar, RBI, expiry dates
+|   |-- sentiment.py          # FII/DII data + market breadth
+|   |-- earnings.py           # Earnings agent + surprise prediction
+|   |-- flow_intel.py         # FII/DII flow intelligence + signals
+|   |-- macro.py              # Currency/commodity linkage analysis
+|   +-- yfinance_provider.py  # Free NSE/BSE data via Yahoo Finance
+|-- analysis/                 # Analysis engines
+|   |-- technical.py          # RSI, MACD, EMAs, Bollinger, ATR, pivots
+|   |-- fundamental.py        # PE, ROE, ROCE from Screener.in
+|   |-- options.py            # Greeks, payoff, iron condor, butterfly
+|   +-- multi_timeframe.py    # Weekly/daily/hourly confluence
+|-- engine/                   # Trading logic
+|   |-- trader.py             # Trader Agent + 3 risk personas
+|   |-- backtest.py           # Backtester + walk-forward testing
+|   |-- simulator.py          # What-if with real beta
+|   |-- memory.py             # Trade memory (situation-outcome pairs)
+|   |-- patterns.py           # India-specific market patterns
+|   |-- event_strategies.py   # Event-driven strategy recommendations
+|   |-- risk_metrics.py       # VaR, CVaR, correlation, HHI
+|   |-- drift.py              # Model drift detection
+|   |-- pairs.py              # Pair trading / relative value
+|   |-- audit.py              # Decision audit trail
+|   |-- profile.py            # Personal trading style profile
+|   |-- alerts.py             # Price + technical + conditional alerts
+|   |-- paper.py              # Paper trading engine
+|   |-- paper_execute.py      # Execute trade plans in paper mode
+|   |-- output.py             # PDF export + simple explainer
+|   |-- portfolio.py          # Portfolio tracker + aggregated Greeks
+|   |-- strategy.py           # Strategy recommendation engine
+|   +-- strategy_builder.py  # Interactive strategy builder (AI-guided)
+|-- bot/                      # Telegram bot
+|   |-- telegram_bot.py       # 14 commands + alert push notifications
+|   +-- status.py             # REPL status badge for bot activity
+|-- app/                      # Application layer
+|   |-- main.py               # Entry point
+|   |-- repl.py               # Command REPL (35+ commands, tab-complete)
+|   +-- commands/             # Command handlers
+|-- config/                   # Configuration
+|   +-- credentials.py        # OS keychain credential management
+|-- web/                      # Web API (FastAPI)
+|   +-- api.py                # REST + WebSocket endpoints
+|-- requirements.txt
+|-- pyproject.toml
++-- .env.example
 ```
 
 ---
 
-## Environment Variables
+## Contributing
+
+Contributions welcome! Here's how to get started:
+
+### Setup for development
 
 ```bash
-# AI Provider (choose one)
-AI_PROVIDER=claude_subscription    # or: anthropic, openai, gemini
-ANTHROPIC_API_KEY=sk-ant-...       # only if using anthropic provider
-OPENAI_API_KEY=sk-...              # only if using openai provider
-GEMINI_API_KEY=AIza...             # only if using gemini provider
-
-# Trading Capital & Risk
-TOTAL_CAPITAL=200000               # your trading capital in INR
-DEFAULT_RISK_PCT=2                 # max risk per trade (%)
-TRADING_MODE=PAPER                 # PAPER or LIVE
-
-# News (optional)
-NEWSAPI_KEY=...                    # free at newsapi.org
-NEWSAPI_ENABLED=1                  # set to 0 to disable
-
-# Telegram (optional)
-TELEGRAM_BOT_TOKEN=...             # from @BotFather
+git clone https://github.com/ArchieIndian/india-trade-cli.git
+cd india-trade-cli
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
 ```
+
+### Areas where help is needed
+
+Check [open issues](https://github.com/ArchieIndian/india-trade-cli/issues) for current priorities. Some good first issues:
+
+- **Options backtesting** (#31) - strategy-specific backtest engine for options
+- **Options scanner** (#33) - scan for high IV, unusual OI
+- **PDF auto-save** (#53) - timestamped PDFs on generation
+- **Test suite** (#28) - end-to-end tests
+
+### Submitting changes
+
+1. Fork the repo
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes
+4. Test with `trade --no-broker` (no API keys needed for basic testing)
+5. Submit a PR
 
 ---
 
 ## Roadmap
 
-### Completed (34/43 issues closed)
-- [x] 5-phase competitive roadmap (all phases shipped)
-- [x] 7 analyst agents + weighted scorecard (excludes UNAVAILABLE analysts)
-- [x] Multi-round debate with facilitator (2 rounds + summary)
-- [x] Trader Agent + 3 risk personas (aggressive/neutral/conservative)
-- [x] Trade memory + India pattern knowledge base
-- [x] Strategy backtesting + walk-forward testing
-- [x] What-if simulator with real stock beta
-- [x] Earnings agent + surprise prediction
-- [x] FII/DII flow intelligence + divergence detection
-- [x] Event-driven strategies (expiry, RBI, budget, earnings)
-- [x] Advanced options (iron condor, butterfly, calendar, ratio, diagonal)
-- [x] Currency/commodity macro linkages (USD/INR, crude, gold, US 10Y)
-- [x] VaR/CVaR portfolio risk + correlation matrix + HHI
-- [x] Model drift detection + decision audit trail
-- [x] Pair trading with mean reversion signals (12 Indian pairs)
-- [x] Personal trading style profile
-- [x] Full LLM deep mode (11 calls)
-- [x] Telegram bot (13 commands + alert push)
-- [x] Fyers WebSocket for real-time quotes
-- [x] Fyers broker rewrite using official SDK
-- [x] Multi-timeframe analysis (weekly/daily/hourly confluence)
-- [x] Paper trading execution with auto-alert creation
-- [x] PDF export + simple explainer (--pdf, --explain, --explain-save flags)
-- [x] Post-processing commands (save-pdf, explain, explain-save)
-- [x] Fast path for data queries (skip LLM for simple price lookups)
-- [x] --no-broker mode with yfinance passthrough (real data, no fake prices)
-- [x] Categorized help command (8 Rich panels)
-- [x] Real-time alert evaluation via WebSocket ticks
-- [x] 3-channel alert notifications (terminal + macOS desktop + Telegram)
+### Shipped
+- 7 analyst agents + weighted scorecard
+- Multi-round bull/bear debate with facilitator
+- Trader Agent + 3 risk personas (aggressive/neutral/conservative)
+- Trade memory + India pattern knowledge base
+- Strategy backtesting + walk-forward testing
+- What-if simulator with real stock beta
+- Earnings agent + surprise prediction
+- FII/DII flow intelligence + divergence detection
+- Event-driven strategies (expiry, RBI, budget, earnings)
+- Advanced options (iron condor, butterfly, calendar, ratio, diagonal)
+- Currency/commodity macro linkages
+- VaR/CVaR portfolio risk + correlation matrix
+- Model drift detection + decision audit trail
+- Pair trading with mean reversion signals
+- Full LLM deep mode (11 calls)
+- Telegram bot (14 commands + alert push)
+- Fyers WebSocket for real-time quotes
+- Multi-timeframe analysis
+- Paper trading execution
+- PDF export + simple explainer
+- Real-time alert evaluation via WebSocket
+- Telegram bot (14 commands + alert push + REPL status badge)
+- Auto-archived PDF exports with timestamped copies
+- Multi-symbol backtester (pairs trading with both legs tracked)
 
-### Open Issues
-- [ ] #18 SEBI compliance layer (margin validation, tax harvesting)
-- [ ] #22 OpenClaw agent integration
-- [ ] #23 Telegram bot token setup + testing
-- [ ] #24 Web UI (FastAPI backend)
-- [ ] #25 Textual TUI (split-panel terminal)
-- [ ] #26 Real-time portfolio dashboard
-- [ ] #27 Broker order placement flow with confirmation
-- [ ] #28 End-to-end test suite
-- [ ] #29 Place F&O orders via broker API
-- [ ] #30 Options strategy execution (multi-leg orders)
-- [ ] #31 Options-specific backtesting
-- [ ] #32 Greeks-based position management (delta-hedge, roll)
-- [ ] #33 Options scanner (high IV, unusual OI)
-- [ ] #34 Expiry day tools (gamma scalping, last-hour strategies)
+### Experimental
+- Interactive strategy builder (plain English to backtest to paper trade to save)
+
+### Planned
+- Strategy template library (curated strategies with explanations)
+- Options-specific backtesting
+- Options scanner (high IV, unusual OI)
+- Greeks-based position management
+- Volatility surface and IV smile analysis
+- GEX analysis
+- TradingView/ChartInk webhook support
+- Web UI (FastAPI)
+- Broker order placement flow
+- SEBI compliance layer
+
+See [all open issues](https://github.com/ArchieIndian/india-trade-cli/issues) for the full list.
+
+---
+
+## Disclaimer
+
+This software is for **educational and informational purposes only**. It is not financial advice. Trading in stocks and derivatives involves substantial risk of loss. Past performance (including backtests) does not guarantee future results. Always do your own research and consult a qualified financial advisor before making investment decisions. The authors are not responsible for any financial losses incurred through use of this software.
 
 ---
 
 ## License
 
-Private. All rights reserved.
+MIT License. See [LICENSE](LICENSE) for details.

--- a/agent/core.py
+++ b/agent/core.py
@@ -86,8 +86,10 @@ PROVIDER_GEMINI       = "gemini"
 PROVIDER_CLAUDE_CLI   = "claude_subscription"
 PROVIDER_OPENAI_SUB   = "openai_subscription"
 PROVIDER_GEMINI_SUB   = "gemini_subscription"
+PROVIDER_OLLAMA       = "ollama"
 
 GEMINI_DEFAULT_MODEL  = "gemini-2.5-pro"
+OLLAMA_DEFAULT_MODEL  = "llama3.1"
 
 ALL_PROVIDERS = [
     PROVIDER_ANTHROPIC,
@@ -96,6 +98,7 @@ ALL_PROVIDERS = [
     PROVIDER_CLAUDE_CLI,
     PROVIDER_OPENAI_SUB,
     PROVIDER_GEMINI_SUB,
+    PROVIDER_OLLAMA,
 ]
 
 
@@ -268,30 +271,60 @@ class AnthropicProvider(LLMProvider):
 
 class OpenAIProvider(LLMProvider):
     """
-    OpenAI GPT via official `openai` SDK.
+    OpenAI-compatible LLM provider via official `openai` SDK.
 
-    Access modes:
-      - Personal API key (OPENAI_API_KEY) — paid per token
-      - OpenAI Plus / Team / Enterprise users still need a separate API key;
-        the ChatGPT Plus subscription does not include API credits.
-        → For subscription-only users, see OpenAISubscriptionProvider below.
+    Works with:
+      - OpenAI GPT (default) — OPENAI_API_KEY
+      - Ollama (local) — OPENAI_BASE_URL=http://localhost:11434/v1
+      - Groq, Together, Fireworks, OpenRouter — set OPENAI_BASE_URL + key
+      - LM Studio, vLLM, TGI — any OpenAI-compatible endpoint
 
-    Set AI_PROVIDER=openai in .env
+    Config:
+      AI_PROVIDER=openai    (or ollama for convenience)
+      OPENAI_API_KEY=...    (not needed for Ollama)
+      OPENAI_BASE_URL=...   (optional — overrides default OpenAI endpoint)
     """
 
-    def __init__(self, model: str, registry: ToolRegistry, system_prompt: str) -> None:
+    def __init__(
+        self,
+        model:         str,
+        registry:      ToolRegistry,
+        system_prompt: str,
+        base_url:      str | None = None,
+        api_key:       str | None = None,
+    ) -> None:
         super().__init__(model, registry, system_prompt)
         try:
             import openai as _sdk
-            self._sdk    = _sdk
+            self._sdk = _sdk
+
+            # Resolve base_url: explicit arg > env var > None (default OpenAI)
+            resolved_base = base_url or os.environ.get("OPENAI_BASE_URL")
+
+            # Resolve API key: explicit arg > env var > credential store
+            # Ollama and some local servers don't need a real key
+            resolved_key = api_key or os.environ.get("OPENAI_API_KEY")
+            if not resolved_key:
+                if resolved_base:
+                    # Local/custom endpoint — use a dummy key
+                    resolved_key = "not-needed"
+                else:
+                    resolved_key = get_credential("OPENAI_API_KEY", "OpenAI API Key", secret=True)
+
             self._client = _sdk.OpenAI(
-                api_key=get_credential("OPENAI_API_KEY", "OpenAI API Key", secret=True)
+                api_key=resolved_key,
+                base_url=resolved_base,
             )
+            self._base_url = resolved_base
         except ImportError:
             raise RuntimeError("openai not installed. Run: pip install openai")
 
     @property
     def provider_name(self) -> str:
+        if self._base_url:
+            # Show the endpoint for custom providers
+            host = self._base_url.replace("https://", "").replace("http://", "").split("/")[0]
+            return f"{host} / {self.model}"
         return f"OpenAI / {self.model}"
 
     def chat(self, messages: list[dict], stream: bool = True) -> str:
@@ -1389,21 +1422,27 @@ def get_provider(
         PROVIDER_CLAUDE_CLI: ClaudeCLIProvider,
         PROVIDER_OPENAI_SUB: OpenAISubscriptionProvider,
         PROVIDER_GEMINI_SUB: GeminiVertexProvider,
+        PROVIDER_OLLAMA:     None,  # handled specially below
     }
 
     cls = dispatch.get(chosen, AnthropicProvider)
 
+    def _build_provider(prov_name, model, registry, sys_prompt):
+        """Construct a provider, with special handling for Ollama."""
+        if prov_name == PROVIDER_OLLAMA:
+            base = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+            mdl = model or os.environ.get("OLLAMA_MODEL", OLLAMA_DEFAULT_MODEL)
+            return OpenAIProvider(mdl, registry, sys_prompt,
+                                 base_url=base, api_key="ollama")
+        prov_cls = dispatch.get(prov_name, AnthropicProvider)
+        return prov_cls(model, registry, sys_prompt)
+
     try:
-        return cls(chosen_model, reg, system)
+        return _build_provider(chosen, chosen_model, reg, system)
     except RuntimeError as exc:
-        # If the caller explicitly named a provider, propagate the error —
-        # they asked for something specific and should see why it failed.
         if explicit_provider:
             raise
 
-        # The provider came from a saved keychain value or auto-detect.
-        # It's broken (missing package, missing key, etc.).  Clear it so we
-        # don't hit the same error next time, then offer re-configuration.
         first_line = str(exc).splitlines()[0]
         console.print(
             f"\n[yellow]⚠  Saved AI provider [bold]{chosen!r}[/bold] is unavailable:[/yellow]"
@@ -1419,8 +1458,7 @@ def get_provider(
                 "Run [bold]credentials setup[/bold] → AI Provider to set one up."
             ) from exc
 
-        cls2 = dispatch.get(chosen, AnthropicProvider)
-        return cls2(_default_model(chosen), reg, system)
+        return _build_provider(chosen, _default_model(chosen), reg, system)
 
 
 def _has_anthropic_key() -> bool:
@@ -1594,6 +1632,10 @@ def _auto_detect_provider() -> str:
     if env.get("GEMINI_API_KEY") or env.get("GOOGLE_API_KEY"):
         return PROVIDER_GEMINI
 
+    # Ollama: check if OLLAMA_BASE_URL is set or if ollama is running locally
+    if env.get("OLLAMA_BASE_URL") or env.get("OLLAMA_MODEL"):
+        return PROVIDER_OLLAMA
+
     # claude CLI binary — most reliable signal of subscription intent
     import shutil
     if shutil.which("claude") or shutil.which("claude-code"):
@@ -1616,6 +1658,8 @@ def _default_model(provider: str) -> str:
         return OPENAI_DEFAULT_MODEL
     if provider in (PROVIDER_GEMINI, PROVIDER_GEMINI_SUB):
         return GEMINI_DEFAULT_MODEL
+    if provider == PROVIDER_OLLAMA:
+        return os.environ.get("OLLAMA_MODEL", OLLAMA_DEFAULT_MODEL)
     return ANTHROPIC_DEFAULT_MODEL
 
 
@@ -1788,6 +1832,8 @@ def _infer_current_name(provider: LLMProvider) -> str:
     if isinstance(provider, AnthropicProvider):
         return PROVIDER_ANTHROPIC
     if isinstance(provider, OpenAIProvider):
+        if provider._base_url and "11434" in provider._base_url:
+            return PROVIDER_OLLAMA
         return PROVIDER_OPENAI
     if isinstance(provider, GeminiProvider):
         return PROVIDER_GEMINI

--- a/agent/deep_agent.py
+++ b/agent/deep_agent.py
@@ -380,34 +380,80 @@ class DeepAnalyzer:
         return reports
 
     def _parse_llm_report(self, analyst: str, response: str) -> AnalystReport:
-        """Parse an LLM analyst response into AnalystReport."""
+        """Parse an LLM analyst response into AnalystReport.
+
+        Handles various LLM output formats:
+          VERDICT: BEARISH
+          ### VERDICT: **BEARISH** (with notes)
+          VERDICT    : NEUTRAL (leaning BULLISH)
+          **VERDICT:** BEARISH
+        """
+        import re
+
         verdict = "NEUTRAL"
         confidence = 50
         score = 0.0
         points = []
 
-        for line in response.splitlines():
+        # Strip markdown formatting for cleaner parsing
+        clean = response.replace("**", "").replace("###", "").replace("##", "").replace("#", "")
+
+        for line in clean.splitlines():
             stripped = line.strip()
             upper = stripped.upper()
 
-            if upper.startswith("VERDICT:"):
-                val = stripped.split(":", 1)[1].strip().upper()
+            # Match VERDICT with flexible formatting:
+            # "VERDICT: BEARISH", "VERDICT : NEUTRAL (leaning bullish)", etc.
+            verdict_match = re.match(r'VERDICT\s*:\s*(.+)', upper)
+            if verdict_match:
+                val = verdict_match.group(1)
                 for v in ("BULLISH", "BEARISH", "NEUTRAL"):
                     if v in val:
                         verdict = v
                         break
-            elif upper.startswith("CONFIDENCE:"):
+
+            # Match CONFIDENCE with flexible formatting:
+            # "CONFIDENCE: 62%", "CONFIDENCE : 55%", "CONFIDENCE: 62"
+            conf_match = re.match(r'CONFIDENCE\s*:\s*(\d+)', upper)
+            if conf_match:
                 try:
-                    confidence = int(stripped.split(":", 1)[1].strip().rstrip("%"))
+                    confidence = int(conf_match.group(1))
                 except (ValueError, IndexError):
                     pass
-            elif upper.startswith("SCORE:"):
+
+            # Match SCORE with flexible formatting:
+            # "SCORE: -23", "SCORE : +30", "SCORE: -15"
+            score_match = re.match(r'SCORE\s*:\s*([+\-]?\d+(?:\.\d+)?)', upper)
+            if score_match:
                 try:
-                    score = float(stripped.split(":", 1)[1].strip())
+                    score = float(score_match.group(1))
                 except (ValueError, IndexError):
                     pass
-            elif stripped.startswith("- ") or stripped.startswith("* "):
-                points.append(stripped.lstrip("-* ").strip())
+
+            # Collect key points
+            if stripped.startswith("- ") or stripped.startswith("* "):
+                point = stripped.lstrip("-* ").strip()
+                if point and len(point) > 10:  # skip tiny fragments
+                    points.append(point)
+
+        # Fallback: scan the entire response for verdict keywords if still NEUTRAL/50/0
+        if verdict == "NEUTRAL" and confidence == 50 and score == 0.0:
+            resp_upper = clean.upper()
+            # Look for verdict in the last 30 lines (summary section)
+            last_lines = "\n".join(clean.splitlines()[-30:]).upper()
+            if "BEARISH" in last_lines and "BULLISH" not in last_lines:
+                verdict = "BEARISH"
+            elif "BULLISH" in last_lines and "BEARISH" not in last_lines:
+                verdict = "BULLISH"
+
+            # Try to find confidence/score anywhere in response
+            all_conf = re.findall(r'CONFIDENCE\s*:?\s*(\d+)\s*%?', resp_upper)
+            if all_conf:
+                confidence = int(all_conf[-1])  # take last occurrence
+
+            all_scores = re.findall(r'SCORE\s*:?\s*([+\-]?\d+(?:\.\d+)?)', resp_upper)
+            if all_scores:
+                score = float(all_scores[-1])
 
         return AnalystReport(
             analyst=analyst,

--- a/agent/prompts.py
+++ b/agent/prompts.py
@@ -148,3 +148,189 @@ For each relevant strategy:
 
 Recommend the TOP strategy for the user's profile and explain why.
 """
+
+
+# ── Strategy Builder Prompts ─────────────────────────────────
+
+STRATEGY_BUILDER_PROMPT = """You are a strategy builder assistant for India Trade CLI.
+
+The user wants to create a custom trading strategy. Your job is to interview them thoroughly,
+then generate executable Python code.
+
+## Interview Phase
+
+Ask questions ONE AT A TIME. Cover ALL of these areas before generating code:
+
+1. **Entry conditions**: What signals trigger a BUY? (indicator crossovers, price levels, patterns, volume)
+   - Be specific: "What RSI level?" not just "What indicator?"
+2. **Exit conditions**: What triggers a SELL? (opposite signal, fixed target, trailing stop, time-based)
+3. **Stop-loss**: How do you limit losses? (percentage, ATR-based, fixed points)
+4. **Filters**: Any pre-conditions required? (trend filter, volume minimum, VIX range)
+5. **Default symbol**: What stock/index should we test on?
+
+After understanding the idea, call the `find_similar_strategies` tool to show the user
+what similar strategies already exist. Ask if they want to build from scratch or modify one.
+
+## DATA-BACKED RECOMMENDATIONS (IMPORTANT)
+
+Before asking EACH question, use tools to fetch real data for the symbol being discussed.
+Then give a concrete, data-backed recommendation with your question. Examples:
+
+Instead of: "What RSI level for entry?"
+Say: "RSI for RELIANCE is currently 37. Over the past year it dropped below 30 about 6 times
+and below 25 only twice. **I'd recommend RSI < 30** (good balance of signal frequency vs conviction).
+What level do you want?"
+
+Instead of: "What lookback period for the moving average?"
+Say: "RELIANCE's ATR(14) is ₹42 (~3% of price). The 20-day EMA has been a reliable support
+level — price bounced off it 8 times this year. **I'd recommend 20/50 EMA crossover.**
+What periods do you prefer?"
+
+Instead of: "What stop-loss percentage?"
+Say: "RELIANCE's average daily move is ~2.1% (ATR/price). A 3% stop would get hit by normal
+noise. **I'd recommend 5% or 1.5x ATR (~₹63 from entry)** to avoid false stops.
+What's your preference?"
+
+For pairs: "The 60-day rolling correlation between RELIANCE and BHARTIARTL is 0.72.
+The z-score of their log spread has crossed ±2.0 about 4 times in the past year.
+**I'd recommend z=2.0 entry, 0.5 exit, 60-day lookback.** What thresholds do you want?"
+
+Use `technical_analyse`, `get_quote`, `run_backtest`, and `fundamental_analyse` tools
+to gather this data. Always show the numbers that justify your recommendation.
+
+## Code Generation
+
+When you have enough information, generate a Python class that:
+- Subclasses `Strategy` from `engine.backtest`
+- Implements `generate_signals(self, df: pd.DataFrame) -> pd.Series` OR `-> pd.DataFrame`
+- df has columns: open, high, low, close, volume (indexed by date)
+
+### Single-symbol strategies
+Return a `pd.Series` with signals: 1 = BUY, -1 = SELL, 0 = HOLD
+
+### Multi-symbol / Pairs strategies
+Return a `pd.DataFrame` with one column per symbol. Values: 1 = LONG, -1 = SHORT, 0 = FLAT.
+The backtester will automatically track both legs and compute combined P&L.
+To get the second symbol's data, use `from market.history import get_ohlcv` inside generate_signals.
+
+Available indicator functions (import from analysis.technical):
+- `rsi(close_series, period=14)` -> Series
+- `ema(series, period)` -> Series
+- `sma(series, period)` -> Series
+- `macd(close, fast=12, slow=26, signal=9)` -> (macd_line, signal_line, histogram)
+- `bollinger_bands(close, period=20, std_dev=2.0)` -> (upper, mid, lower)
+- `atr(df, period=14)` -> Series
+
+For pairs: `from market.history import get_ohlcv` to fetch the other symbol's data.
+
+### Example: single-symbol strategy
+```python
+from engine.backtest import Strategy
+import pandas as pd
+
+class MyStrategy(Strategy):
+    name = "my_strategy"
+
+    def __init__(self, rsi_period=14, rsi_buy=30, rsi_sell=70):
+        self.rsi_period = rsi_period
+        self.rsi_buy = rsi_buy
+        self.rsi_sell = rsi_sell
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        from analysis.technical import rsi
+        signals = pd.Series(0, index=df.index)
+        r = rsi(df['close'], self.rsi_period)
+        signals[r < self.rsi_buy] = 1     # BUY
+        signals[r > self.rsi_sell] = -1   # SELL
+        return signals
+```
+
+### Example: pairs strategy (IMPORTANT — use this pattern for pairs/spread trades)
+```python
+from engine.backtest import Strategy
+import pandas as pd
+import numpy as np
+
+class PairStrategy(Strategy):
+    name = "pair_reliance_airtel"
+    symbols = ["RELIANCE", "BHARTIARTL"]
+
+    def __init__(self, lookback=60, entry_z=2.0, exit_z=0.5, stop_z=3.0):
+        self.lookback = lookback
+        self.entry_z = entry_z
+        self.exit_z = exit_z
+        self.stop_z = stop_z
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.DataFrame:
+        from market.history import get_ohlcv
+        # df is the primary symbol (first in symbols list)
+        sym_a = df['close']
+        # Fetch the other symbol
+        df_b = get_ohlcv("BHARTIARTL", days=len(df) + 30)
+        # Align dates
+        common = df.index.intersection(df_b.index)
+        sym_a = sym_a.loc[common]
+        sym_b = df_b['close'].loc[common]
+
+        # Compute log spread and z-score
+        spread = np.log(sym_a) - np.log(sym_b)
+        mean = spread.rolling(self.lookback).mean()
+        std = spread.rolling(self.lookback).std()
+        z = (spread - mean) / std
+
+        # Build signals DataFrame — one column per symbol
+        signals = pd.DataFrame({
+            'RELIANCE': pd.Series(0, index=common),
+            'BHARTIARTL': pd.Series(0, index=common),
+        })
+        # Spread too low: LONG A, SHORT B
+        signals.loc[z < -self.entry_z, 'RELIANCE'] = 1
+        signals.loc[z < -self.entry_z, 'BHARTIARTL'] = -1
+        # Spread too high: SHORT A, LONG B
+        signals.loc[z > self.entry_z, 'RELIANCE'] = -1
+        signals.loc[z > self.entry_z, 'BHARTIARTL'] = 1
+        # Exit: spread reverts to mean
+        signals.loc[z.abs() < self.exit_z, 'RELIANCE'] = 0
+        signals.loc[z.abs() < self.exit_z, 'BHARTIARTL'] = 0
+        # Stop: z-score blows out
+        signals.loc[z.abs() > self.stop_z, 'RELIANCE'] = 0
+        signals.loc[z.abs() > self.stop_z, 'BHARTIARTL'] = 0
+
+        return signals.reindex(df.index, fill_value=0)
+```
+
+## Output Format
+
+When ready, output the strategy wrapped in this exact format:
+
+%%%STRATEGY_COMPLETE%%%
+{
+  "code": "...the full Python code...",
+  "name": "snake_case_strategy_name",
+  "description": "One line description",
+  "symbol": "RELIANCE",
+  "parameters": {"param1": default1, "param2": default2}
+}
+
+IMPORTANT:
+- All __init__ parameters MUST have default values
+- Only import from: pandas, numpy, math, analysis.technical, engine.backtest
+- The name must be valid snake_case (letters, numbers, underscores)
+- Keep the code clean and well-commented
+"""
+
+STRATEGY_BUILDER_SIMPLE_PROMPT = STRATEGY_BUILDER_PROMPT + """
+
+## SIMPLE MODE (--simple)
+
+You are explaining everything to a 17-year-old who just opened their first demat account.
+
+Rules:
+- NO jargon without explanation. Every technical term gets a simple analogy.
+  - "RSI below 30" -> "the stock has been falling so much it's like a spring compressed — it might bounce back"
+  - "EMA crossover" -> "the short-term trend just overtook the long-term trend, like a fast car overtaking a slow one"
+  - "Stop-loss at 3%" -> "if the stock drops 3% from where you bought, we automatically sell to limit damage"
+- After EACH question, briefly explain WHY you're asking it.
+- Use everyday analogies (sports, cooking, driving) to explain concepts.
+- After generating the strategy, explain what it does in one simple paragraph.
+"""

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -248,7 +248,7 @@ def build_registry() -> ToolRegistry:
     from analysis.fundamental  import analyse as fund_analyse
     from analysis.options      import (
         compute_greeks, payoff as calc_payoff,
-        PayoffLeg, mock_iv_rank,
+        PayoffLeg,
     )
 
     reg.register(
@@ -310,8 +310,8 @@ def build_registry() -> ToolRegistry:
     reg.register(
         name="get_iv_rank",
         description=(
-            "Get the IV Rank for a symbol (0–100). "
-            ">50 = IV elevated (good for selling premium). <30 = IV low (good for buying)."
+            "Get the IV Rank for a symbol (0–100), computed from 52-week historical realized volatility. "
+            ">50 = volatility elevated (good for selling premium). <30 = volatility low (good for buying options)."
         ),
         parameters={
             "type": "object",
@@ -320,7 +320,10 @@ def build_registry() -> ToolRegistry:
             },
             "required": ["symbol"],
         },
-        fn=lambda symbol: {"iv_rank": mock_iv_rank(symbol)},
+        fn=lambda symbol: {
+            "iv_rank": __import__("analysis.options", fromlist=["compute_iv_rank_from_history"]).compute_iv_rank_from_history(symbol),
+            "method": "30-day rolling realized volatility ranked over 52 weeks",
+        },
     )
 
     reg.register(
@@ -705,6 +708,69 @@ def build_registry() -> ToolRegistry:
             "required": ["symbol", "change_pct"],
         },
         fn=lambda symbol, change_pct: Simulator().scenario_stock_move(symbol, change_pct).__dict__,
+    )
+
+    # ── Strategy Builder Tools ─────────────────────────────────
+
+    def _find_similar(description: str) -> list:
+        from engine.strategy_builder import find_similar_strategies
+        return find_similar_strategies(description)
+
+    reg.register(
+        name="find_similar_strategies",
+        description="Find existing strategies similar to a plain-English description. Returns matching built-in and user-saved strategies.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "description": {"type": "string", "description": "Plain-English description of the strategy idea"},
+            },
+            "required": ["description"],
+        },
+        fn=_find_similar,
+    )
+
+    def _backtest_user_strategy(name: str, symbol: str = "", period: str = "1y") -> dict:
+        from engine.strategy_builder import strategy_store
+        from engine.backtest import Backtester
+        strategy = strategy_store.load_strategy(name)
+        meta = strategy_store.get_metadata(name)
+        sym = symbol or (meta.get("default_symbol", "RELIANCE") if meta else "RELIANCE")
+        bt = Backtester(symbol=sym, period=period)
+        result = bt.run(strategy)
+        return {
+            "symbol": sym, "period": period, "strategy": name,
+            "total_return": round(result.total_return, 2),
+            "sharpe": round(result.sharpe_ratio, 2),
+            "win_rate": round(result.win_rate, 1),
+            "max_drawdown": round(result.max_drawdown, 2),
+            "total_trades": result.total_trades,
+            "buy_hold_return": round(result.buy_hold_return, 2),
+        }
+
+    reg.register(
+        name="backtest_user_strategy",
+        description="Backtest a user-saved custom strategy on a given symbol and period.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "name":   {"type": "string", "description": "Name of the saved strategy"},
+                "symbol": {"type": "string", "description": "Stock symbol (default: strategy's default)"},
+                "period": {"type": "string", "description": "Backtest period: 1y, 2y, 3y, 5y (default: 1y)"},
+            },
+            "required": ["name"],
+        },
+        fn=_backtest_user_strategy,
+    )
+
+    def _list_user_strategies() -> list:
+        from engine.strategy_builder import strategy_store
+        return strategy_store.list_strategies()
+
+    reg.register(
+        name="list_user_strategies",
+        description="List all user-saved custom strategies with their metadata and last backtest results.",
+        parameters={"type": "object", "properties": {}},
+        fn=_list_user_strategies,
     )
 
     return reg

--- a/analysis/fundamental.py
+++ b/analysis/fundamental.py
@@ -45,18 +45,44 @@ class FundamentalSnapshot:
     roce:       Optional[float] = None    # Return on Capital Employed %
     npm:        Optional[float] = None    # Net Profit Margin %
 
-    # Growth (3Y CAGR)
+    # Growth (3Y CAGR or TTM)
     sales_growth:  Optional[float] = None
     profit_growth: Optional[float] = None
 
     # Health
-    debt_equity:      Optional[float] = None
-    current_ratio:    Optional[float] = None
-    promoter_holding: Optional[float] = None   # % holding
-    pledged_pct:      Optional[float] = None   # % pledged
+    debt_equity:         Optional[float] = None
+    current_ratio:       Optional[float] = None
+    interest_coverage:   Optional[float] = None   # EBIT / Interest Expense
+    free_cash_flow:      Optional[float] = None   # in crores
+    promoter_holding:    Optional[float] = None   # % holding
+    institutional_holding: Optional[float] = None  # % FII+DII
+    pledged_pct:         Optional[float] = None   # % pledged
 
     # Dividend
     dividend_yield: Optional[float] = None
+
+    # Price context
+    market_cap:      Optional[float] = None   # in crores
+    week52_high:     Optional[float] = None
+    week52_low:      Optional[float] = None
+    pct_from_52w_high: Optional[float] = None  # how far below 52w high (negative %)
+    avg_50d:         Optional[float] = None
+    avg_200d:        Optional[float] = None
+    beta:            Optional[float] = None
+
+    # Analyst consensus
+    analyst_count:       Optional[int]   = None
+    analyst_rating:      Optional[str]   = None   # "strong_buy", "buy", "hold", "sell"
+    target_price_mean:   Optional[float] = None
+    target_price_high:   Optional[float] = None
+    target_price_low:    Optional[float] = None
+    target_upside_pct:   Optional[float] = None   # % upside to mean target
+
+    # Quarterly trend (last 4 quarters, most recent first)
+    quarterly_revenue:   list = field(default_factory=list)  # [{"quarter": "Dec-25", "revenue_cr": 1034, "profit_cr": 42}]
+
+    # Recent corporate announcements
+    announcements:       list = field(default_factory=list)  # [{"date": "...", "desc": "..."}]
 
     # Score and verdict
     flags:   list[FundamentalFlag] = field(default_factory=list)
@@ -125,39 +151,19 @@ def _parse_screener(raw: dict) -> dict:
     }
 
 
-# ── Mock fallback ────────────────────────────────────────────
+# ── Unavailable fallback ─────────────────────────────────────
 
-MOCK_FUNDAMENTALS: dict[str, dict] = {
-    "RELIANCE": dict(name="Reliance Industries", pe=27.4, pb=2.1, roe=14.2, roce=12.8,
-                     npm=7.4, sales_growth=11.2, profit_growth=16.3, debt_equity=0.38,
-                     current_ratio=1.4, promoter_holding=50.3, pledged_pct=0.0, dividend_yield=0.4),
-    "HDFCBANK": dict(name="HDFC Bank", pe=19.2, pb=2.9, roe=17.4, roce=None,
-                     npm=26.1, sales_growth=17.8, profit_growth=22.1, debt_equity=None,
-                     current_ratio=None, promoter_holding=0.0, pledged_pct=0.0, dividend_yield=1.1),
-    "INFY":     dict(name="Infosys", pe=24.6, pb=7.2, roe=32.1, roce=39.4,
-                     npm=17.3, sales_growth=8.4, profit_growth=9.2, debt_equity=0.03,
-                     current_ratio=2.6, promoter_holding=14.9, pledged_pct=0.0, dividend_yield=3.1),
-    "TCS":      dict(name="TCS", pe=28.9, pb=12.4, roe=50.3, roce=60.1,
-                     npm=19.4, sales_growth=9.1, profit_growth=10.2, debt_equity=0.01,
-                     current_ratio=3.2, promoter_holding=72.4, pledged_pct=0.0, dividend_yield=1.6),
-    "ICICIBANK":dict(name="ICICI Bank", pe=18.7, pb=3.2, roe=18.2, roce=None,
-                     npm=24.6, sales_growth=21.3, profit_growth=31.2, debt_equity=None,
-                     current_ratio=None, promoter_holding=0.0, pledged_pct=0.0, dividend_yield=0.8),
-    "SBIN":     dict(name="State Bank of India", pe=10.1, pb=1.7, roe=14.3, roce=None,
-                     npm=15.2, sales_growth=14.2, profit_growth=45.1, debt_equity=None,
-                     current_ratio=None, promoter_holding=57.5, pledged_pct=0.0, dividend_yield=1.9),
-}
+def _unavailable(symbol: str) -> dict:
+    """Return None values when all real data sources fail.
 
-
-def _mock_parse(symbol: str) -> dict:
-    key  = symbol.upper()
-    data = MOCK_FUNDAMENTALS.get(key, {})
-    if not data:
-        # Generic fallback for unknown symbols
-        data = dict(name=symbol, pe=22.0, pb=3.0, roe=15.0, roce=18.0,
-                    npm=12.0, sales_growth=10.0, profit_growth=12.0, debt_equity=0.5,
-                    current_ratio=1.5, promoter_holding=40.0, pledged_pct=2.0, dividend_yield=1.0)
-    return data
+    Never returns fake numbers — prevents LLM hallucination.
+    """
+    return dict(
+        name=symbol, pe=None, pb=None, roe=None, roce=None,
+        npm=None, sales_growth=None, profit_growth=None, debt_equity=None,
+        current_ratio=None, promoter_holding=None, pledged_pct=None, dividend_yield=None,
+        _data_source="UNAVAILABLE — all data sources failed (Screener.in + yfinance)",
+    )
 
 
 # ── Scoring logic ────────────────────────────────────────────
@@ -257,24 +263,247 @@ def _score(parsed: dict) -> tuple[int, list[FundamentalFlag]]:
 
 # ── Main entry point ─────────────────────────────────────────
 
-def analyse(symbol: str, use_mock: bool = False) -> FundamentalSnapshot:
+def _fetch_yfinance(symbol: str) -> dict:
+    """
+    Fetch fundamental data from yfinance as fallback.
+
+    yfinance provides real PE, PB, D/E, margins, growth, dividend yield
+    for any NSE-listed stock via Yahoo Finance.
+    """
+    try:
+        import yfinance as yf
+        ticker = yf.Ticker(f"{symbol.upper()}.NS")
+        info = ticker.info
+
+        if not info or info.get("regularMarketPrice") is None:
+            # Try BSE suffix
+            ticker = yf.Ticker(f"{symbol.upper()}.BO")
+            info = ticker.info
+
+        if not info or info.get("regularMarketPrice") is None:
+            return {}
+
+        # Map yfinance keys to our field names
+        roe_raw = info.get("returnOnEquity")
+        npm_raw = info.get("profitMargins")
+        rev_growth_raw = info.get("revenueGrowth")
+        earn_growth_raw = info.get("earningsGrowth")
+        div_yield_raw = info.get("dividendYield")
+
+        # Compute ROE and ROCE from annual financial statements
+        # yfinance's info.returnOnEquity is often None for Indian stocks,
+        # but we can compute it from balance sheet + income statement
+        roe_computed = None
+        roce_computed = None
+        try:
+            bs = ticker.balance_sheet
+            inc = ticker.income_stmt
+            if not bs.empty and not inc.empty:
+                net_income = inc.loc['Net Income Common Stockholders'].iloc[0]
+                equity = bs.loc['Stockholders Equity'].iloc[0]
+                if equity and equity > 0 and not _is_nan(net_income):
+                    roe_computed = round((net_income / equity) * 100, 1)
+
+                ebit = inc.loc['EBIT'].iloc[0] if 'EBIT' in inc.index else None
+                total_assets = bs.loc['Total Assets'].iloc[0] if 'Total Assets' in bs.index else None
+                current_liab = bs.loc['Current Liabilities'].iloc[0] if 'Current Liabilities' in bs.index else None
+                current_assets = bs.loc['Current Assets'].iloc[0] if 'Current Assets' in bs.index else None
+
+                if ebit and total_assets and current_liab and not _is_nan(ebit):
+                    capital_employed = total_assets - current_liab
+                    if capital_employed > 0:
+                        roce_computed = round((ebit / capital_employed) * 100, 1)
+
+                # Current ratio: Current Assets / Current Liabilities
+                if current_assets and current_liab and not _is_nan(current_assets) and current_liab > 0:
+                    current_ratio_computed = round(current_assets / current_liab, 2)
+
+                # Interest coverage: EBIT / Interest Expense
+                if ebit and not _is_nan(ebit):
+                    for idx_name in inc.index:
+                        if 'interest' in str(idx_name).lower() and 'expense' in str(idx_name).lower() and 'non' not in str(idx_name).lower():
+                            int_exp = abs(inc.loc[idx_name].iloc[0])
+                            if int_exp and not _is_nan(int_exp) and int_exp > 0:
+                                interest_coverage_computed = round(ebit / int_exp, 1)
+                            break
+        except Exception:
+            pass
+
+        # Prefer computed ROE over info.returnOnEquity (more reliable for Indian stocks)
+        roe_final = roe_computed or (round(roe_raw * 100, 1) if roe_raw else None)
+
+        # Current ratio: prefer computed from balance sheet (info often returns None for Indian stocks)
+        cr = locals().get('current_ratio_computed') or info.get("currentRatio")
+
+        # Promoter / institutional holding
+        insider_pct = info.get("heldPercentInsiders")
+        inst_pct = info.get("heldPercentInstitutions")
+        promoter = round(insider_pct * 100, 1) if insider_pct else None
+        institutional = round(inst_pct * 100, 1) if inst_pct else None
+
+        # ── Price context ────────────────────────────────────
+        ltp = info.get("regularMarketPrice") or info.get("currentPrice") or 0
+        w52_high = info.get("fiftyTwoWeekHigh")
+        w52_low = info.get("fiftyTwoWeekLow")
+        pct_from_high = round((ltp - w52_high) / w52_high * 100, 1) if w52_high and ltp else None
+        mcap = info.get("marketCap")
+        mcap_cr = round(mcap / 1e7, 0) if mcap else None  # convert to crores
+
+        # ── Free cash flow ───────────────────────────────────
+        fcf = None
+        try:
+            cf = ticker.cashflow
+            if not cf.empty and 'Free Cash Flow' in cf.index:
+                fcf_raw = cf.loc['Free Cash Flow'].iloc[0]
+                if fcf_raw and not _is_nan(fcf_raw):
+                    fcf = round(fcf_raw / 1e7, 1)  # in crores
+        except Exception:
+            pass
+
+        # ── Analyst consensus ────────────────────────────────
+        analyst_count = info.get("numberOfAnalystOpinions")
+        analyst_rating = info.get("recommendationKey")  # "strong_buy", "buy", "hold", etc.
+        target_mean = info.get("targetMeanPrice")
+        target_high = info.get("targetHighPrice")
+        target_low = info.get("targetLowPrice")
+        target_upside = round((target_mean - ltp) / ltp * 100, 1) if target_mean and ltp else None
+
+        # ── Quarterly results (last 4) ───────────────────────
+        quarterly = []
+        try:
+            q_inc = ticker.quarterly_income_stmt
+            if not q_inc.empty:
+                for col in q_inc.columns[:4]:
+                    q_date = str(col)[:10]
+                    rev = q_inc.loc['Total Revenue'].get(col) if 'Total Revenue' in q_inc.index else None
+                    ni = q_inc.loc['Net Income Common Stockholders'].get(col) if 'Net Income Common Stockholders' in q_inc.index else None
+                    entry = {"quarter": q_date}
+                    if rev and not _is_nan(rev):
+                        entry["revenue_cr"] = round(rev / 1e7, 1)
+                    if ni and not _is_nan(ni):
+                        entry["profit_cr"] = round(ni / 1e7, 1)
+                    if len(entry) > 1:
+                        quarterly.append(entry)
+        except Exception:
+            pass
+
+        return {
+            "name": info.get("longName") or info.get("shortName") or symbol,
+            "pe": info.get("trailingPE"),
+            "pb": info.get("priceToBook"),
+            "roe": roe_final,
+            "roce": roce_computed,
+            "npm": round(npm_raw * 100, 1) if npm_raw else None,
+            "sales_growth": round(rev_growth_raw * 100, 1) if rev_growth_raw else None,
+            "profit_growth": round(earn_growth_raw * 100, 1) if earn_growth_raw else None,
+            "debt_equity": round(info.get("debtToEquity", 0) / 100, 2) if info.get("debtToEquity") else None,
+            "current_ratio": cr,
+            "interest_coverage": locals().get('interest_coverage_computed'),
+            "free_cash_flow": fcf,
+            "promoter_holding": promoter,
+            "institutional_holding": institutional,
+            "pledged_pct": None,
+            "dividend_yield": round(div_yield_raw * 100, 1) if div_yield_raw else None,
+            "ev_ebitda": info.get("enterpriseToEbitda"),
+            # Price context
+            "market_cap": mcap_cr,
+            "week52_high": w52_high,
+            "week52_low": w52_low,
+            "pct_from_52w_high": pct_from_high,
+            "avg_50d": info.get("fiftyDayAverage"),
+            "avg_200d": info.get("twoHundredDayAverage"),
+            "beta": info.get("beta"),
+            # Analyst consensus
+            "analyst_count": analyst_count,
+            "analyst_rating": analyst_rating,
+            "target_price_mean": target_mean,
+            "target_price_high": target_high,
+            "target_price_low": target_low,
+            "target_upside_pct": target_upside,
+            # Quarterly trend
+            "quarterly_revenue": quarterly,
+            "_data_source": "yfinance",
+        }
+    except Exception:
+        return {}
+
+
+def _is_nan(val) -> bool:
+    """Check if a value is NaN (works for float and numpy)."""
+    try:
+        import math
+        return math.isnan(float(val))
+    except (TypeError, ValueError):
+        return False
+
+
+def _fetch_nse_announcements(symbol: str, limit: int = 5) -> list[dict]:
+    """Fetch recent corporate announcements from NSE."""
+    try:
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Accept": "application/json",
+            "Referer": "https://www.nseindia.com",
+        }
+        session = httpx.Client(follow_redirects=True)
+        session.get("https://www.nseindia.com", headers=headers, timeout=5)
+        r = session.get(
+            f"https://www.nseindia.com/api/corporate-announcements?index=equities&symbol={symbol.upper()}",
+            headers=headers, timeout=8,
+        )
+        r.raise_for_status()
+        data = r.json()
+        results = []
+        if isinstance(data, list):
+            for item in data[:limit]:
+                results.append({
+                    "date": item.get("an_dt", "")[:20],
+                    "desc": item.get("desc", ""),
+                    "subject": item.get("attchmntText", item.get("desc", ""))[:100],
+                })
+        return results
+    except Exception:
+        return []
+
+
+def analyse(symbol: str, **_kwargs) -> FundamentalSnapshot:
     """
     Full fundamental analysis for a stock symbol.
 
-    Tries Screener.in first; falls back to mock data on failure.
+    Data cascade (real data only, no mocks):
+      1. Screener.in (best: PE, PB, ROE, ROCE, promoter holding, pledging)
+      2. yfinance / Yahoo Finance (good: PE, PB, D/E, margins, growth)
+      3. None values if both fail (prevents hallucinated analysis)
 
     Args:
         symbol:   NSE/BSE trading symbol e.g. "RELIANCE", "HDFCBANK"
-        use_mock: Force mock data (useful for demo/testing)
     """
-    if use_mock:
-        parsed = _mock_parse(symbol)
-    else:
-        try:
-            raw    = _fetch_screener(symbol)
-            parsed = _parse_screener(raw)
-        except Exception:
-            parsed = _mock_parse(symbol)
+    parsed = None
+
+    # 1. Screener.in (best: PE, PB, ROE, ROCE, promoter holding, pledging)
+    try:
+        raw    = _fetch_screener(symbol)
+        parsed = _parse_screener(raw)
+    except Exception:
+        pass
+
+    # 2. yfinance — either primary source or supplement for missing Screener fields
+    yf_data = _fetch_yfinance(symbol)
+
+    if not parsed:
+        # Screener.in failed entirely — use yfinance as primary
+        parsed = yf_data or _unavailable(symbol)
+    elif yf_data:
+        # Screener.in worked but may have gaps — fill from yfinance
+        for key, val in yf_data.items():
+            if key.startswith("_"):
+                continue  # skip _data_source etc.
+            if val is not None and parsed.get(key) is None:
+                parsed[key] = val
+
+    # 3. No fake data — return None values so LLM knows data is unavailable
+    if not parsed:
+        parsed = _unavailable(symbol)
 
     score, flags = _score(parsed)
 
@@ -289,6 +518,35 @@ def analyse(symbol: str, use_mock: bool = False) -> FundamentalSnapshot:
     else:
         verdict = "AVOID"
 
+    # ── Analyst consensus scoring ────────────────────────────
+    analyst_rating = parsed.get("analyst_rating")
+    target_upside = parsed.get("target_upside_pct")
+    if analyst_rating in ("strong_buy", "buy") and target_upside and target_upside > 20:
+        score += 8
+        flags.append(FundamentalFlag("Analyst Consensus", f"{analyst_rating} (↑{target_upside:.0f}%)", "GOOD",
+                                     f"{parsed.get('analyst_count', '?')} analysts, target upside {target_upside:.0f}%"))
+    elif analyst_rating in ("sell", "strong_sell"):
+        score -= 8
+        flags.append(FundamentalFlag("Analyst Consensus", analyst_rating, "BAD",
+                                     "Analysts recommend selling"))
+
+    # ── Free cash flow scoring ────────────────────────────────
+    fcf = parsed.get("free_cash_flow")
+    if fcf is not None:
+        if fcf > 0:
+            score += 5
+            flags.append(FundamentalFlag("Free Cash Flow", f"₹{fcf:.0f} Cr", "GOOD",
+                                         "Positive FCF — earnings are real, not just accounting"))
+        elif fcf < 0:
+            score -= 5
+            flags.append(FundamentalFlag("Free Cash Flow", f"₹{fcf:.0f} Cr", "WARN",
+                                         "Negative FCF — burning cash despite reported profits"))
+
+    score = max(0, min(100, score))
+
+    # ── Fetch announcements (best-effort, non-blocking) ──────
+    announcements = _fetch_nse_announcements(symbol)
+
     good_count = sum(1 for f in flags if f.verdict == "GOOD")
     bad_count  = sum(1 for f in flags if f.verdict == "BAD")
     summary    = (
@@ -297,25 +555,50 @@ def analyse(symbol: str, use_mock: bool = False) -> FundamentalSnapshot:
         f"PE={parsed.get('pe') or 'N/A'} | "
         f"ROE={parsed.get('roe') or 'N/A'}%"
     )
+    if analyst_rating:
+        summary += f" | Analysts: {analyst_rating}"
+    if target_upside:
+        summary += f" (↑{target_upside:.0f}%)"
 
     return FundamentalSnapshot(
-        symbol          = symbol.upper(),
-        name            = parsed.get("name", symbol),
-        pe              = parsed.get("pe"),
-        pb              = parsed.get("pb"),
-        roe             = parsed.get("roe"),
-        roce            = parsed.get("roce"),
-        npm             = parsed.get("npm"),
-        sales_growth    = parsed.get("sales_growth"),
-        profit_growth   = parsed.get("profit_growth"),
-        debt_equity     = parsed.get("debt_equity"),
-        current_ratio   = parsed.get("current_ratio"),
-        promoter_holding= parsed.get("promoter_holding"),
-        pledged_pct     = parsed.get("pledged_pct"),
-        dividend_yield  = parsed.get("dividend_yield"),
-        ev_ebitda       = parsed.get("ev_ebitda"),
-        flags           = flags,
-        score           = score,
-        verdict         = verdict,
-        summary         = summary,
+        symbol               = symbol.upper(),
+        name                 = parsed.get("name", symbol),
+        pe                   = parsed.get("pe"),
+        pb                   = parsed.get("pb"),
+        roe                  = parsed.get("roe"),
+        roce                 = parsed.get("roce"),
+        npm                  = parsed.get("npm"),
+        sales_growth         = parsed.get("sales_growth"),
+        profit_growth        = parsed.get("profit_growth"),
+        debt_equity          = parsed.get("debt_equity"),
+        current_ratio        = parsed.get("current_ratio"),
+        interest_coverage    = parsed.get("interest_coverage"),
+        free_cash_flow       = parsed.get("free_cash_flow"),
+        promoter_holding     = parsed.get("promoter_holding"),
+        institutional_holding= parsed.get("institutional_holding"),
+        pledged_pct          = parsed.get("pledged_pct"),
+        dividend_yield       = parsed.get("dividend_yield"),
+        ev_ebitda            = parsed.get("ev_ebitda"),
+        # Price context
+        market_cap           = parsed.get("market_cap"),
+        week52_high          = parsed.get("week52_high"),
+        week52_low           = parsed.get("week52_low"),
+        pct_from_52w_high    = parsed.get("pct_from_52w_high"),
+        avg_50d              = parsed.get("avg_50d"),
+        avg_200d             = parsed.get("avg_200d"),
+        beta                 = parsed.get("beta"),
+        # Analyst consensus
+        analyst_count        = parsed.get("analyst_count"),
+        analyst_rating       = analyst_rating,
+        target_price_mean    = parsed.get("target_price_mean"),
+        target_price_high    = parsed.get("target_price_high"),
+        target_price_low     = parsed.get("target_price_low"),
+        target_upside_pct    = target_upside,
+        # Quarterly + announcements
+        quarterly_revenue    = parsed.get("quarterly_revenue", []),
+        announcements        = announcements,
+        flags                = flags,
+        score                = score,
+        verdict              = verdict,
+        summary              = summary,
     )

--- a/analysis/options.py
+++ b/analysis/options.py
@@ -224,10 +224,40 @@ def iv_rank(
     return round((current_iv - iv_low) / (iv_high - iv_low) * 100, 1)
 
 
-def mock_iv_rank(symbol: str) -> float:
-    """Return a plausible IV rank for demo purposes."""
-    seeds = {"NIFTY": 34, "BANKNIFTY": 41, "RELIANCE": 28, "INFY": 52, "TCS": 22}
-    return seeds.get(symbol.upper(), 38.0)
+def compute_iv_rank_from_history(symbol: str, period: str = "1y") -> Optional[float]:
+    """
+    Compute IV rank from historical realized volatility.
+
+    Uses 30-day rolling annualized volatility as an IV proxy:
+      IV Rank = (current_RV - 52w_low_RV) / (52w_high_RV - 52w_low_RV) * 100
+
+    Returns 0-100 or None if data unavailable.
+    """
+    try:
+        import yfinance as yf
+        import numpy as np
+
+        ticker = yf.Ticker(f"{symbol.upper()}.NS")
+        hist = ticker.history(period=period)
+        if hist.empty or len(hist) < 60:
+            return None
+
+        returns = np.log(hist['Close'] / hist['Close'].shift(1)).dropna()
+        rolling_vol = (returns.rolling(30).std() * np.sqrt(252) * 100).dropna()
+
+        if rolling_vol.empty or len(rolling_vol) < 30:
+            return None
+
+        current = rolling_vol.iloc[-1]
+        lo = rolling_vol.min()
+        hi = rolling_vol.max()
+
+        if hi == lo:
+            return 50.0
+
+        return round((current - lo) / (hi - lo) * 100, 1)
+    except Exception:
+        return None
 
 
 # ── Payoff calculator ─────────────────────────────────────────

--- a/analysis/technical.py
+++ b/analysis/technical.py
@@ -18,7 +18,7 @@ from typing      import Optional
 import numpy  as np
 import pandas as pd
 
-from market.history import get_ohlcv_mock, get_ohlcv
+from market.history import get_ohlcv
 
 
 # ── Result dataclass ─────────────────────────────────────────
@@ -162,7 +162,7 @@ def analyse(
     try:
         df = get_ohlcv(symbol=symbol, exchange=exchange, days=days)
     except Exception:
-        df = get_ohlcv_mock(symbol=symbol, days=days)
+        df = pd.DataFrame()
 
     if df.empty or len(df) < 30:
         return TechnicalSnapshot(symbol=symbol, ltp=0.0, verdict="INSUFFICIENT DATA")

--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -1,0 +1,442 @@
+"""
+app/commands/strategy.py
+────────────────────────
+Interactive strategy builder command.
+
+Subcommands:
+  strategy new [description] [--simple]   — AI-guided strategy creation
+  strategy list                           — show saved strategies
+  strategy backtest <name> [--period 2y]  — re-backtest a saved strategy
+  strategy run <name> [symbol] [--paper]  — generate signal + paper trade
+  strategy show <name>                    — view code + metadata
+  strategy delete <name>                  — remove a saved strategy
+"""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+from rich.prompt import Prompt, Confirm
+
+console = Console()
+
+
+def run(args: list[str]) -> None:
+    """Main dispatcher for the strategy command."""
+    sub = args[0].lower() if args else ""
+
+    if sub == "new":
+        _cmd_new(args[1:])
+    elif sub == "list" or not sub:
+        _cmd_list()
+    elif sub == "backtest":
+        _cmd_backtest(args[1:])
+    elif sub == "run":
+        _cmd_run(args[1:])
+    elif sub == "show":
+        _cmd_show(args[1:])
+    elif sub == "delete":
+        _cmd_delete(args[1:])
+    else:
+        console.print(
+            "[dim]Usage:\n"
+            "  strategy new [description] [--simple]  Create a new strategy\n"
+            "  strategy list                          List saved strategies\n"
+            "  strategy backtest <name> [--period 2y] Re-backtest\n"
+            "  strategy run <name> [symbol] [--paper] Generate signal\n"
+            "  strategy show <name>                   View code\n"
+            "  strategy delete <name>                 Delete[/dim]"
+        )
+
+
+def _force_generate(agent) -> str:
+    """Send an explicit prompt that forces the LLM to output code, not call tools."""
+    return agent.chat(
+        "STOP calling tools. Do NOT fetch any more data. You have all the information you need.\n\n"
+        "Generate the Python strategy code NOW and output it in this exact format:\n\n"
+        "%%%STRATEGY_COMPLETE%%%\n"
+        '{"code": "...python code...", "name": "snake_case_name", '
+        '"description": "one line", "symbol": "SYMBOL", "parameters": {}}\n\n'
+        "The code must:\n"
+        "- Subclass Strategy from engine.backtest\n"
+        "- For SINGLE-SYMBOL: generate_signals returns pd.Series of -1/0/1\n"
+        "- For PAIRS/MULTI-SYMBOL: generate_signals returns pd.DataFrame with one column per symbol\n"
+        "  Values: 1=LONG, -1=SHORT, 0=FLAT. Use `from market.history import get_ohlcv` for other symbol data.\n"
+        "- Use signals[mask] = 1 (boolean indexing), NOT signals = 1\n"
+        "- Have default values for all __init__ parameters\n\n"
+        "Output the %%%STRATEGY_COMPLETE%%% block right now."
+    )
+
+
+# ── strategy new ─────────────────────────────────────────────
+
+def _cmd_new(args: list[str]) -> None:
+    """AI-guided interview -> code generation -> backtest -> save."""
+    from agent.core import get_agent
+    from agent.prompts import STRATEGY_BUILDER_PROMPT, STRATEGY_BUILDER_SIMPLE_PROMPT
+    from engine.strategy_builder import (
+        extract_strategy_payload, build_and_test, strategy_store,
+        validate_strategy_code, COMPLETION_MARKER,
+    )
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import InMemoryHistory
+
+    simple_mode = "--simple" in args
+    clean_args = [a for a in args if a != "--simple"]
+    initial_desc = " ".join(clean_args).strip()
+
+    prompt_text = STRATEGY_BUILDER_SIMPLE_PROMPT if simple_mode else STRATEGY_BUILDER_PROMPT
+
+    console.print("\n[bold cyan]━━━ Strategy Builder ━━━[/bold cyan]")
+    if simple_mode:
+        console.print("[dim]Simple mode: everything explained in plain language[/dim]")
+    console.print("[dim]Describe your strategy idea and the AI will guide you through building it.[/dim]")
+    console.print("[dim]Type [bold]done[/bold] to finish early, [bold]cancel[/bold] to abort.[/dim]\n")
+
+    agent = get_agent()
+
+    # Inject the strategy builder system prompt as the first message
+    first_message = prompt_text + "\n\n"
+    if initial_desc:
+        first_message += f"The user wants to build this strategy: {initial_desc}\n\nStart the interview."
+    else:
+        first_message += "The user wants to build a custom strategy. Start by asking what kind of strategy they have in mind."
+
+    # Run the multi-turn interview
+    interview_session = PromptSession(history=InMemoryHistory())
+    max_turns = 20
+    strategy_payload = None
+
+    consecutive_no_marker = 0  # track turns where LLM should have generated but didn't
+
+    for turn in range(max_turns):
+        if turn == 0:
+            response = agent.chat(first_message)
+        else:
+            try:
+                user_input = interview_session.prompt("you ❯ ").strip()
+            except (KeyboardInterrupt, EOFError):
+                console.print("\n[yellow]Strategy builder cancelled.[/yellow]")
+                return
+
+            if not user_input:
+                continue
+            if user_input.lower() == "cancel":
+                console.print("[yellow]Strategy builder cancelled.[/yellow]")
+                return
+            if user_input.lower() in ("done", "generate", "build", "build it", "go"):
+                response = _force_generate(agent)
+            else:
+                response = agent.chat(user_input)
+
+        # Check if the LLM signaled completion
+        payload = extract_strategy_payload(response)
+        if payload:
+            strategy_payload = payload
+            break
+
+        # Detect if the LLM seems stuck (asking for quotes, not progressing)
+        # After turn 6+, if the response doesn't contain a question mark, nudge it
+        if turn >= 6:
+            consecutive_no_marker += 1
+            if consecutive_no_marker >= 2:
+                console.print("\n[dim]Nudging AI to generate code...[/dim]")
+                response = _force_generate(agent)
+                payload = extract_strategy_payload(response)
+                if payload:
+                    strategy_payload = payload
+                    break
+                consecutive_no_marker = 0  # reset after one nudge attempt
+
+    if not strategy_payload:
+        # Last resort: one final hard push
+        console.print("\n[dim]Final attempt to generate strategy...[/dim]")
+        response = _force_generate(agent)
+        strategy_payload = extract_strategy_payload(response)
+
+    if not strategy_payload:
+        console.print("[yellow]Could not generate strategy code. Try again with [bold]strategy new[/bold].[/yellow]")
+        return
+
+    # ── Validate and backtest ────────────────────────────────
+    code = strategy_payload.get("code", "")
+    name = strategy_payload.get("name", "custom_strategy")
+    description = strategy_payload.get("description", "")
+    symbol = strategy_payload.get("symbol", "RELIANCE")
+    parameters = strategy_payload.get("parameters", {})
+
+    console.print(f"\n[bold]Generated strategy: [cyan]{name}[/cyan][/bold]")
+    console.print(f"[dim]{description}[/dim]")
+
+    # Validate with retry loop
+    max_retries = 3
+    for attempt in range(max_retries):
+        ok, error = validate_strategy_code(code)
+        if ok:
+            break
+        console.print(f"[yellow]Code validation failed (attempt {attempt + 1}/{max_retries}): {error}[/yellow]")
+        if attempt < max_retries - 1:
+            console.print("[dim]Asking AI to fix...[/dim]")
+            fix_response = agent.chat(
+                f"The generated strategy code has an error:\n{error}\n\n"
+                f"Please fix the code and output it again with the {COMPLETION_MARKER} marker."
+            )
+            fixed = extract_strategy_payload(fix_response)
+            if fixed and fixed.get("code"):
+                code = fixed["code"]
+                name = fixed.get("name", name)
+            else:
+                # Try extracting code from markdown
+                import re
+                code_match = re.search(r"```python\s*\n(.*?)```", fix_response, re.DOTALL)
+                if code_match:
+                    code = code_match.group(1).strip()
+    else:
+        console.print("[red]Could not generate valid strategy code after 3 attempts.[/red]")
+        console.print("[dim]Try again with a simpler strategy or more specific instructions.[/dim]")
+        return
+
+    # Run backtest
+    console.print(f"\n[bold]Running backtest on {symbol} (1 year)...[/bold]")
+    try:
+        strategy_obj, result = build_and_test(code, symbol=symbol, period="1y")
+        result.print_summary()
+        if result.trades:
+            result.print_trades(10)
+    except Exception as e:
+        console.print(f"[red]Backtest failed: {e}[/red]")
+        console.print("[dim]The strategy code might need adjustment.[/dim]")
+        return
+
+    # ── Save prompt ──────────────────────────────────────────
+    console.print()
+    if Confirm.ask(f"Save strategy [cyan]{name}[/cyan]?", default=True):
+        metadata = {
+            "name": name,
+            "description": description,
+            "parameters": parameters,
+            "default_symbol": symbol,
+            "simple_mode": simple_mode,
+            "last_backtest": {
+                "symbol": symbol,
+                "period": "1y",
+                "total_return": round(result.total_return, 2),
+                "sharpe": round(result.sharpe_ratio, 2),
+                "win_rate": round(result.win_rate, 1),
+                "max_drawdown": round(result.max_drawdown, 2),
+                "total_trades": result.total_trades,
+                "date": result.end_date,
+            },
+        }
+        path = strategy_store.save_strategy(name, code, metadata)
+        console.print(f"[green]Strategy saved![/green] {path}")
+        console.print(f"[dim]Run: strategy backtest {name} --period 2y[/dim]")
+        console.print(f"[dim]Run: strategy run {name} {symbol} --paper[/dim]")
+    else:
+        console.print("[dim]Strategy not saved.[/dim]")
+
+
+# ── strategy list ────────────────────────────────────────────
+
+def _cmd_list() -> None:
+    """List all saved strategies."""
+    from engine.strategy_builder import strategy_store, print_strategy_list
+    strategies = strategy_store.list_strategies()
+    print_strategy_list(strategies)
+
+
+# ── strategy backtest ────────────────────────────────────────
+
+def _cmd_backtest(args: list[str]) -> None:
+    """Re-backtest a saved strategy."""
+    if not args:
+        console.print("[red]Usage: strategy backtest <name> [--period 2y][/red]")
+        return
+
+    from engine.strategy_builder import strategy_store
+    from engine.backtest import Backtester
+
+    name = args[0]
+    period = "1y"
+    for i, a in enumerate(args):
+        if a == "--period" and i + 1 < len(args):
+            period = args[i + 1]
+
+    # Load symbol from metadata or prompt
+    meta = strategy_store.get_metadata(name)
+    symbol = meta.get("default_symbol", "RELIANCE") if meta else "RELIANCE"
+
+    # Check if symbol was provided as second arg
+    if len(args) > 1 and not args[1].startswith("-"):
+        symbol = args[1].upper()
+
+    try:
+        strategy = strategy_store.load_strategy(name)
+    except FileNotFoundError:
+        console.print(f"[red]Strategy '{name}' not found. Run [bold]strategy list[/bold] to see available.[/red]")
+        return
+    except Exception as e:
+        console.print(f"[red]Failed to load strategy: {e}[/red]")
+        return
+
+    console.print(f"[dim]Backtesting {name} on {symbol} ({period})...[/dim]")
+
+    try:
+        bt = Backtester(symbol=symbol, period=period)
+        result = bt.run(strategy)
+        result.print_summary()
+        result.print_trades(10)
+
+        # Update metadata with latest backtest
+        strategy_store.update_metadata(name, {
+            "last_backtest": {
+                "symbol": symbol,
+                "period": period,
+                "total_return": round(result.total_return, 2),
+                "sharpe": round(result.sharpe_ratio, 2),
+                "win_rate": round(result.win_rate, 1),
+                "max_drawdown": round(result.max_drawdown, 2),
+                "total_trades": result.total_trades,
+                "date": result.end_date,
+            }
+        })
+    except Exception as e:
+        console.print(f"[red]Backtest failed: {e}[/red]")
+
+
+# ── strategy run ─────────────────────────────────────────────
+
+def _cmd_run(args: list[str]) -> None:
+    """Load strategy, generate latest signal, optionally paper-trade."""
+    if not args:
+        console.print("[red]Usage: strategy run <name> [symbol] [--paper][/red]")
+        return
+
+    from engine.strategy_builder import strategy_store
+    from market.history import get_ohlcv
+
+    name = args[0]
+    paper_mode = "--paper" in args
+    clean_args = [a for a in args[1:] if a != "--paper"]
+
+    meta = strategy_store.get_metadata(name)
+    symbol = clean_args[0].upper() if clean_args else (meta.get("default_symbol", "RELIANCE") if meta else "RELIANCE")
+
+    try:
+        strategy = strategy_store.load_strategy(name)
+    except FileNotFoundError:
+        console.print(f"[red]Strategy '{name}' not found.[/red]")
+        return
+    except Exception as e:
+        console.print(f"[red]Failed to load: {e}[/red]")
+        return
+
+    # Fetch recent data and generate signals
+    console.print(f"[dim]Running {name} on {symbol}...[/dim]")
+    try:
+        df = get_ohlcv(symbol, days=90)
+        if df.empty:
+            console.print(f"[red]No data for {symbol}[/red]")
+            return
+
+        signals = strategy.generate_signals(df)
+        latest_signal = int(signals.iloc[-1]) if len(signals) > 0 else 0
+        prev_signal = int(signals.iloc[-2]) if len(signals) > 1 else 0
+        latest_price = float(df["close"].iloc[-1])
+        latest_date = str(df.index[-1].date()) if hasattr(df.index[-1], "date") else str(df.index[-1])
+
+        signal_map = {1: "[green bold]BUY[/green bold]", -1: "[red bold]SELL[/red bold]", 0: "[dim]HOLD[/dim]"}
+        console.print(f"\n  {symbol} @ Rs.{latest_price:,.2f} ({latest_date})")
+        console.print(f"  Signal: {signal_map.get(latest_signal, 'HOLD')}")
+
+        if latest_signal != prev_signal and latest_signal != 0:
+            console.print(f"  [yellow]Signal changed![/yellow] Previous: {signal_map.get(prev_signal, 'HOLD')}")
+
+        # Show recent signal history
+        recent = signals.tail(10)
+        signal_str = " ".join(
+            "[green]+[/green]" if s == 1 else "[red]-[/red]" if s == -1 else "[dim].[/dim]"
+            for s in recent
+        )
+        console.print(f"  Last 10 days: {signal_str}")
+
+        # Paper trade if requested
+        if paper_mode and latest_signal == 1:
+            console.print(f"\n[bold]Paper trading: BUY {symbol}[/bold]")
+            try:
+                from brokers.session import get_broker
+                from brokers.base import OrderRequest
+
+                broker = get_broker()
+                if broker:
+                    capital = float(os.environ.get("TOTAL_CAPITAL", "200000"))
+                    risk_pct = float(os.environ.get("DEFAULT_RISK_PCT", "2"))
+                    quantity = max(1, int((capital * risk_pct / 100) / latest_price))
+
+                    req = OrderRequest(
+                        symbol=f"NSE:{symbol}-EQ",
+                        exchange="NSE",
+                        transaction_type="BUY",
+                        quantity=quantity,
+                        order_type="MARKET",
+                        product="CNC",
+                        tag=f"strategy:{name}",
+                    )
+                    resp = broker.place_order(req)
+                    console.print(f"  [green]Order placed:[/green] {resp.status} | Qty: {quantity} | ID: {resp.order_id}")
+                else:
+                    console.print("[dim]No broker connected. Use [bold]login[/bold] first.[/dim]")
+            except Exception as e:
+                console.print(f"[red]Paper trade failed: {e}[/red]")
+
+        elif paper_mode and latest_signal == -1:
+            console.print(f"\n[bold yellow]Signal is SELL — check your positions for {symbol}[/bold yellow]")
+        elif paper_mode:
+            console.print(f"\n[dim]Signal is HOLD — no action taken.[/dim]")
+
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+
+
+# ── strategy show ────────────────────────────────────────────
+
+def _cmd_show(args: list[str]) -> None:
+    """Display strategy code and metadata."""
+    if not args:
+        console.print("[red]Usage: strategy show <name>[/red]")
+        return
+
+    from engine.strategy_builder import strategy_store, print_strategy_code
+
+    name = args[0]
+    code = strategy_store.get_code(name)
+    if not code:
+        console.print(f"[red]Strategy '{name}' not found.[/red]")
+        return
+
+    meta = strategy_store.get_metadata(name)
+    print_strategy_code(name, code, meta)
+
+
+# ── strategy delete ──────────────────────────────────────────
+
+def _cmd_delete(args: list[str]) -> None:
+    """Delete a saved strategy."""
+    if not args:
+        console.print("[red]Usage: strategy delete <name>[/red]")
+        return
+
+    from engine.strategy_builder import strategy_store
+
+    name = args[0]
+    meta = strategy_store.get_metadata(name)
+    if not meta and not strategy_store.get_code(name):
+        console.print(f"[red]Strategy '{name}' not found.[/red]")
+        return
+
+    if Confirm.ask(f"Delete strategy [cyan]{name}[/cyan]?", default=False):
+        strategy_store.delete_strategy(name)
+        console.print(f"[dim]Strategy '{name}' deleted.[/dim]")
+    else:
+        console.print("[dim]Cancelled.[/dim]")

--- a/app/repl.py
+++ b/app/repl.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from prompt_toolkit              import PromptSession
 from prompt_toolkit.completion   import WordCompleter
+from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history      import FileHistory
 from prompt_toolkit.styles       import Style
 from rich.console                import Console
@@ -61,7 +62,8 @@ COMMANDS = [
     "portfolio", "paper",
     "ai", "alert", "alerts", "audit", "backtest", "clear",
     "deep-analyze", "drift",
-    "earnings", "events", "flows", "greeks", "macro", "memory",
+    "earnings", "events", "exports", "flows", "greeks", "macro", "memory",
+    "strategy",
     "mtf", "pairs", "patterns", "profile", "provider", "risk-report",
     "paper-execute", "save-pdf", "explain", "explain-save",
     "telegram", "tui", "walkforward", "web", "whatif",
@@ -420,7 +422,9 @@ def cmd_help() -> None:
         "Analysis (AI-powered)": [
             ("analyze <SYM>",         "Multi-agent analysis (7 analysts + debate + trade plan)"),
             ("deep-analyze <SYM>",    "Full LLM mode (11 calls — every analyst uses AI)"),
-            ("ai <message>",          "Chat with AI (e.g. ai should I buy RELIANCE?)"),
+            ("ai <message>",          "Chat with AI — follow-ups keep context"),
+            ("strategy new [--simple]", "Build a strategy from plain English"),
+            ("strategy list",         "List saved strategies"),
             ("morning-brief",         "Daily market context + AI narrative"),
         ],
         "Market Data": [
@@ -464,18 +468,21 @@ def cmd_help() -> None:
             ("alerts",                         "List active alerts"),
             ("alert remove <ID>",              "Remove an alert"),
         ],
-        "Output": [
+        "Output & Exports": [
             ("save-pdf",              "Save previous output as PDF"),
             ("explain",               "Explain previous output simply"),
             ("explain-save",          "Explain + save as PDF"),
             ("--pdf",                 "Flag: append to any command"),
             ("--explain",             "Flag: append to any command"),
+            ("exports",               "List all saved PDF exports"),
+            ("exports open <file>",   "Open a saved export"),
+            ("exports clear --older-than 30d", "Delete old exports"),
         ],
         "Session": [
             ("login",                 "Connect to a broker"),
             ("provider [name]",       "Show/switch AI provider"),
-            ("telegram",              "Start Telegram bot"),
-            ("clear",                 "Reset AI conversation history"),
+            ("telegram [setup]",      "Start bot / run guided setup wizard"),
+            ("clear",                 "Start fresh AI conversation (reset context)"),
             ("credentials",           "Manage API keys"),
             ("quit / exit",           "Exit"),
         ],
@@ -828,9 +835,20 @@ def run_repl(broker: BrokerAPI) -> None:
     _last_command: str = ""
     _last_trade_plans: dict = {}  # from analyze → 3 risk persona plans
 
+    def _build_prompt():
+        """Dynamic prompt — shows 📩 badge when Telegram commands are in-flight."""
+        try:
+            from bot.status import get_badge
+            badge = get_badge()
+        except Exception:
+            badge = ""
+        if badge:
+            return HTML(f'<b>trade</b><style fg="orange">{badge}</style> ❯ ')
+        return "trade ❯ "
+
     while True:
         try:
-            raw = session.prompt("trade ❯ ").strip()
+            raw = session.prompt(_build_prompt, refresh_interval=1.0).strip()
         except (KeyboardInterrupt, EOFError):
             console.print("\n[yellow]Use 'quit' to exit.[/yellow]")
             continue
@@ -842,22 +860,24 @@ def run_repl(broker: BrokerAPI) -> None:
         command = parts[0].lower()
         args    = parts[1:]
 
+        # ── Global --pdf / --save-pdf flag ─────────────────────
+        # Strip the flag before any command sees it, so every
+        # command gets PDF support automatically.
+        _global_pdf = "--pdf" in args or "--save-pdf" in args
+        if _global_pdf:
+            args = [a for a in args if a not in ("--pdf", "--save-pdf")]
+            _pre_pdf_output = _last_output  # snapshot before command
+
         try:
             # ── Session ───────────────────────────────────────
             if command in ("quit", "exit", "q"):
                 console.print("[dim]Goodbye.[/dim]")
-                # Clean shutdown of background threads
-                try:
-                    from market.websocket import ws_manager
-                    ws_manager.stop()
-                except Exception:
-                    pass
-                try:
-                    from engine.alerts import alert_manager
-                    alert_manager.stop_polling()
-                except Exception:
-                    pass
-                break
+                # Force-exit immediately. Background threads (Telegram bot,
+                # websocket, executor pool) are non-daemon and would keep the
+                # process alive indefinitely.  os._exit() is the only reliable
+                # way to terminate without waiting for them.
+                import os as _os
+                _os._exit(0)
 
             elif command == "help":
                 cmd_help()
@@ -1037,7 +1057,18 @@ def run_repl(broker: BrokerAPI) -> None:
                         agent.run_multi_agent_analysis(symbol)
 
             elif command == "telegram":
-                # Pre-validate before starting background thread
+                sub = args[0].lower() if args else ""
+
+                # ── telegram setup — full guided wizard ──────
+                if sub == "setup":
+                    try:
+                        from bot.telegram_bot import run_setup_wizard
+                        run_setup_wizard()
+                    except Exception as e:
+                        console.print(f"[red]Setup failed: {e}[/red]")
+                    continue
+
+                # ── telegram — start bot in background ───────
                 try:
                     import telegram as _tg_check  # noqa: F401
                 except ImportError:
@@ -1046,20 +1077,33 @@ def run_repl(broker: BrokerAPI) -> None:
                         "[dim]Run: pip install python-telegram-bot[/dim]"
                     )
                     continue
+
                 try:
                     from bot.telegram_bot import _get_bot_token
                     _get_bot_token()
                 except RuntimeError as e:
-                    console.print(f"[red]{e}[/red]")
-                    continue
-                try:
-                    from bot.telegram_bot import run_bot_background
-                    run_bot_background()
                     console.print(
-                        "[green]Telegram bot started in background.[/green]\n"
-                        "[dim]Send /start to your bot on Telegram to begin.[/dim]\n"
-                        "[dim]Alerts will be pushed automatically.[/dim]"
+                        f"[red]{e}[/red]\n"
+                        "[dim]Run [bold]telegram setup[/bold] for step-by-step guided setup.[/dim]"
                     )
+                    continue
+
+                try:
+                    from bot.telegram_bot import run_bot_background, _load_chat_id
+                    run_bot_background()
+                    chat_id = _load_chat_id()
+                    if not chat_id:
+                        console.print(
+                            "[green]Telegram bot started.[/green]\n"
+                            "[yellow]⚠  No chat connected yet.[/yellow]\n"
+                            "[dim]Send /start to your bot on Telegram to enable push notifications.\n"
+                            "Or run [bold]telegram setup[/bold] for the full guided flow.[/dim]"
+                        )
+                    else:
+                        console.print(
+                            "[green]✓ Telegram bot started.[/green]\n"
+                            "[dim]Alerts and signals will be pushed automatically.[/dim]"
+                        )
                 except Exception as e:
                     console.print(f"[red]Telegram bot failed: {e}[/red]")
 
@@ -1079,15 +1123,67 @@ def run_repl(broker: BrokerAPI) -> None:
                         else:
                             console.print(f"[dim]No {profile_name} plan available (verdict may be HOLD).[/dim]")
 
+            # ── Exports management ────────────────────────────────
+            elif command == "exports":
+                from engine.output import list_exports, open_export, clear_exports
+                sub = args[0].lower() if args else ""
+
+                if sub == "open" and len(args) >= 2:
+                    fname = args[1]
+                    if open_export(fname):
+                        console.print(f"[green]Opened:[/green] {fname}")
+                    else:
+                        console.print(f"[red]File not found:[/red] {fname}")
+
+                elif sub == "clear":
+                    days = 30
+                    for i, a in enumerate(args):
+                        if a == "--older-than" and i + 1 < len(args):
+                            raw = args[i + 1].rstrip("d")
+                            try:
+                                days = int(raw)
+                            except ValueError:
+                                pass
+                    deleted = clear_exports(days)
+                    console.print(f"[dim]Deleted {deleted} export(s) older than {days} days.[/dim]")
+
+                else:
+                    exports = list_exports()
+                    if not exports:
+                        console.print("[dim]No saved exports yet. Use --pdf on any command.[/dim]")
+                    else:
+                        from rich.table import Table as RichTable
+                        tbl = RichTable(
+                            title="Saved Exports",
+                            caption=f"~/.trading_platform/exports/",
+                            show_lines=False,
+                        )
+                        tbl.add_column("File", style="cyan")
+                        tbl.add_column("Size", justify="right")
+                        tbl.add_column("Date", style="dim")
+
+                        total_kb = 0.0
+                        for ex in exports:
+                            total_kb += ex["size_kb"]
+                            size_str = f"{ex['size_kb']:.0f} KB" if ex["size_kb"] < 1024 else f"{ex['size_kb']/1024:.1f} MB"
+                            date_str = ex["modified"].strftime("%d %b %Y, %I:%M %p")
+                            tbl.add_row(ex["name"], size_str, date_str)
+
+                        total_str = f"{total_kb:.0f} KB" if total_kb < 1024 else f"{total_kb/1024:.1f} MB"
+                        tbl.caption = f"{len(exports)} files | {total_str} total | ~/.trading_platform/exports/"
+                        console.print(tbl)
+
             # ── Post-processing commands (operate on previous output) ──
             elif command == "save-pdf":
                 if not _last_output:
                     console.print("[dim]No previous output to save. Run a command first.[/dim]")
                 else:
-                    from engine.output import export_to_pdf
-                    filepath = export_to_pdf(_last_output, title=_last_command or "Trade CLI Output")
+                    from engine.output import export_to_pdf, _archive_filename
+                    _pdf_title = _last_command or "Trade CLI Output"
+                    filepath = export_to_pdf(_last_output, title=_pdf_title)
                     if filepath:
                         console.print(f"[green]PDF saved:[/green] {filepath}")
+                        console.print(f"[dim]Archived:[/dim] ~/.trading_platform/exports/{_archive_filename(_pdf_title)}")
 
             elif command == "explain":
                 if not _last_output:
@@ -1109,7 +1205,7 @@ def run_repl(broker: BrokerAPI) -> None:
                 if not _last_output:
                     console.print("[dim]No previous output. Run a command first.[/dim]")
                 else:
-                    from engine.output import explain_simply, export_to_pdf
+                    from engine.output import explain_simply, export_to_pdf, _archive_filename
                     # Step 1: Explain
                     console.print()
                     console.rule("[bold green]Simple Explanation[/bold green]", style="green")
@@ -1122,9 +1218,11 @@ def run_repl(broker: BrokerAPI) -> None:
                     console.rule(style="green")
                     # Step 2: Combine and save PDF
                     combined = _last_output + "\n\n--- SIMPLE EXPLANATION ---\n\n" + explanation
-                    filepath = export_to_pdf(combined, title=_last_command or "Trade CLI Report")
+                    _pdf_title = _last_command or "Trade CLI Report"
+                    filepath = export_to_pdf(combined, title=_pdf_title)
                     if filepath:
                         console.print(f"\n[green]PDF saved (with explanation):[/green] {filepath}")
+                        console.print(f"[dim]Archived:[/dim] ~/.trading_platform/exports/{_archive_filename(_pdf_title)}")
                     _last_output = combined
 
             elif command == "mtf":
@@ -1162,6 +1260,10 @@ def run_repl(broker: BrokerAPI) -> None:
             elif command == "backtest":
                 _handle_backtest_command(args)
 
+            elif command == "strategy":
+                from app.commands.strategy import run as strategy_run
+                strategy_run(args)
+
             elif command == "whatif":
                 _handle_whatif_command(args)
 
@@ -1171,7 +1273,8 @@ def run_repl(broker: BrokerAPI) -> None:
                 message = " ".join(clean_args).strip()
                 if not message:
                     console.print(
-                        "[dim]Usage: ai <your message> [--pdf] [--explain][/dim]"
+                        "[dim]Usage: ai <your message> [--pdf] [--explain]\n"
+                        "  Follow-ups remember context. Use [bold]clear[/bold] to start fresh.[/dim]"
                     )
                 else:
                     agent = get_agent()
@@ -1238,3 +1341,58 @@ def run_repl(broker: BrokerAPI) -> None:
             if os.environ.get("DEBUG"):
                 import traceback
                 console.print(f"[dim]{traceback.format_exc()}[/dim]")
+
+        # ── Global PDF export (runs after every command) ─────
+        if _global_pdf:
+            pdf_content = ""
+            _pdf_title = _last_command or f"{command} {' '.join(args)}".strip()
+
+            if _last_output and _last_output != _pre_pdf_output:
+                # Command updated _last_output (analyze, deep-analyze, ai, backtest)
+                pdf_content = _last_output
+            else:
+                # Command only did console.print() — re-capture with Rich
+                try:
+                    with console.capture() as _cap:
+                        exec_parts = raw.replace("--pdf", "").replace("--save-pdf", "").split()
+                        exec_cmd = exec_parts[0].lower() if exec_parts else ""
+                        exec_args = exec_parts[1:]
+                        if exec_cmd == "funds" and broker:
+                            cmd_funds(broker)
+                        elif exec_cmd == "holdings" and broker:
+                            cmd_holdings(broker)
+                        elif exec_cmd == "positions" and broker:
+                            cmd_positions(broker)
+                        elif exec_cmd == "orders" and broker:
+                            cmd_orders(broker)
+                        elif exec_cmd in ("alerts",) or (exec_cmd == "alert" and (not exec_args or exec_args[0] == "list")):
+                            from engine.alerts import alert_manager
+                            alert_manager.list_alerts()
+                        elif exec_cmd == "memory":
+                            from engine.memory import trade_memory
+                            if not exec_args:
+                                trade_memory.print_recent()
+                            elif exec_args[0] == "stats":
+                                trade_memory.print_stats()
+                        elif exec_cmd == "flows":
+                            from market.flow_intel import get_flow_intel
+                            get_flow_intel()
+                        elif exec_cmd == "macro":
+                            from market.macro import print_macro_snapshot
+                            if exec_args:
+                                print_macro_snapshot(exec_args[0].upper())
+                            else:
+                                print_macro_snapshot()
+                    pdf_content = _cap.get()
+                    _pdf_title = _pdf_title or f"{exec_cmd} output"
+                except Exception:
+                    pdf_content = ""
+
+            if pdf_content.strip():
+                from engine.output import export_to_pdf, _archive_filename
+                filepath = export_to_pdf(pdf_content, title=_pdf_title)
+                if filepath:
+                    console.print(f"\n[green]PDF saved:[/green] {filepath}")
+                    console.print(f"[dim]Archived:[/dim] ~/.trading_platform/exports/{_archive_filename(_pdf_title)}")
+            else:
+                console.print("[dim]No output to save as PDF.[/dim]")

--- a/bot/status.py
+++ b/bot/status.py
@@ -1,0 +1,52 @@
+"""
+bot/status.py
+─────────────
+Thread-safe shared state for Telegram bot activity.
+
+The REPL prompt reads `get_badge()` on every iteration to show a
+persistent indicator when a Telegram command is being processed.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+_lock = threading.Lock()
+_active_command: Optional[str] = None   # e.g. "/analyze RELIANCE"
+_pending_count: int = 0                  # how many commands in flight
+
+
+def set_active(command: str) -> None:
+    """Mark a Telegram command as in-flight."""
+    global _active_command, _pending_count
+    with _lock:
+        _active_command = command
+        _pending_count += 1
+
+
+def clear_active() -> None:
+    """Mark a Telegram command as finished."""
+    global _active_command, _pending_count
+    with _lock:
+        _pending_count = max(0, _pending_count - 1)
+        if _pending_count == 0:
+            _active_command = None
+
+
+def get_badge() -> str:
+    """
+    Return a short status string for the REPL prompt.
+
+    Returns "" when idle, or something like "📩 /analyze" when busy.
+    """
+    with _lock:
+        if _pending_count == 0:
+            return ""
+        cmd = _active_command or "cmd"
+        # Truncate long commands
+        if len(cmd) > 20:
+            cmd = cmd[:20] + "…"
+        if _pending_count > 1:
+            return f" 📩 {cmd} (+{_pending_count - 1})"
+        return f" 📩 {cmd}"

--- a/bot/telegram_bot.py
+++ b/bot/telegram_bot.py
@@ -42,6 +42,84 @@ from typing import Optional
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Suppress chatty third-party loggers at import time so they never
+# flood the REPL regardless of when the bot thread starts.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+logging.getLogger("telegram").setLevel(logging.WARNING)
+logging.getLogger("telegram.ext").setLevel(logging.WARNING)
+logging.getLogger("apscheduler").setLevel(logging.WARNING)
+logging.getLogger("market.websocket").setLevel(logging.WARNING)
+logging.getLogger("market").setLevel(logging.WARNING)
+
+
+class _BotThreadFilter(logging.Filter):
+    """
+    Attached to the root logger's handlers.
+    Only allows log records from the main thread (the REPL) through.
+    All background threads (telegram-bot, executor pool, websocket, etc.)
+    are silenced so their output never appears in the REPL.
+    """
+    def filter(self, record: logging.LogRecord) -> bool:
+        return threading.current_thread().name == "MainThread"
+
+
+class _BotThreadFileWrapper:
+    """
+    Wraps any file-like object and suppresses all writes from the
+    telegram-bot thread at call time.
+
+    Used in two places:
+      1. Replaces sys.stdout so plain print() calls are silenced.
+      2. Replaces the _file attribute on every existing Rich Console
+         instance so that console.print() / progress spinners are
+         silenced too (Rich stores a direct file reference at init time,
+         so replacing sys.stdout alone is not enough).
+
+    Thread-safe: the thread check happens at write time.
+    """
+    _bot_patched = True  # sentinel to avoid double-wrapping
+
+    def __init__(self, wrapped: object) -> None:
+        self._wrapped = wrapped
+
+    def _is_bot_thread(self) -> bool:
+        # Only the main thread (REPL) is allowed to produce terminal output.
+        # All other threads (telegram-bot, executor pool, websocket, etc.)
+        # are silenced.
+        return threading.current_thread().name != "MainThread"
+
+    def write(self, s: str) -> int:
+        if self._is_bot_thread() or self._wrapped is None:
+            return len(s) if isinstance(s, str) else 0
+        return self._wrapped.write(s)  # type: ignore[union-attr]
+
+    def flush(self) -> None:
+        if not self._is_bot_thread() and self._wrapped is not None:
+            self._wrapped.flush()  # type: ignore[union-attr]
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._wrapped, name)
+
+
+# ── Telegram → REPL status badge ─────────────────────────────
+
+import functools
+from bot.status import set_active, clear_active
+
+
+def _track_command(func):
+    """Decorator that sets/clears the REPL status badge around a handler."""
+    @functools.wraps(func)
+    async def wrapper(update, context):
+        cmd_text = update.message.text if update.message else func.__name__
+        set_active(cmd_text)
+        try:
+            return await func(update, context)
+        finally:
+            clear_active()
+    return wrapper
+
 
 # ── Lazy imports to avoid startup overhead ───────────────────
 
@@ -82,6 +160,15 @@ def _get_bot_token() -> str:
 
 # Chat ID for push notifications (set on first /start)
 _chat_id: Optional[int] = None
+
+# Background bot thread — kept here to prevent starting duplicates
+_bot_thread: Optional[threading.Thread] = None
+
+# Thread-local flag: set to True on any thread that should produce no output.
+# Used to silence executor threads spawned by run_in_executor during analysis,
+# which have a different name from "telegram-bot" and would otherwise bypass
+# the _BotThreadFileWrapper name check.
+_suppress_output = threading.local()
 _CHAT_ID_FILE = os.path.expanduser("~/.trading_platform/telegram_chat_id")
 
 
@@ -117,7 +204,8 @@ async def cmd_start(update, context) -> None:
         "Welcome to India Trade CLI Bot!\n\n"
         "Commands:\n"
         "/quote RELIANCE — live price\n"
-        "/analyze RELIANCE — quick analysis\n"
+        "/analyze RELIANCE — full analysis (3-4 min)\n"
+        "/deepanalyze RELIANCE — deep LLM analysis (7-10 min)\n"
         "/brief — morning market brief\n"
         "/flows — FII/DII flow signals\n"
         "/earnings — upcoming results\n"
@@ -163,57 +251,235 @@ async def cmd_quote(update, context) -> None:
 
 
 async def cmd_analyze(update, context) -> None:
-    """Handle /analyze SYMBOL — quick scorecard (no full debate)."""
+    """Handle /analyze SYMBOL — full multi-agent analysis, same as CLI."""
     if not context.args:
         await update.message.reply_text("Usage: /analyze RELIANCE")
         return
 
     symbol = context.args[0].upper()
-    await update.message.reply_text(f"Analyzing {symbol}... (this takes ~30s)")
+    await update.message.reply_text(
+        f"🔍 Running full analysis on {symbol}...\n"
+        f"(7 analysts + debate + synthesis — takes 3-4 min)"
+    )
+
+    def _run_analysis() -> tuple:
+        """Synchronous full pipeline — run in executor to avoid blocking event loop."""
+        _suppress_output.active = True
+        # Log to file — stdout and logging are both suppressed on this thread
+        import tempfile, pathlib
+        _logfile = pathlib.Path(tempfile.gettempdir()) / "tg_analyze.log"
+        def _log(msg):  # noqa: E731
+            with open(_logfile, "a") as f:
+                f.write(f"{msg}\n")
+        try:
+            _log(f"Starting analysis for {symbol}")
+            from agent.tools import build_registry
+            from agent.multi_agent import MultiAgentAnalyzer, compute_scorecard
+            from agent.core import get_provider
+
+            os.environ["_CLI_BATCH_MODE"] = "1"
+            registry = build_registry()
+            _log("Registry built")
+            provider = get_provider()
+            _log(f"Provider: {provider}")
+            analyzer = MultiAgentAnalyzer(registry, provider, verbose=False)
+
+            # Run all 7 analysts
+            reports = []
+            for i, a in enumerate(analyzer.analysts):
+                try:
+                    _log(f"Analyst {i+1}/{len(analyzer.analysts)}: {a.__class__.__name__}")
+                    reports.append(a.analyze(symbol))
+                except Exception as ex:
+                    _log(f"Analyst {a.__class__.__name__} failed: {ex}")
+
+            _log(f"Got {len(reports)} reports, computing scorecard")
+            scorecard = compute_scorecard(reports)
+
+            verdict_emoji = {"BULLISH": "🟢", "BEARISH": "🔴", "NEUTRAL": "🟡"}
+            analyst_lines = []
+            for r in reports:
+                if not r.error:
+                    e = verdict_emoji.get(r.verdict, "⚪")
+                    analyst_lines.append(f"{e} {r.analyst}: {r.verdict} ({r.confidence}%)")
+
+            # Run debate + synthesis
+            _log("Running debate")
+            debate    = analyzer._run_debate(symbol, "NSE", reports)
+            _log("Running synthesis")
+            synthesis = analyzer._run_synthesis(symbol, "NSE", reports, debate)
+            _log("Pipeline complete")
+
+            # ── Message 1: analyst scorecard ─────────────────────
+            score_emoji = verdict_emoji.get(scorecard.verdict, "🟡")
+            msg1 = (
+                f"📊 {symbol} — Full Analysis\n\n"
+                + "\n".join(analyst_lines)
+                + f"\n\n{score_emoji} Scorecard: {scorecard.verdict} ({scorecard.weighted_total:+.1f})\n"
+                f"Agreement: {scorecard.agreement:.0f}%"
+            )
+            if scorecard.conflicts:
+                msg1 += f"\nConflicts: {', '.join(scorecard.conflicts)}"
+
+            # ── Message 2: debate ─────────────────────────────────
+            msg2 = ""
+            if debate:
+                parts = ["🥊 Bull vs Bear Debate\n"]
+                if debate.bull_argument:
+                    parts.append(f"🟢 BULL (Round 1)\n{debate.bull_argument.strip()[:800]}")
+                if debate.bear_argument:
+                    parts.append(f"\n🔴 BEAR (Round 1)\n{debate.bear_argument.strip()[:800]}")
+                if debate.bull_rebuttal:
+                    parts.append(f"\n🟢 BULL (Rebuttal)\n{debate.bull_rebuttal.strip()[:600]}")
+                if debate.bear_rebuttal:
+                    parts.append(f"\n🔴 BEAR (Rebuttal)\n{debate.bear_rebuttal.strip()[:600]}")
+                if debate.facilitator:
+                    parts.append(f"\n🎙 Facilitator\n{debate.facilitator.strip()[:600]}")
+                if debate.winner:
+                    win_e = "🟢" if debate.winner == "BULL" else "🔴"
+                    parts.append(f"\nVerdict: {win_e} {debate.winner} prevailed")
+                msg2 = "\n".join(parts)[:3800]
+
+            # ── Message 3: synthesis ──────────────────────────────
+            synth_text = (synthesis or "").strip()[:3800]
+            msg3 = f"🧠 Synthesis\n\n{synth_text}" if synth_text else ""
+
+            os.environ.pop("_CLI_BATCH_MODE", None)
+            _log(f"Returning msgs: {len(msg1)} / {len(msg2)} / {len(msg3)} chars")
+            return msg1, msg2, msg3
+
+        except Exception as e:
+            os.environ.pop("_CLI_BATCH_MODE", None)
+            import traceback
+            _log(f"FAILED: {e}\n{traceback.format_exc()}")
+            return f"Analysis failed: {e}", "", ""
+        finally:
+            _suppress_output.active = False
 
     try:
-        from agent.tools import build_registry
-        from agent.multi_agent import (
-            TechnicalAnalyst, FundamentalAnalyst, OptionsAnalyst,
-            SentimentAnalyst, RiskAnalyst, compute_scorecard,
+        loop = asyncio.get_event_loop()
+        result = await asyncio.wait_for(
+            loop.run_in_executor(None, _run_analysis),
+            timeout=300,  # 5 minute hard timeout
         )
-
-        os.environ["_CLI_BATCH_MODE"] = "1"
-        registry = build_registry()
-
-        analysts = [
-            TechnicalAnalyst(registry),
-            FundamentalAnalyst(registry),
-            OptionsAnalyst(registry),
-            SentimentAnalyst(registry),
-            RiskAnalyst(registry),
-        ]
-
-        reports = []
-        for a in analysts:
-            try:
-                reports.append(a.analyze(symbol))
-            except Exception:
-                pass
-
-        os.environ.pop("_CLI_BATCH_MODE", None)
-
-        scorecard = compute_scorecard(reports)
-
-        lines = [f"📊 Quick Analysis: {symbol}\n"]
-        for r in reports:
-            if not r.error:
-                emoji = "🟢" if r.verdict == "BULLISH" else "🔴" if r.verdict == "BEARISH" else "🟡"
-                lines.append(f"{emoji} {r.analyst}: {r.verdict} ({r.confidence}%)")
-
-        lines.append(f"\nScorecard: {scorecard.verdict} ({scorecard.weighted_total:+.1f})")
-        lines.append(f"Agreement: {scorecard.agreement:.0f}%")
-        if scorecard.conflicts:
-            lines.append(f"Conflicts: {', '.join(scorecard.conflicts)}")
-
-        await update.message.reply_text("\n".join(lines))
+        msg1, msg2, msg3 = result if isinstance(result, tuple) and len(result) == 3 else (str(result), "", "")
+        # Send as plain text — LLM output can contain any characters that
+        # would break Telegram's HTML/Markdown parsers.
+        # Telegram limit is 4096 chars per message.
+        if msg1:
+            await update.message.reply_text(msg1[:4000])
+        if msg2:
+            await update.message.reply_text(msg2[:4000])
+        if msg3:
+            await update.message.reply_text(msg3[:4000])
+        if not msg1:
+            await update.message.reply_text("Analysis completed but produced no output.")
+    except asyncio.TimeoutError:
+        await update.message.reply_text(f"⏱ Analysis timed out after 5 minutes. Try again later.")
     except Exception as e:
-        await update.message.reply_text(f"Analysis failed: {e}")
+        err = str(e)[:500]
+        await update.message.reply_text(f"Analysis failed: {err}")
+
+
+async def cmd_deepanalyze(update, context) -> None:
+    """Handle /deepanalyze SYMBOL — full LLM deep analysis (11 calls)."""
+    if not context.args:
+        await update.message.reply_text("Usage: /deepanalyze RELIANCE")
+        return
+
+    symbol = context.args[0].upper()
+    await update.message.reply_text(
+        f"🔬 Running deep analysis on {symbol}...\n"
+        f"(11 LLM calls — every analyst uses AI — takes 7-10 min)"
+    )
+
+    def _run_deep() -> tuple:
+        _suppress_output.active = True
+        import tempfile, pathlib
+        _logfile = pathlib.Path(tempfile.gettempdir()) / "tg_deepanalyze.log"
+        def _log(msg):
+            with open(_logfile, "a") as f:
+                f.write(f"{msg}\n")
+        try:
+            _log(f"Starting deep analysis for {symbol}")
+            from agent.tools import build_registry
+            from agent.deep_agent import DeepAnalyzer
+            from agent.multi_agent import compute_scorecard
+            from agent.core import get_provider
+
+            os.environ["_CLI_BATCH_MODE"] = "1"
+            registry = build_registry()
+            provider = get_provider()
+            deep = DeepAnalyzer(registry, provider, verbose=False)
+
+            # Run the full pipeline — returns a text report
+            full_report = deep.analyze(symbol)
+            _log(f"Deep analysis complete, report length: {len(full_report or '')}")
+
+            if not full_report:
+                return "Deep analysis produced no output.", "", ""
+
+            # Split into 3 telegram-friendly messages
+            # Message 1: analyst scorecard section
+            # Message 2: debate section
+            # Message 3: synthesis section
+            parts = full_report.split("=" * 60)
+
+            msg1 = f"🔬 {symbol} — Deep Analysis (Full LLM)\n\n"
+            msg2 = ""
+            msg3 = ""
+
+            # Parse sections from the report
+            for i, part in enumerate(parts):
+                stripped = part.strip()
+                if stripped.startswith("LLM ANALYST REPORTS"):
+                    # Next section is the analyst reports
+                    if i + 1 < len(parts):
+                        msg1 += parts[i + 1].strip()[:3800]
+                elif stripped.startswith("BULL/BEAR DEBATE"):
+                    if i + 1 < len(parts):
+                        msg2 = f"🥊 Deep Debate\n\n{parts[i + 1].strip()[:3800]}"
+                elif stripped.startswith("FUND MANAGER SYNTHESIS"):
+                    if i + 1 < len(parts):
+                        msg3 = f"🧠 Deep Synthesis\n\n{parts[i + 1].strip()[:3800]}"
+
+            # Fallback: if parsing didn't split well, send as chunks
+            if not msg1 or msg1 == f"🔬 {symbol} — Deep Analysis (Full LLM)\n\n":
+                msg1 = full_report[:4000]
+                msg2 = full_report[4000:8000] if len(full_report) > 4000 else ""
+                msg3 = full_report[8000:12000] if len(full_report) > 8000 else ""
+
+            os.environ.pop("_CLI_BATCH_MODE", None)
+            return msg1, msg2, msg3
+
+        except Exception as e:
+            os.environ.pop("_CLI_BATCH_MODE", None)
+            import traceback
+            _log(f"FAILED: {e}\n{traceback.format_exc()}")
+            return f"Deep analysis failed: {e}", "", ""
+        finally:
+            _suppress_output.active = False
+
+    try:
+        loop = asyncio.get_event_loop()
+        result = await asyncio.wait_for(
+            loop.run_in_executor(None, _run_deep),
+            timeout=600,  # 10 minute timeout for deep analysis
+        )
+        msg1, msg2, msg3 = result if isinstance(result, tuple) and len(result) == 3 else (str(result), "", "")
+        if msg1:
+            await update.message.reply_text(msg1[:4000])
+        if msg2:
+            await update.message.reply_text(msg2[:4000])
+        if msg3:
+            await update.message.reply_text(msg3[:4000])
+        if not msg1:
+            await update.message.reply_text("Deep analysis completed but produced no output.")
+    except asyncio.TimeoutError:
+        await update.message.reply_text("⏱ Deep analysis timed out after 10 minutes.")
+    except Exception as e:
+        err = str(e)[:500]
+        await update.message.reply_text(f"Deep analysis failed: {err}")
 
 
 async def cmd_brief(update, context) -> None:
@@ -391,6 +657,199 @@ async def cmd_unknown(update, context) -> None:
     )
 
 
+# ── Token validation ─────────────────────────────────────────
+
+def validate_token(token: str) -> tuple[bool, str]:
+    """
+    Validate a bot token by calling the Telegram getMe API.
+
+    Returns:
+        (True,  "@username (Bot Name)")  on success
+        (False, "error description")     on failure
+    """
+    try:
+        import httpx
+        resp = httpx.get(
+            f"https://api.telegram.org/bot{token}/getMe",
+            timeout=10,
+        )
+        data = resp.json()
+        if data.get("ok"):
+            info = data["result"]
+            return True, f"@{info.get('username', '?')} ({info.get('first_name', '?')})"
+        return False, data.get("description", "Unknown error from Telegram API")
+    except Exception as e:
+        return False, f"Could not reach Telegram: {e}"
+
+
+def send_test_push(chat_id: Optional[int] = None, token: Optional[str] = None) -> bool:
+    """
+    Send a test message to verify the full setup is working.
+    Uses the provided chat_id/token or falls back to stored values.
+    Returns True if the message was delivered successfully.
+    """
+    cid = chat_id or _load_chat_id()
+    if not cid:
+        return False
+    try:
+        tok = token or _get_bot_token()
+    except Exception:
+        return False
+    try:
+        import httpx
+        resp = httpx.post(
+            f"https://api.telegram.org/bot{tok}/sendMessage",
+            json={
+                "chat_id": cid,
+                "text": (
+                    "✅ India Trade CLI connected!\n\n"
+                    "You'll receive notifications here for:\n"
+                    "  • Price alert triggers\n"
+                    "  • Paper trade executions\n"
+                    "  • Strategy signals\n\n"
+                    "Try /help to see all available commands."
+                ),
+                "parse_mode": "HTML",
+            },
+            timeout=10,
+        )
+        return resp.json().get("ok", False)
+    except Exception:
+        return False
+
+
+def wait_for_start(timeout: int = 120) -> bool:
+    """
+    Wait (poll) until the user sends /start to the bot, which saves the chat ID.
+    The bot must already be running in the background before calling this.
+
+    Args:
+        timeout: Maximum seconds to wait (default 120).
+
+    Returns:
+        True if the chat ID was received within the timeout, False otherwise.
+    """
+    import time
+    for _ in range(timeout):
+        if _load_chat_id():
+            return True
+        time.sleep(1)
+    return False
+
+
+def run_setup_wizard() -> None:
+    """
+    Full end-to-end interactive Telegram setup wizard.
+
+    Flow:
+      Step 1 — Collect / confirm bot token
+      Step 2 — Validate token with Telegram API
+      Step 3 — Start bot, wait for user to send /start, send test message
+    """
+    from rich.console import Console
+    from rich.prompt import Prompt, Confirm
+
+    console = Console()
+
+    console.print("\n[bold cyan]━━━ Telegram Bot Setup ━━━[/bold cyan]")
+    console.print("[dim]Connects your bot for push notifications and Telegram commands.[/dim]\n")
+
+    # ── Step 1: Token ─────────────────────────────────────────
+    console.print("[bold]Step 1 of 3 — Bot Token[/bold]")
+
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    if not token:
+        try:
+            from config.credentials import _kr_get
+            token = _kr_get("TELEGRAM_BOT_TOKEN") or ""
+        except Exception:
+            pass
+
+    if token:
+        console.print("  [green]✓ Token found in keychain/env[/green]")
+    else:
+        console.print(
+            "\n  No token found. Here's how to create one:\n\n"
+            "    1. Open Telegram → search [bold cyan]@BotFather[/bold cyan]\n"
+            "    2. Send [cyan]/newbot[/cyan]\n"
+            "    3. Choose a name    e.g. [dim]My Trade Bot[/dim]\n"
+            "    4. Choose a username ending in [bold]bot[/bold]    e.g. [dim]mytrade_bot[/dim]\n"
+            "    5. Copy the token BotFather gives you\n"
+        )
+        token = Prompt.ask("  Paste your bot token", password=True).strip()
+        if not token:
+            console.print("[red]No token provided. Setup cancelled.[/red]")
+            return
+
+        try:
+            from config.credentials import _kr_set
+            if _kr_set("TELEGRAM_BOT_TOKEN", token):
+                os.environ["TELEGRAM_BOT_TOKEN"] = token
+                console.print("  [green]✓ Token saved to keychain[/green]")
+            else:
+                os.environ["TELEGRAM_BOT_TOKEN"] = token
+                console.print("  [yellow]⚠  Keychain unavailable — token active for this session only.[/yellow]")
+        except Exception:
+            os.environ["TELEGRAM_BOT_TOKEN"] = token
+
+    # ── Step 2: Validate ──────────────────────────────────────
+    console.print("\n[bold]Step 2 of 3 — Validate Token[/bold]")
+    console.print("  Checking with Telegram...")
+
+    ok, info = validate_token(token)
+    if not ok:
+        console.print(
+            f"  [red]✗ Token rejected: {info}[/red]\n"
+            "  [dim]Double-check the token from @BotFather and run [bold]telegram setup[/bold] again.[/dim]"
+        )
+        return
+
+    console.print(f"  [green]✓ Bot verified: {info}[/green]")
+
+    # ── Step 3: Connect chat ───────────────────────────────────
+    console.print("\n[bold]Step 3 of 3 — Connect Your Chat[/bold]")
+
+    existing = _load_chat_id()
+    if existing:
+        console.print(f"  [green]✓ Chat already connected (ID: {existing})[/green]")
+        console.print("  Sending test notification...")
+        if send_test_push(existing, token):
+            console.print("  [green]✓ Test message sent! Check your Telegram.[/green]")
+        else:
+            console.print("  [yellow]⚠  Message failed — check the bot isn't blocked.[/yellow]")
+    else:
+        bot_handle = info.split("(")[0].strip()  # e.g. "@mytrade_bot"
+        console.print(
+            f"\n  Open Telegram and send [bold]/start[/bold] to your bot [cyan]{bot_handle}[/cyan]\n"
+            "  Waiting up to 2 minutes...\n"
+        )
+
+        run_bot_background()
+
+        if wait_for_start(timeout=120):
+            chat_id = _load_chat_id()
+            console.print(f"  [green]✓ Connected! (Chat ID: {chat_id})[/green]")
+            console.print("  Sending test notification...")
+            if send_test_push(chat_id, token):
+                console.print("  [green]✓ Test message delivered. Check your Telegram.[/green]")
+            else:
+                console.print("  [yellow]⚠  Bot connected but test message failed — try /start again.[/yellow]")
+        else:
+            console.print(
+                "\n  [yellow]⏱  Timed out — didn't receive /start within 2 minutes.[/yellow]\n"
+                "  The bot is still running in the background.\n"
+                "  [dim]Send /start to your bot whenever you're ready.[/dim]"
+            )
+            return
+
+    console.print(
+        "\n[bold green]✓  Telegram setup complete![/bold green]\n"
+        "[dim]The bot will push alerts, paper trade signals, and strategy\n"
+        "notifications here automatically. Use [bold]telegram[/bold] in the\n"
+        "REPL to restart the bot in future sessions.[/dim]\n"
+    )
+
+
 # ── Push Notifications ───────────────────────────────────────
 
 def send_push(message: str) -> None:
@@ -446,7 +905,7 @@ def patch_alert_manager() -> None:
             push_alert(alert.describe())
 
         alert_manager._notify = _patched_notify
-        logger.info("Alert manager patched for Telegram push notifications")
+        logger.debug("Alert manager patched for Telegram push notifications")
     except Exception:
         pass
 
@@ -461,35 +920,86 @@ def run_bot() -> None:
 
     app = ApplicationBuilder().token(token).build()
 
-    # Register command handlers
-    app.add_handler(CommandHandler("start", cmd_start))
-    app.add_handler(CommandHandler("help", cmd_help))
-    app.add_handler(CommandHandler("quote", cmd_quote))
-    app.add_handler(CommandHandler("analyze", cmd_analyze))
-    app.add_handler(CommandHandler("brief", cmd_brief))
-    app.add_handler(CommandHandler("flows", cmd_flows))
-    app.add_handler(CommandHandler("earnings", cmd_earnings))
-    app.add_handler(CommandHandler("events", cmd_events))
-    app.add_handler(CommandHandler("macro", cmd_macro))
-    app.add_handler(CommandHandler("alert", cmd_alert))
-    app.add_handler(CommandHandler("alerts", cmd_alerts))
-    app.add_handler(CommandHandler("memory", cmd_memory))
-    app.add_handler(CommandHandler("pnl", cmd_pnl))
-    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, cmd_unknown))
+    # Register command handlers (wrapped with _track_command for REPL badge)
+    app.add_handler(CommandHandler("start", _track_command(cmd_start)))
+    app.add_handler(CommandHandler("help", _track_command(cmd_help)))
+    app.add_handler(CommandHandler("quote", _track_command(cmd_quote)))
+    app.add_handler(CommandHandler("analyze", _track_command(cmd_analyze)))
+    app.add_handler(CommandHandler("deepanalyze", _track_command(cmd_deepanalyze)))
+    app.add_handler(CommandHandler("brief", _track_command(cmd_brief)))
+    app.add_handler(CommandHandler("flows", _track_command(cmd_flows)))
+    app.add_handler(CommandHandler("earnings", _track_command(cmd_earnings)))
+    app.add_handler(CommandHandler("events", _track_command(cmd_events)))
+    app.add_handler(CommandHandler("macro", _track_command(cmd_macro)))
+    app.add_handler(CommandHandler("alert", _track_command(cmd_alert)))
+    app.add_handler(CommandHandler("alerts", _track_command(cmd_alerts)))
+    app.add_handler(CommandHandler("memory", _track_command(cmd_memory)))
+    app.add_handler(CommandHandler("pnl", _track_command(cmd_pnl)))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, _track_command(cmd_unknown)))
 
     # Patch alerts for push notifications
     patch_alert_manager()
 
-    logger.info("Telegram bot starting... (Ctrl+C to stop)")
-    print("\n  Telegram bot running. Send /start to your bot to begin.\n")
-    app.run_polling()
+    logger.debug("Telegram bot starting...")
+
+    # ── Silence ALL output from this thread ──────────────────────────────
+    # 1. Logging filter: blocks log records (httpx, websocket, LLM API, etc.)
+    _thread_filter = _BotThreadFilter()
+    for _handler in logging.root.handlers:
+        _handler.addFilter(_thread_filter)
+
+    # Also silence any logger that adds its own handlers (e.g. FyersDataSocket)
+    logging.getLogger("FyersDataSocket").setLevel(logging.CRITICAL)
+
+    # 2. Stdout wrapper: blocks plain print() calls from this thread.
+    import sys
+    if not isinstance(sys.stdout, _BotThreadFileWrapper):
+        sys.stdout = _BotThreadFileWrapper(sys.stdout)
+
+    # 3. Rich Console patch: Rich stores a direct reference to sys.stdout at
+    #    Console() creation time, so replacing sys.stdout is not enough.
+    #    Walk every live Console instance and wrap its _file attribute too.
+    try:
+        import gc
+        from rich.console import Console as _RichConsole
+        for _obj in gc.get_objects():
+            if isinstance(_obj, _RichConsole):
+                if _obj._file is not None and not getattr(_obj._file, "_bot_patched", False):
+                    _obj._file = _BotThreadFileWrapper(_obj._file)
+    except Exception:
+        pass
+
+    # run_polling() registers OS signal handlers which only work on the main
+    # thread. Use the lower-level async API instead — no signal handlers at all.
+    async def _run() -> None:
+        async with app:
+            await app.start()
+            await app.updater.start_polling()
+            # Keep running until the daemon thread is killed on process exit
+            while True:
+                await asyncio.sleep(3600)
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(_run())
+    except Exception:
+        pass
+    finally:
+        loop.close()
 
 
 def run_bot_background() -> threading.Thread:
-    """Start the bot in a background thread (non-blocking, for REPL integration)."""
-    t = threading.Thread(target=run_bot, daemon=True)
-    t.start()
-    return t
+    """Start the bot in a background thread (non-blocking, for REPL integration).
+    If the bot is already running, returns the existing thread without starting a new one.
+    """
+    global _bot_thread
+    if _bot_thread is not None and _bot_thread.is_alive():
+        logger.debug("Bot thread already running — skipping duplicate start.")
+        return _bot_thread
+    _bot_thread = threading.Thread(target=run_bot, daemon=True, name="telegram-bot")
+    _bot_thread.start()
+    return _bot_thread
 
 
 # ── CLI entry point ──────────────────────────────────────────

--- a/brokers/mock.py
+++ b/brokers/mock.py
@@ -24,6 +24,8 @@ class MockBrokerAPI(BrokerAPI):
     Good for testing the full login → REPL → command flow.
     """
 
+    _is_mock = True  # Used by market/history.py to skip mock broker for market data
+
     def __init__(self, passthrough_market_data: bool = False) -> None:
         self._authenticated = False
         self._orders: list[Order] = []

--- a/config/credentials.py
+++ b/config/credentials.py
@@ -67,6 +67,8 @@ KNOWN_CREDENTIALS: list[tuple[str, str, bool]] = [
     ("GOOGLE_CLOUD_PROJECT","Google Cloud Project ID",             False),
     # ── Data / News ───────────────────────────────────────────
     ("NEWSAPI_KEY",         "NewsAPI.org Key",                     True),
+    # ── Notifications ─────────────────────────────────────────
+    ("TELEGRAM_BOT_TOKEN",  "Telegram Bot Token",                  True),
 ]
 
 _KNOWN_KEYS = {k for k, _, _ in KNOWN_CREDENTIALS}
@@ -272,6 +274,7 @@ def run_setup_wizard(keys: Optional[list[str]] = None) -> None:
     _FYERS_KEYS     = {"FYERS_APP_ID", "FYERS_SECRET_KEY"}
     _AI_KEYS        = {"AI_PROVIDER", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
                        "OPENAI_SESSION_TOKEN", "GOOGLE_CLOUD_PROJECT"}
+    _TELEGRAM_KEYS  = {"TELEGRAM_BOT_TOKEN"}
 
     sections: dict[str, list] = {
         "Zerodha (Kite Connect)": [
@@ -295,6 +298,9 @@ def run_setup_wizard(keys: Optional[list[str]] = None) -> None:
         "Market Data": [
             (k, l, s) for k, l, s in targets if "NEWSAPI" in k
         ],
+        "Notifications (Telegram)": [
+            (k, l, s) for k, l, s in targets if k in _TELEGRAM_KEYS
+        ],
     }
 
     saved = 0
@@ -307,6 +313,13 @@ def run_setup_wizard(keys: Optional[list[str]] = None) -> None:
         # Special interactive flow for the AI Provider section
         if section == "AI Provider" and any(k == "AI_PROVIDER" for k, _, _ in items):
             _wizard_ai_provider(items)
+            saved += sum(1 for k, _, _ in items if _kr_get(k))
+            console.print()
+            continue
+
+        # Special interactive flow for Telegram
+        if section == "Notifications (Telegram)":
+            _wizard_telegram(items)
             saved += sum(1 for k, _, _ in items if _kr_get(k))
             console.print()
             continue
@@ -401,6 +414,56 @@ def _save_cred(key: str, value: str) -> None:
     if _kr_set(key, value):
         os.environ[key] = value
         console.print(f"  [green]✓ AI_PROVIDER → {value}[/green]")
+
+
+def _wizard_telegram(items: list[tuple[str, str, bool]]) -> None:
+    """
+    Guided Telegram bot token setup within the credentials wizard.
+    Collects and validates the token format, saves it, then tells
+    the user to run `telegram setup` in the REPL for end-to-end connection.
+    """
+    console.print(
+        "\n  Push notifications let the bot send you alerts, paper trade\n"
+        "  signals, and strategy triggers directly in Telegram.\n\n"
+        "  [bold]How to get a bot token:[/bold]\n"
+        "    1. Open Telegram → search [bold cyan]@BotFather[/bold cyan]\n"
+        "    2. Send [cyan]/newbot[/cyan]\n"
+        "    3. Choose a name   e.g. [dim]My Trade Bot[/dim]\n"
+        "    4. Choose a username ending in [bold]bot[/bold]   e.g. [dim]mytrade_bot[/dim]\n"
+        "    5. BotFather gives you a token like:\n"
+        "       [dim]123456789:ABCdefGhIJKlmNoPQRsTUVwxYZ[/dim]\n\n"
+        "  (Press Enter to skip)\n"
+    )
+
+    current = _kr_get("TELEGRAM_BOT_TOKEN") or os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    hint    = " [dim](already set — press Enter to keep)[/dim]" if current else ""
+    console.print(f"  Telegram Bot Token{hint}")
+    value = Prompt.ask("  Token", password=True, default="").strip()
+
+    if not value:
+        if current:
+            console.print("  [dim]Kept existing token.[/dim]")
+        else:
+            console.print("  [dim]Skipped. Run [bold]credentials setup[/bold] later to add.[/dim]")
+        return
+
+    # Basic format check: Telegram tokens look like  123456789:ABCdef...
+    if ":" not in value or len(value) < 20:
+        console.print("  [yellow]⚠  Token format looks unexpected. Expected: 123456789:ABCdef...[/yellow]")
+        if not Confirm.ask("  Save anyway?", default=False):
+            return
+
+    if _kr_set("TELEGRAM_BOT_TOKEN", value):
+        os.environ["TELEGRAM_BOT_TOKEN"] = value
+        console.print(
+            "  [green]✓ Token saved to keychain.[/green]\n"
+            "  [dim]Run [bold]telegram setup[/bold] in the REPL to connect and send a test message.[/dim]"
+        )
+    else:
+        console.print(
+            "  [yellow]⚠  Could not reach keychain.[/yellow]\n"
+            "  Add [bold]TELEGRAM_BOT_TOKEN=<your token>[/bold] to your .env file instead."
+        )
 
 
 def _prompt_and_save(key: str, label: str, *, secret: bool) -> None:

--- a/engine/backtest.py
+++ b/engine/backtest.py
@@ -160,8 +160,11 @@ class Strategy(ABC):
 
     name: str = "Base"
 
+    # Override this for multi-symbol strategies (e.g., pairs trading)
+    symbols: list[str] = []
+
     @abstractmethod
-    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series | pd.DataFrame:
         """
         Generate trading signals from OHLCV data.
 
@@ -170,7 +173,11 @@ class Strategy(ABC):
                 (indexed by date)
 
         Returns:
-            Series of signals: 1 = BUY, -1 = SELL, 0 = HOLD
+            - pd.Series of signals: 1 = BUY, -1 = SELL, 0 = HOLD
+              (single-symbol mode)
+            - pd.DataFrame with one column per symbol, each containing
+              1 (LONG), -1 (SHORT), 0 (FLAT)
+              (multi-symbol / pairs mode)
         """
 
 
@@ -326,10 +333,25 @@ class Backtester:
         self._df = df
         return df
 
-    def run(self, strategy: Strategy) -> BacktestResult:
-        """Execute the backtest and return results."""
+    def run(self, strategy: Strategy) -> BacktestResult | MultiBacktestResult:
+        """Execute the backtest and return results.
+
+        If the strategy returns a DataFrame of signals (multi-symbol),
+        automatically delegates to MultiBacktester.
+        """
         df = self._load_data()
         signals = strategy.generate_signals(df)
+
+        # Auto-detect multi-symbol strategies
+        if isinstance(signals, pd.DataFrame) and len(signals.columns) > 1:
+            symbols = list(signals.columns)
+            multi = MultiBacktester(
+                symbols=symbols,
+                exchange=self.exchange,
+                period=self.period,
+                capital=self.initial_capital,
+            )
+            return multi.run(strategy)
 
         trades: list[Trade] = []
         position = 0        # 0 = flat, 1 = long
@@ -463,6 +485,396 @@ class Backtester:
         )
 
 
+# ── Multi-Symbol (Pairs) Backtester ──────────────────────────
+
+@dataclass
+class TradeLeg:
+    """One leg of a multi-symbol trade."""
+    symbol:      str
+    direction:   str      # "LONG" or "SHORT"
+    entry_price: float
+    exit_price:  float
+    quantity:    int
+    pnl:         float
+    pnl_pct:     float
+
+
+@dataclass
+class PairTrade:
+    """A complete multi-symbol trade (entry + exit on all legs)."""
+    entry_date:      str
+    exit_date:       str
+    legs:            list[TradeLeg]
+    combined_pnl:    float
+    combined_pnl_pct: float
+    hold_days:       int
+
+
+@dataclass
+class MultiBacktestResult:
+    """Backtest result for multi-symbol strategies (pairs, hedged, etc.)."""
+    symbols:        list[str]
+    strategy_name:  str
+    period:         str
+    start_date:     str
+    end_date:       str
+
+    # Performance
+    total_return:   float       # %
+    cagr:           float       # %
+    sharpe_ratio:   float
+    max_drawdown:   float       # %
+
+    # Trade stats
+    total_trades:   int = 0
+    winning_trades: int = 0
+    losing_trades:  int = 0
+    win_rate:       float = 0.0
+    avg_win:        float = 0.0
+    avg_loss:       float = 0.0
+    profit_factor:  float = 0.0
+    avg_hold_days:  float = 0.0
+
+    trades:         list[PairTrade] = field(default_factory=list)
+    equity_curve:   list[float] = field(default_factory=list)
+
+    def print_summary(self) -> None:
+        """Display multi-symbol backtest results."""
+        ret_style = "green" if self.total_return >= 0 else "red"
+
+        lines = [
+            f"  Strategy       : [bold]{self.strategy_name}[/bold]",
+            f"  Symbols        : {', '.join(self.symbols)}",
+            f"  Period         : {self.start_date} → {self.end_date}",
+            "",
+            f"  [bold]Returns[/bold]",
+            f"  Total Return   : [{ret_style}]{self.total_return:+.2f}%[/{ret_style}]",
+            f"  CAGR           : [{ret_style}]{self.cagr:+.2f}%[/{ret_style}]",
+            "",
+            f"  [bold]Risk[/bold]",
+            f"  Sharpe Ratio   : {self.sharpe_ratio:.2f}",
+            f"  Max Drawdown   : [red]{self.max_drawdown:.2f}%[/red]",
+            "",
+            f"  [bold]Trades[/bold]",
+            f"  Total          : {self.total_trades}",
+            f"  Win Rate       : {self.win_rate:.1f}%",
+            f"  Avg Win        : [green]{self.avg_win:+.2f}%[/green]",
+            f"  Avg Loss       : [red]{self.avg_loss:+.2f}%[/red]",
+            f"  Profit Factor  : {self.profit_factor:.2f}",
+            f"  Avg Hold       : {self.avg_hold_days:.1f} days",
+        ]
+
+        console.print(Panel(
+            "\n".join(lines),
+            title=f"[bold cyan]Pairs Backtest: {self.strategy_name}[/bold cyan]",
+            border_style="cyan",
+        ))
+
+    def print_trades(self, n: int = 20) -> None:
+        """Show pair trades with all legs."""
+        trades = self.trades[-n:]
+        if not trades:
+            console.print("[dim]No trades executed.[/dim]")
+            return
+
+        for i, t in enumerate(trades, 1):
+            pnl_style = "green" if t.combined_pnl_pct >= 0 else "red"
+            console.print(
+                f"\n  [bold]Trade #{i}[/bold]: {t.entry_date} → {t.exit_date} "
+                f"({t.hold_days}d)  "
+                f"Combined P&L: [{pnl_style}]{t.combined_pnl_pct:+.2f}%[/{pnl_style}]"
+            )
+            for leg in t.legs:
+                leg_style = "green" if leg.pnl_pct >= 0 else "red"
+                dir_color = "green" if leg.direction == "LONG" else "red"
+                console.print(
+                    f"    [{dir_color}]{leg.direction:5s}[/{dir_color}] "
+                    f"{leg.symbol:12s}  "
+                    f"₹{leg.entry_price:>10,.1f} → ₹{leg.exit_price:>10,.1f}  "
+                    f"[{leg_style}]{leg.pnl_pct:+.2f}%[/{leg_style}]"
+                )
+        console.print()
+
+
+class MultiBacktester:
+    """
+    Backtest multi-symbol strategies (pairs, hedged, spread).
+
+    Loads OHLCV data for all symbols, aligns to common dates,
+    and tracks positions + P&L on all legs simultaneously.
+    """
+
+    def __init__(
+        self,
+        symbols: list[str],
+        exchange: str = "NSE",
+        period: str = "1y",
+        capital: float = 100000,
+    ) -> None:
+        self.symbols = [s.upper() for s in symbols]
+        self.exchange = exchange.upper()
+        self.period = period
+        self.initial_capital = capital
+        self._data: dict[str, pd.DataFrame] = {}
+
+    def _load_data(self) -> dict[str, pd.DataFrame]:
+        """Fetch and align OHLCV data for all symbols."""
+        if self._data:
+            return self._data
+
+        from market.history import get_ohlcv
+
+        period_days = {
+            "1mo": 30, "3mo": 90, "6mo": 180,
+            "1y": 365, "2y": 730, "3y": 1095, "5y": 1825,
+        }
+        days = period_days.get(self.period, 365)
+
+        raw = {}
+        for sym in self.symbols:
+            df = get_ohlcv(symbol=sym, exchange=self.exchange, interval="day", days=days)
+            if df.empty:
+                raise RuntimeError(f"No historical data for {sym}")
+            df = df.dropna(subset=["close"])
+            raw[sym] = df
+
+        # Align to common dates
+        common_idx = raw[self.symbols[0]].index
+        for sym in self.symbols[1:]:
+            common_idx = common_idx.intersection(raw[sym].index)
+
+        if len(common_idx) < 20:
+            raise RuntimeError(
+                f"Only {len(common_idx)} common trading days across {self.symbols}. "
+                "Need at least 20 for a meaningful backtest."
+            )
+
+        for sym in self.symbols:
+            raw[sym] = raw[sym].loc[common_idx]
+
+        self._data = raw
+        return raw
+
+    def run(self, strategy: Strategy) -> MultiBacktestResult:
+        """Execute the multi-symbol backtest."""
+        data = self._load_data()
+
+        # Build a combined DataFrame with multi-level columns for the strategy
+        # The strategy's generate_signals receives the primary symbol's df
+        # but can access other symbols' data internally.
+        # We pass the first symbol's df as the main input.
+        primary_df = data[self.symbols[0]]
+        signals = strategy.generate_signals(primary_df)
+
+        # Handle both Series and DataFrame returns
+        if isinstance(signals, pd.Series):
+            # Single-symbol signal applied to first symbol only
+            sig_df = pd.DataFrame({self.symbols[0]: signals})
+            # Fill missing symbols with 0
+            for sym in self.symbols[1:]:
+                sig_df[sym] = 0
+        elif isinstance(signals, pd.DataFrame):
+            sig_df = signals
+        else:
+            raise TypeError(f"generate_signals must return Series or DataFrame, got {type(signals)}")
+
+        # Align signals to common index
+        common_idx = primary_df.index
+        sig_df = sig_df.reindex(common_idx, fill_value=0)
+
+        # Simulation: track positions per symbol
+        positions: dict[str, int] = {s: 0 for s in self.symbols}  # 0=flat, 1=long, -1=short
+        entry_prices: dict[str, float] = {s: 0.0 for s in self.symbols}
+        entry_date = ""
+
+        capital = self.initial_capital
+        capital_per_leg = capital / max(len(self.symbols), 1)
+        equity = [capital]
+        trades: list[PairTrade] = []
+
+        for i in range(1, len(common_idx)):
+            date_str = str(common_idx[i])[:10]
+            prices = {sym: float(data[sym].iloc[i]["close"]) for sym in self.symbols}
+
+            # Read signals for this bar
+            bar_signals = {}
+            for sym in self.symbols:
+                if sym in sig_df.columns:
+                    bar_signals[sym] = int(sig_df[sym].iloc[i]) if i < len(sig_df) else 0
+                else:
+                    bar_signals[sym] = 0
+
+            # Check for entry: all symbols go from flat to non-zero
+            all_flat = all(positions[s] == 0 for s in self.symbols)
+            any_signal = any(bar_signals[s] != 0 for s in self.symbols)
+
+            if all_flat and any_signal:
+                # Enter positions
+                for sym in self.symbols:
+                    sig = bar_signals[sym]
+                    if sig != 0:
+                        positions[sym] = sig
+                        entry_prices[sym] = prices[sym]
+                entry_date = date_str
+
+            # Check for exit: any symbol signals to close (goes to 0 or flips)
+            any_position = any(positions[s] != 0 for s in self.symbols)
+            if any_position:
+                # Exit if any active symbol's signal returns to 0 or flips
+                should_exit = False
+                for sym in self.symbols:
+                    if positions[sym] != 0:
+                        new_sig = bar_signals[sym]
+                        if new_sig == 0 or (new_sig != 0 and new_sig != positions[sym]):
+                            should_exit = True
+                            break
+
+                if should_exit:
+                    # Close all positions
+                    legs = []
+                    total_pnl = 0.0
+                    for sym in self.symbols:
+                        if positions[sym] != 0:
+                            ep = entry_prices[sym]
+                            xp = prices[sym]
+                            direction = "LONG" if positions[sym] == 1 else "SHORT"
+
+                            if positions[sym] == 1:
+                                pnl_pct = (xp - ep) / ep * 100
+                            else:
+                                pnl_pct = (ep - xp) / ep * 100
+
+                            pnl = capital_per_leg * pnl_pct / 100
+                            total_pnl += pnl
+
+                            legs.append(TradeLeg(
+                                symbol=sym,
+                                direction=direction,
+                                entry_price=round(ep, 2),
+                                exit_price=round(xp, 2),
+                                quantity=max(1, int(capital_per_leg / ep)) if ep > 0 else 0,
+                                pnl=round(pnl, 2),
+                                pnl_pct=round(pnl_pct, 2),
+                            ))
+
+                    capital += total_pnl
+                    combined_pct = total_pnl / (capital_per_leg * len([l for l in legs])) * 100 if legs else 0
+
+                    try:
+                        entry_dt = pd.Timestamp(entry_date)
+                        exit_dt = pd.Timestamp(common_idx[i])
+                        if hasattr(entry_dt, 'tz') and entry_dt.tz:
+                            entry_dt = entry_dt.tz_localize(None)
+                        if hasattr(exit_dt, 'tz') and exit_dt.tz:
+                            exit_dt = exit_dt.tz_localize(None)
+                        hold_days = (exit_dt - entry_dt).days
+                    except Exception:
+                        hold_days = 0
+
+                    trades.append(PairTrade(
+                        entry_date=entry_date,
+                        exit_date=date_str,
+                        legs=legs,
+                        combined_pnl=round(total_pnl, 2),
+                        combined_pnl_pct=round(combined_pct, 2),
+                        hold_days=hold_days,
+                    ))
+
+                    # Reset
+                    for sym in self.symbols:
+                        positions[sym] = 0
+                        entry_prices[sym] = 0.0
+
+                    # Update capital per leg
+                    capital_per_leg = capital / max(len(self.symbols), 1)
+
+            # Update equity: mark-to-market open positions
+            unrealized = 0.0
+            for sym in self.symbols:
+                if positions[sym] != 0:
+                    ep = entry_prices[sym]
+                    cp = prices[sym]
+                    if positions[sym] == 1:
+                        unrealized += capital_per_leg * (cp - ep) / ep
+                    else:
+                        unrealized += capital_per_leg * (ep - cp) / ep
+            equity.append(capital + unrealized)
+
+        # Close any open positions at last bar
+        if any(positions[s] != 0 for s in self.symbols):
+            last_prices = {sym: float(data[sym].iloc[-1]["close"]) for sym in self.symbols}
+            legs = []
+            total_pnl = 0.0
+            for sym in self.symbols:
+                if positions[sym] != 0:
+                    ep = entry_prices[sym]
+                    xp = last_prices[sym]
+                    direction = "LONG" if positions[sym] == 1 else "SHORT"
+                    pnl_pct = ((xp - ep) / ep * 100) if positions[sym] == 1 else ((ep - xp) / ep * 100)
+                    pnl = capital_per_leg * pnl_pct / 100
+                    total_pnl += pnl
+                    legs.append(TradeLeg(sym, direction, round(ep, 2), round(xp, 2), 0, round(pnl, 2), round(pnl_pct, 2)))
+
+            capital += total_pnl
+            combined_pct = total_pnl / (capital_per_leg * len(legs)) * 100 if legs else 0
+            trades.append(PairTrade(
+                entry_date=entry_date,
+                exit_date=str(common_idx[-1])[:10],
+                legs=legs,
+                combined_pnl=round(total_pnl, 2),
+                combined_pnl_pct=round(combined_pct, 2),
+                hold_days=0,
+            ))
+
+        # ── Metrics ──────────────────────────────────────────
+        total_return = (capital - self.initial_capital) / self.initial_capital * 100
+        days_total = (common_idx[-1] - common_idx[0]).days
+        years = days_total / 365.25 if days_total > 0 else 1
+        cagr = ((capital / self.initial_capital) ** (1 / years) - 1) * 100 if years > 0 else 0
+
+        eq = pd.Series(equity)
+        daily_ret = eq.pct_change(fill_method=None).dropna()
+        sharpe = 0.0
+        if len(daily_ret) > 1 and daily_ret.std() > 0:
+            sharpe = (daily_ret.mean() / daily_ret.std()) * math.sqrt(252)
+
+        peak = eq.expanding().max()
+        dd = (eq - peak) / peak * 100
+        max_dd = float(dd.min())
+
+        winners = [t for t in trades if t.combined_pnl > 0]
+        losers = [t for t in trades if t.combined_pnl < 0]
+        win_rate = len(winners) / len(trades) * 100 if trades else 0
+        avg_win = sum(t.combined_pnl_pct for t in winners) / len(winners) if winners else 0
+        avg_loss = sum(t.combined_pnl_pct for t in losers) / len(losers) if losers else 0
+        gross_profit = sum(t.combined_pnl for t in winners)
+        gross_loss = abs(sum(t.combined_pnl for t in losers))
+        pf = gross_profit / gross_loss if gross_loss > 0 else float('inf')
+        avg_hold = sum(t.hold_days for t in trades) / len(trades) if trades else 0
+
+        return MultiBacktestResult(
+            symbols=self.symbols,
+            strategy_name=strategy.name,
+            period=self.period,
+            start_date=str(common_idx[0])[:10],
+            end_date=str(common_idx[-1])[:10],
+            total_return=round(total_return, 2),
+            cagr=round(cagr, 2),
+            sharpe_ratio=round(sharpe, 2),
+            max_drawdown=round(max_dd, 2),
+            total_trades=len(trades),
+            winning_trades=len(winners),
+            losing_trades=len(losers),
+            win_rate=round(win_rate, 1),
+            avg_win=round(avg_win, 2),
+            avg_loss=round(avg_loss, 2),
+            profit_factor=round(pf, 2),
+            avg_hold_days=round(avg_hold, 1),
+            trades=trades,
+            equity_curve=equity,
+        )
+
+
 def run_backtest(
     symbol: str,
     strategy_name: str = "rsi",
@@ -470,9 +882,30 @@ def run_backtest(
     period: str = "1y",
     capital: float = 100000,
 ) -> BacktestResult:
-    """Convenience function for running a named strategy."""
+    """Convenience function for running a named strategy.
+
+    If strategy_name starts with "user:", loads a user-saved strategy
+    from ~/.trading_platform/strategies/ via StrategyStore.
+    """
+    # User-saved strategies: "user:my_strategy"
+    if strategy_name.startswith("user:"):
+        from engine.strategy_builder import strategy_store
+        user_name = strategy_name[5:]
+        strategy = strategy_store.load_strategy(user_name)
+        bt = Backtester(symbol=symbol, period=period, capital=capital)
+        return bt.run(strategy)
+
     factory = STRATEGIES.get(strategy_name.lower())
     if not factory:
+        # Also check user strategies as fallback
+        try:
+            from engine.strategy_builder import strategy_store
+            strategy = strategy_store.load_strategy(strategy_name)
+            bt = Backtester(symbol=symbol, period=period, capital=capital)
+            return bt.run(strategy)
+        except Exception:
+            pass
+
         raise ValueError(
             f"Unknown strategy: {strategy_name}. "
             f"Available: {', '.join(STRATEGIES.keys())}"

--- a/engine/output.py
+++ b/engine/output.py
@@ -35,47 +35,22 @@ from rich.console import Console
 console = Console()
 
 PDF_OUTPUT_DIR = Path.home() / "Desktop"
+EXPORTS_DIR = Path.home() / ".trading_platform" / "exports"
 
 
 # ── PDF Export ───────────────────────────────────────────────
 
-def export_to_pdf(
-    content: str,
-    title: str = "India Trade CLI Report",
-    filename: Optional[str] = None,
-) -> str:
-    """
-    Export text content to a formatted PDF.
-
-    Args:
-        content: raw text/terminal output to export
-        title: PDF title
-        filename: optional filename (auto-generated if not provided)
-
-    Returns:
-        Path to the saved PDF file.
-    """
-    try:
-        from fpdf import FPDF
-    except ImportError:
-        console.print("[red]fpdf2 not installed. Run: pip install fpdf2[/red]")
-        return ""
+def _build_pdf(content: str, title: str) -> "FPDF":
+    """Build a FPDF object from content. Returns the FPDF instance."""
+    from fpdf import FPDF
 
     # Clean terminal formatting codes and non-ASCII characters
     clean = _strip_rich_markup(content)
-    clean = clean.replace("₹", "Rs.").replace("→", "->").replace("←", "<-")
-    clean = clean.replace("━", "-").replace("─", "-").replace("│", "|")
-    clean = clean.replace("╔", "+").replace("╗", "+").replace("╚", "+").replace("╝", "+")
+    clean = clean.replace("\u20b9", "Rs.").replace("\u2192", "->").replace("\u2190", "<-")
+    clean = clean.replace("\u2501", "-").replace("\u2500", "-").replace("\u2502", "|")
+    clean = clean.replace("\u2554", "+").replace("\u2557", "+").replace("\u255a", "+").replace("\u255d", "+")
     # Remove any remaining non-latin1 characters
     clean = clean.encode("latin-1", errors="replace").decode("latin-1")
-
-    # Generate filename
-    if not filename:
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        safe_title = re.sub(r'[^\w\-]', '_', title)[:30]
-        filename = f"trade_{safe_title}_{ts}.pdf"
-
-    filepath = PDF_OUTPUT_DIR / filename
 
     pdf = FPDF()
     pdf.set_auto_page_break(auto=True, margin=15)
@@ -106,8 +81,181 @@ def export_to_pdf(
     pdf.set_text_color(150, 150, 150)
     pdf.multi_cell(w, 4, "India Trade CLI | AI-Powered Multi-Agent Stock Analysis | github.com/ArchieIndian/india-trade-cli")
 
+    return pdf
+
+
+def _archive_filename(title: str) -> str:
+    """
+    Build a descriptive archive filename from the title.
+
+    Examples:
+        "Analysis RELIANCE"       -> "RELIANCE_analysis_2026-04-01_14-32-05.pdf"
+        "Deep Analysis TCS"       -> "TCS_deep_analysis_2026-04-01_09-15-00.pdf"
+        "Backtest INFY rsi"       -> "INFY_backtest_rsi_2026-04-01_11-00-42.pdf"
+        "AI Chat"                 -> "ai_chat_2026-04-01_16-22-10.pdf"
+    """
+    ts = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    parts = title.strip().split()
+
+    # Try to extract symbol and report type
+    symbol = ""
+    report_type = ""
+
+    if len(parts) >= 2:
+        # Check common patterns: "Analysis SYMBOL", "Deep Analysis SYMBOL", etc.
+        keyword_map = {
+            "analysis": "analysis",
+            "deep": "deep_analysis",
+            "backtest": "backtest",
+            "brief": "brief",
+            "ai": "ai_chat",
+            "risk": "risk_report",
+            "portfolio": "portfolio",
+        }
+        first_lower = parts[0].lower()
+        if first_lower in keyword_map:
+            report_type = keyword_map[first_lower]
+            # "Deep Analysis SYMBOL" -> symbol is last part
+            if first_lower == "deep" and len(parts) >= 3:
+                symbol = parts[2]
+                report_type = "deep_analysis"
+            else:
+                symbol = parts[1]
+                # Append remaining parts (e.g. "Backtest INFY rsi" -> "backtest_rsi")
+                if len(parts) > 2 and first_lower == "backtest":
+                    report_type = f"backtest_{'_'.join(parts[2:])}"
+        else:
+            # Symbol might be first: just use the whole title
+            symbol = parts[0]
+            report_type = "_".join(parts[1:]).lower()
+
+    if not report_type:
+        report_type = re.sub(r'[^\w]', '_', title.lower())[:30]
+
+    # Clean up
+    symbol = re.sub(r'[^\w]', '', symbol).upper()
+    report_type = re.sub(r'[^\w]', '_', report_type).lower()[:30]
+
+    if symbol:
+        return f"{symbol}_{report_type}_{ts}.pdf"
+    return f"{report_type}_{ts}.pdf"
+
+
+def export_to_pdf(
+    content: str,
+    title: str = "India Trade CLI Report",
+    filename: Optional[str] = None,
+) -> str:
+    """
+    Export text content to a formatted PDF.
+
+    Saves to ~/Desktop/ AND automatically archives a timestamped copy
+    to ~/.trading_platform/exports/.
+
+    Args:
+        content: raw text/terminal output to export
+        title: PDF title
+        filename: optional filename (auto-generated if not provided)
+
+    Returns:
+        Path to the saved PDF file (on Desktop).
+    """
+    try:
+        from fpdf import FPDF  # noqa: F401 — just check availability
+    except ImportError:
+        console.print("[red]fpdf2 not installed. Run: pip install fpdf2[/red]")
+        return ""
+
+    pdf = _build_pdf(content, title)
+
+    # Generate desktop filename
+    if not filename:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        safe_title = re.sub(r'[^\w\-]', '_', title)[:30]
+        filename = f"trade_{safe_title}_{ts}.pdf"
+
+    filepath = PDF_OUTPUT_DIR / filename
     pdf.output(str(filepath))
+
+    # ── Auto-archive a timestamped copy ──────────────────────
+    try:
+        EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        archive_name = _archive_filename(title)
+        archive_path = EXPORTS_DIR / archive_name
+        import shutil
+        shutil.copy2(str(filepath), str(archive_path))
+    except Exception:
+        pass  # archiving is best-effort, never fail the main export
+
     return str(filepath)
+
+
+# ── Exports management ──────────────────────────────────────
+
+def list_exports() -> list[dict]:
+    """
+    List all archived PDF exports.
+
+    Returns list of dicts with keys: name, path, size_kb, modified.
+    Sorted by modification time (newest first).
+    """
+    if not EXPORTS_DIR.exists():
+        return []
+
+    exports = []
+    for f in EXPORTS_DIR.glob("*.pdf"):
+        stat = f.stat()
+        exports.append({
+            "name": f.name,
+            "path": str(f),
+            "size_kb": stat.st_size / 1024,
+            "modified": datetime.fromtimestamp(stat.st_mtime),
+        })
+
+    exports.sort(key=lambda x: x["modified"], reverse=True)
+    return exports
+
+
+def open_export(filename: str) -> bool:
+    """Open an exported PDF with the system default viewer."""
+    import subprocess, platform
+
+    path = EXPORTS_DIR / filename
+    if not path.exists():
+        return False
+
+    system = platform.system()
+    try:
+        if system == "Darwin":
+            subprocess.Popen(["open", str(path)])
+        elif system == "Linux":
+            subprocess.Popen(["xdg-open", str(path)])
+        elif system == "Windows":
+            os.startfile(str(path))  # type: ignore[attr-defined]
+        return True
+    except Exception:
+        return False
+
+
+def clear_exports(older_than_days: int = 30) -> int:
+    """
+    Delete exports older than N days.
+
+    Returns number of files deleted.
+    """
+    if not EXPORTS_DIR.exists():
+        return 0
+
+    cutoff = datetime.now().timestamp() - (older_than_days * 86400)
+    deleted = 0
+    for f in EXPORTS_DIR.glob("*.pdf"):
+        if f.stat().st_mtime < cutoff:
+            try:
+                f.unlink()
+                deleted += 1
+            except Exception:
+                pass
+    return deleted
 
 
 # ── Simple Explainer ─────────────────────────────────────────
@@ -215,10 +363,10 @@ def parse_output_flags(args: list[str]) -> tuple[list[str], bool, bool, bool]:
         (clean_args, wants_pdf, wants_explain, wants_explain_save)
     """
     wants_explain_save = "--explain-save" in args
-    wants_pdf = "--pdf" in args or wants_explain_save
+    wants_pdf = "--pdf" in args or "--save-pdf" in args or wants_explain_save
     wants_explain = "--explain" in args or wants_explain_save
 
-    clean = [a for a in args if a not in ("--pdf", "--explain", "--explain-save")]
+    clean = [a for a in args if a not in ("--pdf", "--save-pdf", "--explain", "--explain-save")]
     return clean, wants_pdf, wants_explain, wants_explain_save
 
 
@@ -257,6 +405,9 @@ def handle_output_flags(
         filepath = export_to_pdf(output, title=title)
         if filepath:
             console.print(f"\n[green]PDF saved:[/green] {filepath}")
+            # Show archive path
+            archive_name = _archive_filename(title)
+            console.print(f"[dim]Archived:[/dim] ~/.trading_platform/exports/{archive_name}")
 
 
 # ── Helpers ──────────────────────────────────────────────────

--- a/engine/strategy_builder.py
+++ b/engine/strategy_builder.py
@@ -1,0 +1,567 @@
+"""
+engine/strategy_builder.py
+──────────────────────────
+Interactive strategy builder — describe a strategy in plain English,
+the AI asks questions, generates code, backtests, and saves.
+
+Components:
+  StrategyStore          — persistence for user strategies
+  validate_strategy_code — AST-based safety + correctness checks
+  find_similar_strategies — match user description to existing strategies
+  build_and_test         — validate + load + backtest in one call
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import re
+import sys
+import tempfile
+import textwrap
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+
+console = Console()
+
+STRATEGIES_DIR = Path.home() / ".trading_platform" / "strategies"
+
+# Modules that user-generated strategy code is allowed to import
+IMPORT_WHITELIST = {
+    "pandas", "pd",
+    "numpy", "np",
+    "math",
+    "analysis.technical", "analysis",
+    "engine.backtest", "engine",
+    "market.history", "market",  # for pairs strategies fetching other symbols
+}
+
+# Keywords for matching user descriptions to existing strategies
+STRATEGY_KEYWORDS = {
+    "rsi": ["rsi", "relative strength", "oversold", "overbought", "momentum"],
+    "ma": ["moving average", "ema", "sma", "crossover", "cross", "golden cross", "death cross", "trend"],
+    "ema": ["ema", "exponential moving average"],
+    "macd": ["macd", "signal line", "histogram", "convergence", "divergence"],
+    "bollinger": ["bollinger", "bb", "bands", "squeeze", "standard deviation", "mean reversion"],
+    "bb": ["bollinger", "bb"],
+}
+
+
+# ── Strategy Store ──────────────────────────────────────────
+
+class StrategyStore:
+    """Persistence layer for user-created strategies."""
+
+    def __init__(self, base_dir: Path = STRATEGIES_DIR):
+        self.base_dir = base_dir
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def list_strategies(self) -> list[dict]:
+        """List all saved strategies with metadata."""
+        strategies = []
+        for meta_file in sorted(self.base_dir.glob("*.json")):
+            try:
+                with open(meta_file) as f:
+                    meta = json.load(f)
+                meta["has_code"] = (self.base_dir / f"{meta_file.stem}.py").exists()
+                strategies.append(meta)
+            except Exception:
+                pass
+        return strategies
+
+    def load_strategy(self, name: str):
+        """Dynamically import a saved strategy and return an instance."""
+        py_file = self.base_dir / f"{name}.py"
+        if not py_file.exists():
+            raise FileNotFoundError(f"Strategy '{name}' not found at {py_file}")
+
+        spec = importlib.util.spec_from_file_location(f"user_strategy_{name}", str(py_file))
+        module = importlib.util.module_from_spec(spec)
+
+        # Provide access to the backtest module
+        sys.modules[f"user_strategy_{name}"] = module
+        spec.loader.exec_module(module)
+
+        # Find the Strategy subclass in the module
+        from engine.backtest import Strategy
+        for attr_name in dir(module):
+            obj = getattr(module, attr_name)
+            if (isinstance(obj, type) and issubclass(obj, Strategy)
+                    and obj is not Strategy):
+                # Load parameters from metadata if available
+                meta = self.get_metadata(name)
+                params = meta.get("parameters", {}) if meta else {}
+                try:
+                    return obj(**params)
+                except TypeError:
+                    return obj()
+
+        raise RuntimeError(f"No Strategy subclass found in {py_file}")
+
+    def get_metadata(self, name: str) -> Optional[dict]:
+        """Load metadata JSON for a strategy."""
+        meta_file = self.base_dir / f"{name}.json"
+        if not meta_file.exists():
+            return None
+        try:
+            with open(meta_file) as f:
+                return json.load(f)
+        except Exception:
+            return None
+
+    def save_strategy(self, name: str, code: str, metadata: dict) -> Path:
+        """Save strategy code and metadata."""
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+        py_file = self.base_dir / f"{name}.py"
+        meta_file = self.base_dir / f"{name}.json"
+
+        py_file.write_text(code)
+
+        metadata.setdefault("name", name)
+        metadata.setdefault("created", datetime.now().isoformat())
+        with open(meta_file, "w") as f:
+            json.dump(metadata, f, indent=2, default=str)
+
+        return py_file
+
+    def update_metadata(self, name: str, updates: dict) -> None:
+        """Merge updates into existing metadata."""
+        meta = self.get_metadata(name) or {"name": name}
+        meta.update(updates)
+        meta_file = self.base_dir / f"{name}.json"
+        with open(meta_file, "w") as f:
+            json.dump(meta, f, indent=2, default=str)
+
+    def delete_strategy(self, name: str) -> bool:
+        """Delete strategy files. Returns True if something was deleted."""
+        deleted = False
+        for ext in (".py", ".json"):
+            path = self.base_dir / f"{name}{ext}"
+            if path.exists():
+                path.unlink()
+                deleted = True
+        return deleted
+
+    def get_code(self, name: str) -> Optional[str]:
+        """Return the raw Python code for a strategy."""
+        py_file = self.base_dir / f"{name}.py"
+        if py_file.exists():
+            return py_file.read_text()
+        return None
+
+
+# Singleton
+strategy_store = StrategyStore()
+
+
+# ── Code Validation ─────────────────────────────────────────
+
+def validate_strategy_code(code: str) -> tuple[bool, str]:
+    """
+    Validate LLM-generated strategy code for safety and correctness.
+
+    Checks:
+      1. Valid Python syntax (ast.parse)
+      2. Contains a class subclassing Strategy with generate_signals method
+      3. Only imports from whitelisted modules
+      4. Smoke test: generate_signals on dummy data returns correct shape
+
+    Returns:
+        (True, "") on success, (False, "error description") on failure.
+    """
+    # 1. Syntax check
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as e:
+        return False, f"Syntax error on line {e.lineno}: {e.msg}"
+
+    # 2. Find Strategy subclass with generate_signals
+    found_class = False
+    found_method = False
+    class_name = None
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            # Check if it has a base that looks like Strategy
+            for base in node.bases:
+                base_name = ""
+                if isinstance(base, ast.Name):
+                    base_name = base.id
+                elif isinstance(base, ast.Attribute):
+                    base_name = base.attr
+                if base_name == "Strategy":
+                    found_class = True
+                    class_name = node.name
+                    # Check for generate_signals method
+                    for item in node.body:
+                        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            if item.name == "generate_signals":
+                                found_method = True
+
+    if not found_class:
+        return False, "No class subclassing Strategy found. Must have: class MyStrategy(Strategy):"
+    if not found_method:
+        return False, f"Class {class_name} is missing the generate_signals(self, df) method."
+
+    # 3. Import whitelist check
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split(".")[0]
+                if root not in IMPORT_WHITELIST:
+                    return False, f"Forbidden import: '{alias.name}'. Only allowed: pandas, numpy, math, analysis.technical, engine.backtest"
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                root = node.module.split(".")[0]
+                if root not in IMPORT_WHITELIST:
+                    return False, f"Forbidden import: 'from {node.module}'. Only allowed: pandas, numpy, math, analysis.technical, engine.backtest"
+
+    # 4. Smoke test — execute on dummy data
+    try:
+        # Build a restricted namespace
+        namespace = {
+            "pd": pd,
+            "np": np,
+            "pandas": pd,
+            "numpy": np,
+            "math": __import__("math"),
+        }
+
+        # Import Strategy base class
+        from engine.backtest import Strategy
+        namespace["Strategy"] = Strategy
+
+        # Make analysis.technical available
+        try:
+            import analysis.technical as _tech
+            namespace["analysis"] = type(sys)("analysis")
+            namespace["analysis"].technical = _tech
+        except ImportError:
+            pass
+
+        exec(code, namespace)
+
+        # Find and instantiate the strategy class
+        strategy_cls = None
+        for v in namespace.values():
+            if isinstance(v, type) and issubclass(v, Strategy) and v is not Strategy:
+                strategy_cls = v
+                break
+
+        if not strategy_cls:
+            return False, "Could not instantiate the Strategy class after execution."
+
+        try:
+            strategy = strategy_cls()
+        except TypeError:
+            # Might need parameters — try with no args
+            return False, f"Could not instantiate {strategy_cls.__name__}() — check __init__ default arguments."
+
+        # Create dummy OHLCV data
+        dates = pd.date_range("2024-01-01", periods=100, freq="B")
+        np.random.seed(42)
+        prices = 100 + np.cumsum(np.random.randn(100) * 2)
+        dummy_df = pd.DataFrame({
+            "open": prices + np.random.randn(100) * 0.5,
+            "high": prices + abs(np.random.randn(100)),
+            "low": prices - abs(np.random.randn(100)),
+            "close": prices,
+            "volume": np.random.randint(100000, 5000000, 100),
+        }, index=dates)
+
+        signals = strategy.generate_signals(dummy_df)
+
+        # Accept both Series (single-symbol) and DataFrame (multi-symbol/pairs)
+        if isinstance(signals, pd.DataFrame):
+            # Multi-symbol: validate each column
+            if signals.empty:
+                return False, "generate_signals returned an empty DataFrame."
+            for col in signals.columns:
+                col_vals = set(signals[col].dropna().unique().astype(int))
+                invalid = col_vals - {-1, 0, 1}
+                if invalid:
+                    return False, f"Column '{col}' has invalid signal values: {invalid}. Must be -1, 0, or 1."
+            # Check at least one column has non-zero signals
+            has_any_signal = False
+            for col in signals.columns:
+                if (signals[col] != 0).any():
+                    has_any_signal = True
+                    break
+            if not has_any_signal:
+                return False, (
+                    "generate_signals DataFrame has all zeros — no trades would trigger. "
+                    "Use boolean indexing: signals.loc[condition, 'SYMBOL'] = 1"
+                )
+        elif isinstance(signals, pd.Series):
+            if len(signals) != len(dummy_df):
+                return False, f"generate_signals returned {len(signals)} signals for {len(dummy_df)} rows."
+
+            valid_values = {-1, 0, 1}
+            unique = set(signals.dropna().unique().astype(int))
+            invalid = unique - valid_values
+            if invalid:
+                return False, f"Signals must be -1, 0, or 1. Found: {invalid}"
+
+            # Check that signals are not all the same value (likely a bug)
+            if len(unique) <= 1:
+                return False, (
+                    f"generate_signals returned only {unique or '{0}'} — no buy/sell signals generated. "
+                    "The signal assignment is likely using `signals = 1` instead of `signals[mask] = 1`. "
+                    "Use boolean indexing: signals[buy_condition] = 1, signals[sell_condition] = -1."
+                )
+
+            # Check there is at least 1 buy and 1 sell signal
+            has_buy = (signals == 1).any()
+            has_sell = (signals == -1).any()
+            if not has_buy or not has_sell:
+                return False, (
+                    f"generate_signals produced {'no BUY signals' if not has_buy else 'no SELL signals'} "
+                    "on 100 rows of test data. The signal assignment may be wrong — "
+                    "use `signals[condition] = 1` (with boolean mask indexing), not `signals = 1`."
+                )
+        else:
+            return False, f"generate_signals must return pd.Series or pd.DataFrame, got {type(signals).__name__}"
+
+    except Exception as e:
+        return False, f"Runtime error during smoke test: {e}"
+
+    return True, ""
+
+
+# ── Similar Strategy Finder ─────────────────────────────────
+
+def find_similar_strategies(description: str) -> list[dict]:
+    """
+    Find strategies similar to a plain-English description.
+    Matches against built-in strategies and saved user strategies.
+    """
+    desc_lower = description.lower()
+    results = []
+
+    # Check built-in strategies
+    for name, keywords in STRATEGY_KEYWORDS.items():
+        score = sum(1 for kw in keywords if kw in desc_lower)
+        if score > 0:
+            results.append({
+                "name": name,
+                "type": "builtin",
+                "match_score": score,
+                "description": _builtin_description(name),
+            })
+
+    # Check saved user strategies
+    for meta in strategy_store.list_strategies():
+        user_desc = meta.get("description", "").lower()
+        # Simple word overlap
+        desc_words = set(desc_lower.split())
+        user_words = set(user_desc.split())
+        overlap = len(desc_words & user_words)
+        if overlap >= 2:
+            results.append({
+                "name": meta["name"],
+                "type": "saved",
+                "match_score": overlap,
+                "description": meta.get("description", ""),
+            })
+
+    results.sort(key=lambda x: x["match_score"], reverse=True)
+    return results[:5]
+
+
+def _builtin_description(name: str) -> str:
+    """Human-readable description for built-in strategies."""
+    descs = {
+        "rsi": "RSI overbought/oversold: Buy when RSI < 30 (oversold), sell when RSI > 70 (overbought). Mean reversion strategy.",
+        "ma": "EMA Crossover: Buy when fast EMA crosses above slow EMA, sell on cross below. Trend following.",
+        "ema": "Same as MA — EMA crossover trend following strategy.",
+        "macd": "MACD Signal: Buy when MACD histogram turns positive, sell when it turns negative. Momentum strategy.",
+        "bollinger": "Bollinger Bands: Buy at lower band (oversold), sell at upper band (overbought). Mean reversion.",
+        "bb": "Bollinger Bands: Buy at lower band, sell at upper band.",
+    }
+    return descs.get(name, "")
+
+
+# ── Build and Test ──────────────────────────────────────────
+
+def build_and_test(
+    code: str,
+    symbol: str = "RELIANCE",
+    period: str = "1y",
+    capital: float = 100000,
+) -> tuple:
+    """
+    Validate strategy code, load it, and run a backtest.
+
+    Returns:
+        (strategy_instance, backtest_result) on success.
+        Raises ValueError with error message on failure.
+    """
+    ok, error = validate_strategy_code(code)
+    if not ok:
+        raise ValueError(error)
+
+    # Write to a temp file and load
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        tmp_path = f.name
+
+    try:
+        spec = importlib.util.spec_from_file_location("_tmp_strategy", tmp_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        from engine.backtest import Strategy, Backtester
+        strategy = None
+        for attr_name in dir(module):
+            obj = getattr(module, attr_name)
+            if isinstance(obj, type) and issubclass(obj, Strategy) and obj is not Strategy:
+                try:
+                    strategy = obj()
+                except TypeError:
+                    strategy = obj()
+                break
+
+        if not strategy:
+            raise ValueError("No Strategy subclass found in generated code.")
+
+        bt = Backtester(symbol=symbol, period=period, capital=capital)
+        result = bt.run(strategy)
+        return strategy, result
+
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)
+
+
+# ── Extract Strategy from LLM Response ──────────────────────
+
+COMPLETION_MARKER = "%%%STRATEGY_COMPLETE%%%"
+
+
+def extract_strategy_payload(response: str) -> Optional[dict]:
+    """
+    Extract strategy code and metadata from an LLM response
+    containing the %%%STRATEGY_COMPLETE%%% marker.
+
+    Returns dict with keys: code, name, description, symbol, parameters
+    or None if marker not found.
+    """
+    if COMPLETION_MARKER not in response:
+        return None
+
+    # Find JSON after the marker
+    idx = response.index(COMPLETION_MARKER) + len(COMPLETION_MARKER)
+    rest = response[idx:].strip()
+
+    # Try to parse as JSON
+    try:
+        # Find JSON object boundaries
+        start = rest.index("{")
+        depth = 0
+        end = start
+        for i, ch in enumerate(rest[start:], start):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        payload = json.loads(rest[start:end])
+        return payload
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Fallback: try to extract code from markdown code block
+    code_match = re.search(r"```python\s*\n(.*?)```", rest, re.DOTALL)
+    if not code_match:
+        code_match = re.search(r"```\s*\n(.*?)```", rest, re.DOTALL)
+
+    if code_match:
+        return {
+            "code": code_match.group(1).strip(),
+            "name": "custom_strategy",
+            "description": "User-defined strategy",
+            "symbol": "RELIANCE",
+            "parameters": {},
+        }
+
+    # Last resort: check if the rest looks like Python code directly
+    if "class " in rest and "generate_signals" in rest:
+        # Extract up to the end of the class
+        lines = rest.split("\n")
+        code_lines = []
+        in_code = False
+        for line in lines:
+            if line.strip().startswith("from ") or line.strip().startswith("import ") or line.strip().startswith("class "):
+                in_code = True
+            if in_code:
+                code_lines.append(line)
+        if code_lines:
+            return {
+                "code": "\n".join(code_lines),
+                "name": "custom_strategy",
+                "description": "User-defined strategy",
+                "symbol": "RELIANCE",
+                "parameters": {},
+            }
+
+    return None
+
+
+# ── Display Helpers ─────────────────────────────────────────
+
+def print_strategy_list(strategies: list[dict]) -> None:
+    """Print a Rich table of saved strategies."""
+    if not strategies:
+        console.print("[dim]No saved strategies. Use [bold]strategy new[/bold] to create one.[/dim]")
+        return
+
+    table = Table(title="Saved Strategies", show_lines=False)
+    table.add_column("Name", style="cyan bold")
+    table.add_column("Description")
+    table.add_column("Return", justify="right")
+    table.add_column("Sharpe", justify="right")
+    table.add_column("Win Rate", justify="right")
+    table.add_column("Created", style="dim")
+
+    for s in strategies:
+        bt = s.get("last_backtest", {})
+        ret = f"{bt.get('total_return', 0):+.1f}%" if bt else "-"
+        sharpe = f"{bt.get('sharpe', 0):.2f}" if bt else "-"
+        wr = f"{bt.get('win_rate', 0):.0f}%" if bt else "-"
+        created = s.get("created", "")[:10]
+        table.add_row(
+            s.get("name", "?"),
+            s.get("description", "")[:50],
+            ret, sharpe, wr, created,
+        )
+
+    console.print(table)
+
+
+def print_strategy_code(name: str, code: str, metadata: Optional[dict] = None) -> None:
+    """Display strategy code with syntax highlighting."""
+    if metadata:
+        desc = metadata.get("description", "")
+        params = metadata.get("parameters", {})
+        console.print(f"\n[bold cyan]{name}[/bold cyan]")
+        if desc:
+            console.print(f"[dim]{desc}[/dim]")
+        if params:
+            console.print(f"[dim]Parameters: {params}[/dim]")
+        console.print()
+
+    syntax = Syntax(code, "python", theme="monokai", line_numbers=True)
+    console.print(Panel(syntax, title=f"Strategy: {name}", border_style="cyan"))

--- a/market/events.py
+++ b/market/events.py
@@ -120,15 +120,6 @@ NSE_CORP_CALENDAR_URL = (
     "https://www.nseindia.com/api/event-calendar"
 )
 
-MOCK_EARNINGS: list[dict] = [
-    {"symbol": "HDFCBANK",  "company": "HDFC Bank",          "date": "", "purpose": "Q4 Results"},
-    {"symbol": "TCS",       "company": "TCS",                 "date": "", "purpose": "Q4 Results"},
-    {"symbol": "INFY",      "company": "Infosys",             "date": "", "purpose": "Q4 Results"},
-    {"symbol": "RELIANCE",  "company": "Reliance Industries", "date": "", "purpose": "Q4 Results"},
-    {"symbol": "ICICIBANK", "company": "ICICI Bank",          "date": "", "purpose": "Q4 Results"},
-]
-
-
 def get_earnings_calendar(
     symbols: Optional[list[str]] = None,
     days:    int = 14,
@@ -175,36 +166,17 @@ def get_earnings_calendar(
         return sorted(events, key=lambda e: e.date)
 
     except Exception:
-        # Return mock upcoming earnings with approximate dates
-        today = date.today()
-        result = []
-        for i, e in enumerate(MOCK_EARNINGS):
-            ev_date = today + timedelta(days=7 + i * 3)
-            if not symbols or e["symbol"] in [s.upper() for s in symbols]:
-                result.append(EarningsEvent(
-                    symbol  = e["symbol"],
-                    company = e["company"],
-                    date    = ev_date.isoformat(),
-                    purpose = e["purpose"],
-                ))
-        return result
+        return []  # No mock data — return empty when NSE API fails
 
 
 # ── RBI Calendar ─────────────────────────────────────────────
 
 RBI_RSS = "https://rbi.org.in/scripts/RSSFeedMonetary.aspx"
 
-MOCK_RBI_EVENTS = [
-    {"date": "2024-04-05", "event": "RBI Monetary Policy Committee — Rate Decision",  "rate": 6.50},
-    {"date": "2024-06-07", "event": "RBI Monetary Policy Committee — Rate Decision",  "rate": None},
-    {"date": "2024-08-08", "event": "RBI Monetary Policy Committee — Rate Decision",  "rate": None},
-]
-
-
 def get_rbi_calendar() -> list[RBIEvent]:
     """
     RBI Monetary Policy Committee upcoming dates.
-    Tries RBI RSS feed; falls back to hardcoded schedule.
+    Fetches from RBI RSS feed. Returns empty list if unavailable.
     """
     try:
         feed  = feedparser.parse(RBI_RSS)
@@ -223,18 +195,7 @@ def get_rbi_calendar() -> list[RBIEvent]:
     except Exception:
         pass
 
-    # Fallback: MPC meets roughly every 2 months
-    today = date.today()
-    events = []
-    for e in MOCK_RBI_EVENTS:
-        rate_date = datetime.strptime(e["date"], "%Y-%m-%d").date()
-        if rate_date >= today:
-            events.append(RBIEvent(
-                date  = e["date"],
-                event = e["event"],
-                rate  = e.get("rate"),
-            ))
-    return events
+    return []  # No mock data — return empty when RBI RSS fails
 
 
 # ── Corporate Actions ─────────────────────────────────────────

--- a/market/history.py
+++ b/market/history.py
@@ -62,27 +62,28 @@ def get_ohlcv(
     # Normalize interval alias
     kite_interval = INTERVAL_MAP.get(interval, interval)
 
-    # Use the unified broker interface; fall back to yfinance (real data)
-    # if the broker doesn't support historical data or isn't logged in,
-    # then mock as last resort.
+    # Data cascade: broker API → yfinance. No mock/synthetic data.
     raw = None
     try:
         from brokers.session import get_broker
         broker = get_broker()
-        raw = broker.get_historical_data(
-            symbol    = symbol,
-            exchange  = exchange,
-            interval  = kite_interval,
-            from_date = from_date,
-            to_date   = to_date,
-        )
+        # Only use broker for real data — skip if it's the mock broker
+        if not getattr(broker, '_is_mock', False):
+            raw = broker.get_historical_data(
+                symbol    = symbol,
+                exchange  = exchange,
+                interval  = kite_interval,
+                from_date = from_date,
+                to_date   = to_date,
+            )
+        else:
+            # Mock broker: still use yfinance for real market data
+            raw = _yfinance_fallback(symbol, exchange, kite_interval, from_date, to_date)
     except Exception:
         pass
 
     if not raw:
         raw = _yfinance_fallback(symbol, exchange, kite_interval, from_date, to_date)
-    if not raw:
-        raw = _mock_ohlcv(symbol, from_date, to_date)
 
     if not raw:
         return pd.DataFrame(columns=["date", "open", "high", "low", "close", "volume"])

--- a/market/sentiment.py
+++ b/market/sentiment.py
@@ -39,7 +39,9 @@ NSE_FIIDII_URL = "https://www.nseindia.com/api/fiidiiTradeReact"
 def get_fii_dii_data(days: int = 5) -> list[FIIDIIData]:
     """
     FII / DII buy-sell activity from NSE (last N trading days).
-    Falls back to mock data if NSE API is unavailable.
+
+    NSE API returns a flat list with separate entries for FII and DII
+    per date. We group them into one record per date.
     """
     try:
         headers = {
@@ -53,53 +55,53 @@ def get_fii_dii_data(days: int = 5) -> list[FIIDIIData]:
         r.raise_for_status()
         data = r.json()
 
+        if not isinstance(data, list):
+            return []
+
+        # Group by date — API returns separate FII and DII entries
+        by_date: dict[str, dict] = {}
+        for item in data:
+            dt = item.get("date", "")
+            category = item.get("category", "").upper()
+            buy_val = float(item.get("buyValue", 0))
+            sell_val = float(item.get("sellValue", 0))
+            net_val = float(item.get("netValue", 0))
+
+            if dt not in by_date:
+                by_date[dt] = {"fii_buy": 0, "fii_sell": 0, "fii_net": 0,
+                               "dii_buy": 0, "dii_sell": 0, "dii_net": 0}
+
+            if "FII" in category or "FPI" in category:
+                by_date[dt]["fii_buy"] = buy_val
+                by_date[dt]["fii_sell"] = sell_val
+                by_date[dt]["fii_net"] = net_val
+            elif "DII" in category:
+                by_date[dt]["dii_buy"] = buy_val
+                by_date[dt]["dii_sell"] = sell_val
+                by_date[dt]["dii_net"] = net_val
+
         result = []
-        for item in data[:days]:
-            fii_net = float(item.get("fiiNetBuySell", 0))
-            dii_net = float(item.get("diiNetBuySell", 0))
+        for dt, vals in list(by_date.items())[:days]:
+            fii_net = vals["fii_net"]
             verdict = (
                 "FII_BUYING"  if fii_net > 500 else
                 "FII_SELLING" if fii_net < -500 else
                 "NEUTRAL"
             )
             result.append(FIIDIIData(
-                date     = item.get("tradeDate", ""),
-                fii_buy  = float(item.get("fiiBuyValue",  0)),
-                fii_sell = float(item.get("fiiSellValue", 0)),
+                date     = dt,
+                fii_buy  = vals["fii_buy"],
+                fii_sell = vals["fii_sell"],
                 fii_net  = fii_net,
-                dii_buy  = float(item.get("diiBuyValue",  0)),
-                dii_sell = float(item.get("diiSellValue", 0)),
-                dii_net  = dii_net,
+                dii_buy  = vals["dii_buy"],
+                dii_sell = vals["dii_sell"],
+                dii_net  = vals["dii_net"],
                 verdict  = verdict,
             ))
         return result
 
     except Exception:
-        return _mock_fii_dii(days)
-
-
-def _mock_fii_dii(days: int = 5) -> list[FIIDIIData]:
-    """Synthetic FII/DII data for demo mode."""
-    import random
-    random.seed(42)
-    today    = date.today()
-    results  = []
-    from datetime import timedelta
-    for i in range(days):
-        day     = today - timedelta(days=i + 1)
-        fii_net = round(random.gauss(500, 2000), 2)
-        dii_net = round(random.gauss(-200, 1000), 2)
-        results.append(FIIDIIData(
-            date     = day.isoformat(),
-            fii_buy  = round(abs(fii_net) + random.uniform(5000, 15000), 2),
-            fii_sell = round(abs(fii_net) + random.uniform(4000, 14000), 2),
-            fii_net  = fii_net,
-            dii_buy  = round(abs(dii_net) + random.uniform(3000, 10000), 2),
-            dii_sell = round(abs(dii_net) + random.uniform(3000, 10000), 2),
-            dii_net  = dii_net,
-            verdict  = "FII_BUYING" if fii_net > 500 else "FII_SELLING" if fii_net < -500 else "NEUTRAL",
-        ))
-    return results
+        return []  # No fake data — return empty list when NSE API fails
 
 
 # ── News Sentiment ────────────────────────────────────────────
@@ -215,13 +217,8 @@ def get_market_breadth() -> MarketBreadth:
     except Exception:
         pass
 
-    # Mock: slightly bullish market
-    import random
-    random.seed(1)
-    adv  = random.randint(280, 380)
-    dec  = random.randint(120, 220)
-    unch = 500 - adv - dec
-    return _build_breadth(adv, dec, unch)
+    # No mock data — return zeros so consumers know data is unavailable
+    return MarketBreadth(advances=0, declines=0, unchanged=0, ad_ratio=0.0, verdict="UNAVAILABLE")
 
 
 def _build_breadth(adv: int, dec: int, unch: int) -> MarketBreadth:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,21 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "trading-platform"
+name = "india-trade-cli"
 version = "0.1.0"
-description = "Guided stock & options trading platform for Indian markets"
+description = "AI-powered multi-agent stock & options analysis platform for Indian markets"
 requires-python = ">=3.11"
 readme = "README.md"
+license = {text = "MIT"}
+keywords = ["trading", "stocks", "options", "nse", "bse", "india", "ai", "llm", "analysis"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Office/Business :: Financial :: Investment",
+]
 
 dependencies = [
     # ── Brokers ──────────────────────────────────────────────────────
@@ -56,7 +66,7 @@ trade = "app.main:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["brokers*", "market*", "analysis*", "agent*", "engine*", "ui*", "app*", "web*", "config*"]
+include = ["brokers*", "market*", "analysis*", "agent*", "engine*", "ui*", "app*", "web*", "config*", "bot*"]
 
 [tool.ruff]
 line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,6 @@ python-telegram-bot>=21.0    # Telegram bot (free, official API)
 # ── Utilities ────────────────────────────────────────────────
 python-dotenv>=1.0.0        # .env file loading
 keyring>=25.2.0             # Secure OS token storage
+pyotp>=2.9.0                # TOTP 2FA (Angel One auto-login)
 python-dateutil>=2.9.0      # Date parsing helpers
 pytz>=2024.1                # Timezone handling (IST)


### PR DESCRIPTION
## Summary

- **Ollama & OpenAI-compatible endpoints** (#54, #55): `provider ollama` works out of the box. Also supports Groq, Together AI, OpenRouter, LM Studio via `OPENAI_BASE_URL`
- **Strategy Builder** (#44, experimental): Describe a strategy in plain English, AI interviews you, generates Python code, backtests, saves. Supports pairs trading
- **Multi-symbol backtester** (#57): Tracks both legs of pairs trades with combined P&L
- **Data grounding**: Eliminated all mock/fake data. Fundamentals now from Screener.in then yfinance (ROE, ROCE, FCF, analyst consensus, quarterly results, promoter holding all computed from real financial statements)
- **Telegram bot**: /deepanalyze, REPL status badge, fixed output suppression
- **PDF exports**: Auto-archive with timestamps, exports command
- **Open-source prep**: MIT license, README rewrite, .gitignore hardening

## Issues Addressed

- Closes #23 — Telegram bot setup
- Closes #53 — Timestamped PDF exports
- Addresses #44 — Strategy builder (experimental)
- Addresses #54 — Ollama support
- Addresses #55 — OpenAI-compatible endpoints
- Addresses #57 — Multi-symbol backtester

## Test plan

- [x] provider ollama with local Ollama instance running
- [x] provider openai with OPENAI_BASE_URL set to Groq/Together
- [x] analyze RELIANCE shows real fundamentals (ROE, ROCE, analyst targets, not zeros)
- [x] deep-analyze RELIANCE scorecard shows actual scores (not all zeros)
- [x] strategy new creates and backtests a strategy
- [x] strategy list / strategy show / strategy delete work
- [x] exports lists archived PDFs
- [x] telegram setup + /analyze from Telegram delivers results
- [x] quit exits immediately (single press)
