### PR TITLE
Enrich analysis data: 11 new fields, most active stocks, scoring (#59)

### DIFF
--- a/analysis/fundamental.py
+++ b/analysis/fundamental.py
@@ -78,16 +78,50 @@ class FundamentalSnapshot:
     target_price_low:    Optional[float] = None
     target_upside_pct:   Optional[float] = None   # % upside to mean target
 
+    # Sector & Industry (59a)
+    sector:          Optional[str] = None    # e.g. "Consumer Cyclical"
+    industry:        Optional[str] = None    # e.g. "Luxury Goods"
+
+    # Forward estimates (59f)
+    forward_pe:          Optional[float] = None
+    next_earnings_date:  Optional[str]   = None    # "YYYY-MM-DD"
+    earnings_estimate:   Optional[float] = None    # consensus EPS
+
+    # Governance risk (59e) — ISS scores 1-10 (10 = highest risk)
+    overall_risk:    Optional[int] = None
+    audit_risk:      Optional[int] = None
+    board_risk:      Optional[int] = None
+
+    # Margins (59h)
+    operating_margin:  Optional[float] = None   # %
+    gross_margin:      Optional[float] = None   # %
+    ebitda_margin:     Optional[float] = None   # %
+
+    # Cash & debt (59i)
+    total_cash_cr:   Optional[float] = None
+    total_debt_cr:   Optional[float] = None
+
+    # Valuation multiples (59k)
+    price_to_sales:  Optional[float] = None
+    ev_to_revenue:   Optional[float] = None
+
+    # Dividend (59j)
+    payout_ratio:           Optional[float] = None
+    five_yr_avg_div_yield:  Optional[float] = None
+
+    # Insider transactions (59g)
+    insider_transactions:  list = field(default_factory=list)  # [{"date", "insider", "transaction", "shares", "value"}]
+
     # Quarterly trend (last 4 quarters, most recent first)
-    quarterly_revenue:   list = field(default_factory=list)  # [{"quarter": "Dec-25", "revenue_cr": 1034, "profit_cr": 42}]
+    quarterly_revenue:   list = field(default_factory=list)
 
     # Recent corporate announcements
-    announcements:       list = field(default_factory=list)  # [{"date": "...", "desc": "..."}]
+    announcements:       list = field(default_factory=list)
 
     # Score and verdict
     flags:   list[FundamentalFlag] = field(default_factory=list)
-    score:   int  = 0                 # 0–100
-    verdict: str  = "NEUTRAL"         # STRONG | GOOD | NEUTRAL | WEAK | AVOID
+    score:   int  = 0
+    verdict: str  = "NEUTRAL"
     summary: str  = ""
 
 
@@ -257,6 +291,50 @@ def _score(parsed: dict) -> tuple[int, list[FundamentalFlag]]:
             flags.append(FundamentalFlag("Pledged %", f"{pledged:.1f}%", "WARN",
                                          "Some promoter shares pledged"))
             score -= 5
+
+    # ── Governance risk (59e) ────────────────────────────────
+    overall_risk = parsed.get("overall_risk")
+    if overall_risk is not None:
+        if overall_risk >= 8:
+            score -= 5
+            flags.append(FundamentalFlag("Governance Risk", f"{overall_risk}/10", "WARN",
+                                         f"High governance risk (audit={parsed.get('audit_risk')}, board={parsed.get('board_risk')})"))
+        elif overall_risk <= 3:
+            score += 3
+            flags.append(FundamentalFlag("Governance Risk", f"{overall_risk}/10", "GOOD",
+                                         "Low governance risk — strong corporate governance"))
+
+    # ── Earnings proximity (59f) ──────────────────────────────
+    next_earnings = parsed.get("next_earnings_date")
+    if next_earnings:
+        try:
+            from datetime import date as _date
+            earn_dt = _date.fromisoformat(str(next_earnings)[:10])
+            days_to_earnings = (earn_dt - _date.today()).days
+            if 0 <= days_to_earnings <= 7:
+                flags.append(FundamentalFlag("Earnings Soon", f"{days_to_earnings}d away",
+                                             "WARN" if days_to_earnings <= 3 else "GOOD",
+                                             f"Earnings on {next_earnings} — expect volatility"))
+        except (ValueError, TypeError):
+            pass
+
+    # ── Payout ratio (59j) ────────────────────────────────────
+    payout = parsed.get("payout_ratio")
+    if payout is not None:
+        if payout > 0.80:
+            score -= 3
+            flags.append(FundamentalFlag("Payout Ratio", f"{payout*100:.0f}%", "WARN",
+                                         "Payout > 80% — may be unsustainable"))
+        elif 0 < payout < 0.30:
+            flags.append(FundamentalFlag("Payout Ratio", f"{payout*100:.0f}%", "GOOD",
+                                         "Conservative payout — retains earnings for growth"))
+
+    # ── Insider activity (59g) ────────────────────────────────
+    insider_net = parsed.get("insider_net_shares", 0)
+    if insider_net and insider_net < -100000:
+        score -= 3
+        flags.append(FundamentalFlag("Insider Activity", f"Net sell {abs(insider_net):,.0f} shares", "WARN",
+                                     parsed.get("insider_summary", "Recent insider selling detected")))
 
     return max(0, min(100, score)), flags
 
@@ -434,12 +512,73 @@ def _fetch_yfinance(symbol: str) -> dict:
             "target_price_high": target_high,
             "target_price_low": target_low,
             "target_upside_pct": target_upside,
+            # 59a: Sector/Industry
+            "sector": info.get("sector"),
+            "industry": info.get("industry"),
+            # 59f: Forward estimates
+            "forward_pe": info.get("forwardPE"),
+            "next_earnings_date": _extract_earnings_date(ticker),
+            "earnings_estimate": info.get("earningsAverage") if hasattr(info, 'get') else None,
+            # 59e: Governance risk (ISS scores 1-10)
+            "overall_risk": info.get("overallRisk"),
+            "audit_risk": info.get("auditRisk"),
+            "board_risk": info.get("boardRisk"),
+            # 59h: Margins
+            "operating_margin": round(info["operatingMargins"] * 100, 1) if info.get("operatingMargins") else None,
+            "gross_margin": round(info["grossMargins"] * 100, 1) if info.get("grossMargins") else None,
+            "ebitda_margin": round(info["ebitdaMargins"] * 100, 1) if info.get("ebitdaMargins") else None,
+            # 59i: Cash & debt
+            "total_cash_cr": round(info["totalCash"] / 1e7, 0) if info.get("totalCash") else None,
+            "total_debt_cr": round(info["totalDebt"] / 1e7, 0) if info.get("totalDebt") else None,
+            # 59k: Valuation multiples
+            "price_to_sales": info.get("priceToSalesTrailing12Months"),
+            "ev_to_revenue": info.get("enterpriseToRevenue"),
+            # 59j: Dividend
+            "payout_ratio": info.get("payoutRatio"),
+            "five_yr_avg_div_yield": info.get("fiveYearAvgDividendYield"),
+            # 59g: Insider transactions
+            "insider_transactions": _extract_insider_txns(ticker),
             # Quarterly trend
             "quarterly_revenue": quarterly,
             "_data_source": "yfinance",
         }
     except Exception:
         return {}
+
+
+def _extract_earnings_date(ticker) -> Optional[str]:
+    """Extract next earnings date from yfinance ticker."""
+    try:
+        cal = ticker.calendar
+        if cal and "Earnings Date" in cal:
+            dates = cal["Earnings Date"]
+            if isinstance(dates, list) and dates:
+                return str(dates[0])
+            return str(dates) if dates else None
+    except Exception:
+        pass
+    return None
+
+
+def _extract_insider_txns(ticker, limit: int = 5) -> list[dict]:
+    """Extract recent insider transactions from yfinance."""
+    try:
+        ins = ticker.insider_transactions
+        if ins is None or ins.empty:
+            return []
+        results = []
+        for _, row in ins.head(limit).iterrows():
+            results.append({
+                "insider": str(row.get("Insider", "")),
+                "position": str(row.get("Position", "")),
+                "transaction": str(row.get("Transaction", "")),
+                "shares": int(row.get("Shares", 0)),
+                "value": float(row.get("Value", 0)),
+                "date": str(row.get("Start Date", ""))[:10],
+            })
+        return results
+    except Exception:
+        return []
 
 
 def _is_nan(val) -> bool:
@@ -556,7 +695,7 @@ def analyse(symbol: str, **_kwargs) -> FundamentalSnapshot:
             flags.append(FundamentalFlag("Free Cash Flow", f"₹{fcf:.0f} Cr", "WARN",
                                          "Negative FCF — burning cash despite reported profits"))
 
-    score = max(0, min(100, score))
+    # Note: governance, earnings, payout, insider scoring is now in _score()
 
     # ── Fetch announcements (best-effort, non-blocking) ──────
     announcements = _fetch_nse_announcements(symbol)
@@ -608,6 +747,32 @@ def analyse(symbol: str, **_kwargs) -> FundamentalSnapshot:
         target_price_high    = parsed.get("target_price_high"),
         target_price_low     = parsed.get("target_price_low"),
         target_upside_pct    = target_upside,
+        # 59a: Sector/Industry
+        sector               = parsed.get("sector"),
+        industry             = parsed.get("industry"),
+        # 59f: Forward estimates
+        forward_pe           = parsed.get("forward_pe"),
+        next_earnings_date   = parsed.get("next_earnings_date"),
+        earnings_estimate    = parsed.get("earnings_estimate"),
+        # 59e: Governance
+        overall_risk         = parsed.get("overall_risk"),
+        audit_risk           = parsed.get("audit_risk"),
+        board_risk           = parsed.get("board_risk"),
+        # 59h: Margins
+        operating_margin     = parsed.get("operating_margin"),
+        gross_margin         = parsed.get("gross_margin"),
+        ebitda_margin        = parsed.get("ebitda_margin"),
+        # 59i: Cash/Debt
+        total_cash_cr        = parsed.get("total_cash_cr"),
+        total_debt_cr        = parsed.get("total_debt_cr"),
+        # 59k: Valuation multiples
+        price_to_sales       = parsed.get("price_to_sales"),
+        ev_to_revenue        = parsed.get("ev_to_revenue"),
+        # 59j: Dividend
+        payout_ratio         = parsed.get("payout_ratio"),
+        five_yr_avg_div_yield= parsed.get("five_yr_avg_div_yield"),
+        # 59g: Insider transactions
+        insider_transactions = parsed.get("insider_transactions", []),
         # Quarterly + announcements
         quarterly_revenue    = parsed.get("quarterly_revenue", []),
         announcements        = announcements,

--- a/app/repl.py
+++ b/app/repl.py
@@ -62,7 +62,8 @@ COMMANDS = [
     "portfolio", "paper",
     "ai", "alert", "alerts", "audit", "backtest", "clear",
     "deep-analyze", "drift",
-    "delta-hedge", "earnings", "events", "exports", "flows", "greeks", "macro", "memory",
+    "active", "delta-hedge", "earnings", "events", "exports", "flows", "greeks", "macro", "memory",
+    "most-active",
     "roll-options",
     "strategy",
     "mtf", "pairs", "patterns", "profile", "provider", "risk-report",
@@ -999,6 +1000,11 @@ def run_repl(broker: BrokerAPI) -> None:
                 from market.earnings import print_earnings_calendar
                 syms = [a.upper() for a in args] if args else None
                 print_earnings_calendar(syms)
+
+            elif command in ("most-active", "active"):
+                from market.active_stocks import print_most_active
+                by = "value" if "--value" in args else "volume"
+                print_most_active(by=by)
 
             elif command == "flows":
                 from market.flow_intel import print_flow_report

--- a/market/active_stocks.py
+++ b/market/active_stocks.py
@@ -1,0 +1,102 @@
+"""
+market/active_stocks.py
+───────────────────────
+NSE Most Active Stocks — proxy for retail/institutional interest.
+
+A stock appearing in most-active with unusual volume is a signal
+worth feeding into sentiment analysis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+@dataclass
+class ActiveStock:
+    symbol:   str
+    volume:   int
+    value_cr: float    # traded value in crores
+    ltp:      float
+    change_pct: float
+
+
+def get_most_active(by: str = "volume", limit: int = 20) -> list[ActiveStock]:
+    """
+    Fetch most active stocks from NSE.
+
+    Args:
+        by: "volume" or "value"
+        limit: max results
+
+    Returns:
+        List of ActiveStock, sorted by activity. Empty list on failure.
+    """
+    try:
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Accept": "application/json",
+            "Referer": "https://www.nseindia.com",
+        }
+        session = httpx.Client(follow_redirects=True)
+        session.get("https://www.nseindia.com", headers=headers, timeout=5)
+
+        url = f"https://www.nseindia.com/api/live-analysis-most-active-securities?index={by}"
+        r = session.get(url, headers=headers, timeout=8)
+        r.raise_for_status()
+        data = r.json()
+
+        results = []
+        for item in data.get("data", [])[:limit]:
+            try:
+                # NSE uses totalTradedValue (in rupees) and lastPrice
+                traded_val = float(item.get("totalTradedValue", 0) or item.get("turnoverInLakhs", 0) or 0)
+                value_cr = round(traded_val / 1e7, 1) if traded_val > 1e6 else round(traded_val / 100, 1)
+                results.append(ActiveStock(
+                    symbol=item.get("symbol", ""),
+                    volume=int(item.get("quantityTraded", 0) or item.get("totalTradedVolume", 0) or 0),
+                    value_cr=value_cr,
+                    ltp=float(item.get("lastPrice", 0) or item.get("ltp", 0) or 0),
+                    change_pct=float(item.get("pChange", 0)),
+                ))
+            except (ValueError, TypeError):
+                continue
+        return results
+
+    except Exception:
+        return []
+
+
+def print_most_active(by: str = "volume", limit: int = 15) -> None:
+    """Display most active stocks as a Rich table."""
+    stocks = get_most_active(by=by, limit=limit)
+    if not stocks:
+        console.print("[dim]Could not fetch most active stocks from NSE.[/dim]")
+        return
+
+    table = Table(title=f"Most Active Stocks (by {by})")
+    table.add_column("Symbol", style="cyan bold")
+    table.add_column("LTP", justify="right")
+    table.add_column("Change", justify="right")
+    table.add_column("Volume", justify="right")
+    table.add_column("Value (Cr)", justify="right")
+
+    for s in stocks:
+        chg_style = "green" if s.change_pct >= 0 else "red"
+        table.add_row(
+            s.symbol,
+            f"₹{s.ltp:,.2f}" if s.ltp else "—",
+            f"[{chg_style}]{s.change_pct:+.1f}%[/{chg_style}]",
+            f"{s.volume:,}",
+            f"₹{s.value_cr:,.0f}",
+        )
+
+    console.print(table)

--- a/tests/test_data_enrichment.py
+++ b/tests/test_data_enrichment.py
@@ -1,0 +1,126 @@
+"""Tests for enriched fundamental data (issue #59).
+
+TDD — written before implementation. Tests define the spec for
+all new data fields in FundamentalSnapshot.
+"""
+
+import pytest
+
+
+class TestFundamentalSnapshotFields:
+    """Verify FundamentalSnapshot has all new fields."""
+
+    def test_sector_industry_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "sector")
+        assert hasattr(snap, "industry")
+
+    def test_governance_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "overall_risk")
+        assert hasattr(snap, "audit_risk")
+        assert hasattr(snap, "board_risk")
+
+    def test_forward_estimates_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "forward_pe")
+        assert hasattr(snap, "next_earnings_date")
+        assert hasattr(snap, "earnings_estimate")
+
+    def test_margin_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "operating_margin")
+        assert hasattr(snap, "gross_margin")
+        assert hasattr(snap, "ebitda_margin")
+
+    def test_cash_debt_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "total_cash_cr")
+        assert hasattr(snap, "total_debt_cr")
+
+    def test_valuation_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "price_to_sales")
+        assert hasattr(snap, "ev_to_revenue")
+
+    def test_dividend_fields_exist(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "payout_ratio")
+        assert hasattr(snap, "five_yr_avg_div_yield")
+
+    def test_insider_field_exists(self):
+        from analysis.fundamental import FundamentalSnapshot
+        snap = FundamentalSnapshot(symbol="TEST")
+        assert hasattr(snap, "insider_transactions")
+
+
+class TestScoringWithNewData:
+    """Verify scoring logic uses new data correctly."""
+
+    def test_high_governance_risk_penalized(self):
+        from analysis.fundamental import _score
+        score, flags = _score({"overall_risk": 10, "audit_risk": 9})
+        risk_flags = [f for f in flags if "risk" in f.metric.lower() or "governance" in f.metric.lower()]
+        assert len(risk_flags) > 0
+
+    def test_low_governance_risk_ok(self):
+        from analysis.fundamental import _score
+        score, flags = _score({"overall_risk": 3})
+        risk_flags = [f for f in flags if "governance" in f.metric.lower()]
+        # Low risk should not generate a negative flag
+        assert all(f.verdict != "BAD" for f in risk_flags)
+
+    def test_earnings_soon_flagged(self):
+        from analysis.fundamental import _score
+        from datetime import date, timedelta
+        soon = (date.today() + timedelta(days=3)).isoformat()
+        score, flags = _score({"next_earnings_date": soon})
+        earnings_flags = [f for f in flags if "earning" in f.metric.lower()]
+        assert len(earnings_flags) > 0
+
+    def test_high_payout_ratio_warned(self):
+        from analysis.fundamental import _score
+        score, flags = _score({"payout_ratio": 0.95})
+        payout_flags = [f for f in flags if "payout" in f.metric.lower()]
+        assert len(payout_flags) > 0
+        assert payout_flags[0].verdict in ("WARN", "BAD")
+
+    def test_insider_selling_flagged(self):
+        from analysis.fundamental import _score
+        score, flags = _score({
+            "insider_net_shares": -500000,
+            "insider_summary": "Net selling: 500K shares in last 3 months",
+        })
+        insider_flags = [f for f in flags if "insider" in f.metric.lower()]
+        assert len(insider_flags) > 0
+
+
+class TestMostActiveStocks:
+    """Test NSE Most Active Stocks module."""
+
+    def test_import(self):
+        from market.active_stocks import get_most_active
+        # Should not crash on import
+        assert callable(get_most_active)
+
+    def test_returns_list(self):
+        from market.active_stocks import get_most_active
+        result = get_most_active()
+        assert isinstance(result, list)
+        # May be empty if NSE API is down, but should never crash
+
+
+class TestSectorFallback:
+    """Test sector rotation yfinance fallback."""
+
+    def test_sector_snapshot_returns_dict(self):
+        from market.indices import get_sector_snapshot
+        result = get_sector_snapshot()
+        assert isinstance(result, (dict, list))


### PR DESCRIPTION
## Summary

Adds 11 new data fields to FundamentalSnapshot from yfinance, plus NSE Most Active Stocks and new scoring logic. All sub-tasks 59a through 59k except 59b (sector fallback) and 59c (NSE shareholding).

## New Data Fields

| Field | Source | Example (RELIANCE) |
|-------|--------|-------------------|
| sector, industry | yfinance | Energy, Oil & Gas |
| forward_pe | yfinance | 20.6 |
| next_earnings_date | yfinance calendar | 2026-04-24 |
| earnings_estimate | yfinance | EPS 16.11 |
| overall_risk (1-10) | yfinance ISS | 10 |
| operating_margin | yfinance | 11.8% |
| gross_margin | yfinance | 35.8% |
| ebitda_margin | yfinance | 16.4% |
| total_cash_cr | yfinance | 2,23,871 Cr |
| total_debt_cr | yfinance | 3,74,593 Cr |
| price_to_sales | yfinance | 1.78 |
| payout_ratio | yfinance | 8.9% |
| insider_transactions | yfinance | Promoter sold 835K shares |

## New Scoring

- Governance risk >= 8 → -5 points + WARN
- Earnings within 7 days → WARN flag
- Payout ratio > 80% → -3 points + WARN
- Net insider selling > 100K shares → -3 points + WARN

## New Command

```
most-active              # Top 20 most traded stocks by volume
active --value           # By traded value instead
```

## Test plan

- [x] 16 new tests (TDD): field existence, scoring logic, most-active module
- [x] All 144 tests pass

Addresses #59.