### PR TITLE
DCF improvements: reverse DCF, FCF quality, bank P/BV, scenarios (#75)

### DIFF
--- a/agent/deep_agent.py
+++ b/agent/deep_agent.py
@@ -162,34 +162,44 @@ Compute a DCF (Discounted Cash Flow) valuation for {symbol} ({exchange}).
 
 {tool_data}
 
-The DCF tool has been called with auto-detected parameters. Your job:
+The data above includes:
+- **Base DCF** with auto-detected growth rate
+- **Reverse DCF**: what growth the market implies at the current price
+- **FCF quality**: whether free cash flow is sustainable
+- **Bull/Base/Bear scenarios** with different growth assumptions
+- **If this is a bank**: a P/BV model instead of (or alongside) DCF
 
-1. **Review the assumptions**: Is the growth rate reasonable for this company and sector?
-   - Compare with historical growth, analyst estimates, sector trends
-   - If growth seems too high or low, state what you'd use and why
+Your job as a valuation analyst:
 
-2. **Interpret the result**:
-   - Intrinsic value vs current price — margin of safety
-   - Is the stock undervalued, fairly valued, or overvalued?
-   - Which scenarios in the sensitivity table are most realistic?
+1. **PICK YOUR OWN GROWTH RATE** with reasoning:
+   - Look at: revenue growth, analyst consensus, sector trends, competitive position
+   - State: "I'm using X% because..." (don't just accept the auto-detected rate)
+   - If you disagree with the auto rate, explain why
 
-3. **Key risks to the DCF**:
-   - What could make FCF drop? (margin compression, capex surge, competition)
-   - What could change the growth trajectory? (new products, regulation, macro)
-   - Is the terminal growth assumption appropriate?
+2. **Interpret the reverse DCF**:
+   - "Market implies X% growth. This is [realistic/aggressive/conservative] because..."
+   - This is the most important insight — tells you what the market is pricing in
 
-4. **Comparison with market valuation**:
-   - How does DCF value compare to PE-implied value?
-   - Do analyst targets align with your DCF?
+3. **Assess FCF quality**:
+   - Is FCF sustainable? Any red flags (capex cuts, working capital swings)?
+   - If quality is LOW, discount the DCF result
+
+4. **Pick the most realistic scenario**:
+   - Bull/Base/Bear — which one matches your view?
+   - What would need to happen for bull case? For bear case?
+
+5. **For banks**: Use the P/BV model primarily. DCF doesn't work well for banks.
+   - Justified P/BV = ROE / Cost of Equity
+   - Is the stock trading above or below justified book?
 
 Respond with:
 VERDICT: [BULLISH / BEARISH / NEUTRAL]
 CONFIDENCE: [0-100]%
 SCORE: [-100 to +100]
 KEY_POINTS:
-- [point 1]
-- [point 2]
-- [point 3]"""
+- [point 1 — must include your chosen growth rate and intrinsic value]
+- [point 2 — must reference reverse DCF / market-implied growth]
+- [point 3 — risk or quality concern]"""
 
 
 # ── Deep Analyzer ────────────────────────────────────────────

--- a/analysis/dcf.py
+++ b/analysis/dcf.py
@@ -90,7 +90,8 @@ class DCFResult:
     terminal_growth: float
     fcf_projections: list[dict]  # [{year, fcf, pv}]
     terminal_value:  float
-    sensitivity:     list[dict]  # [{growth, wacc, intrinsic_value}]
+    terminal_pct:    float = 0.0  # terminal value as % of EV
+    sensitivity:     list[dict] = field(default_factory=list)
 
 
 def compute_dcf(
@@ -153,6 +154,7 @@ def compute_dcf(
 
     # Enterprise value
     enterprise_value = pv_fcfs + pv_terminal
+    terminal_pct = (pv_terminal / enterprise_value * 100) if enterprise_value > 0 else 0
 
     # Equity value
     equity_value = enterprise_value - net_debt_cr
@@ -202,8 +204,55 @@ def compute_dcf(
         terminal_growth=terminal_growth,
         fcf_projections=projections,
         terminal_value=round(terminal_value, 1),
+        terminal_pct=round(terminal_pct, 1),
         sensitivity=sensitivity,
     )
+
+
+def _get_fcf_quality(ticker) -> Optional[dict]:
+    """Extract FCF quality from yfinance cash flow statement."""
+    try:
+        cf = ticker.cashflow
+        if cf is None or cf.empty:
+            return None
+        fcf = cf.loc["Free Cash Flow"].iloc[0] if "Free Cash Flow" in cf.index else None
+        ocf = cf.loc["Operating Cash Flow"].iloc[0] if "Operating Cash Flow" in cf.index else None
+        capex = cf.loc["Capital Expenditure"].iloc[0] if "Capital Expenditure" in cf.index else None
+        prev_capex = cf.loc["Capital Expenditure"].iloc[1] if "Capital Expenditure" in cf.index and len(cf.columns) > 1 else None
+
+        if fcf and ocf:
+            return check_fcf_quality(
+                fcf=float(fcf) / 1e7,
+                operating_cashflow=float(ocf) / 1e7,
+                capex=float(capex) / 1e7 if capex else 0,
+                prev_capex=float(prev_capex) / 1e7 if prev_capex else 0,
+            )
+    except Exception:
+        pass
+    return None
+
+
+def _get_bank_model(snap, beta: float) -> Optional[dict]:
+    """Compute bank P/BV model if applicable."""
+    try:
+        pb = snap.pb
+        roe = snap.roe
+        if not pb or not roe or pb <= 0:
+            return None
+        # BV per share = price / PB
+        ltp = 0
+        try:
+            from market.quotes import get_ltp
+            ltp = get_ltp(f"NSE:{snap.symbol}")
+        except Exception:
+            pass
+        bv = ltp / pb if pb > 0 and ltp > 0 else 0
+        if bv <= 0:
+            return None
+        ke = RISK_FREE_RATE + max(beta, 0.5) * EQUITY_RISK_PREMIUM
+        return compute_bank_pbv(bv, roe, ke, ltp)
+    except Exception:
+        return None
 
 
 # ── Convenience: DCF from symbol ─────────────────────────────
@@ -379,6 +428,21 @@ def dcf_for_symbol(
             "raw_beta": raw_beta,
             "net_debt_cr": net_debt,
             "sensitivity": result.sensitivity,
+            "terminal_pct": result.terminal_pct,
+            # Phase 1: Reverse DCF
+            "implied_growth": reverse_dcf(
+                fcf_cr=fcf, wacc=computed_wacc, shares_outstanding=shares,
+                net_debt_cr=net_debt, current_price=ltp,
+            ),
+            # Phase 1: FCF quality
+            "fcf_quality": _get_fcf_quality(t),
+            # Phase 2: Bank model (if applicable)
+            "bank_model": _get_bank_model(snap, beta) if is_bank_stock(snap.sector, snap.industry) else None,
+            # Phase 4: Scenarios
+            "scenarios": compute_scenarios(
+                fcf_cr=fcf, wacc=computed_wacc, shares_outstanding=shares,
+                net_debt_cr=net_debt, base_growth=growth_rate,
+            ),
             "sources": sources,
             "commentary": commentary,
         }
@@ -460,3 +524,213 @@ def print_dcf(symbol: str, growth_rate: Optional[float] = None, wacc: Optional[f
             table.add_row(*row)
 
         console.print(table)
+
+    # Terminal value transparency
+    tv_pct = data.get("terminal_pct", 0)
+    if tv_pct:
+        tv_style = "yellow" if tv_pct > 70 else "dim"
+        console.print(f"\n  [{tv_style}]Terminal value = {tv_pct:.0f}% of enterprise value[/{tv_style}]")
+        if tv_pct > 80:
+            console.print("  [yellow]⚠ Terminal value dominates — consider extending projection to 10 years[/yellow]")
+
+    # Reverse DCF
+    implied = data.get("implied_growth")
+    if implied is not None:
+        console.print(f"\n  [bold]Reverse DCF:[/bold] Market implies {implied:.1f}% growth at ₹{cmp:,.0f}")
+        gap = implied - data["growth_rate"]
+        if abs(gap) > 5:
+            gap_style = "red" if gap > 0 else "green"
+            console.print(f"  [{gap_style}]Gap: market expects {gap:+.1f}% vs base case — "
+                          f"{'market is more optimistic' if gap > 0 else 'stock may be undervalued'}[/{gap_style}]")
+
+    # FCF quality
+    fcf_q = data.get("fcf_quality")
+    if fcf_q:
+        q_color = {"HIGH": "green", "MEDIUM": "yellow", "LOW": "red"}.get(fcf_q["quality"], "dim")
+        console.print(f"\n  [bold]FCF Quality:[/bold] [{q_color}]{fcf_q['quality']}[/{q_color}]")
+        for w in fcf_q.get("warnings", []):
+            console.print(f"  [yellow]{w}[/yellow]")
+
+    # Scenarios
+    scenarios = data.get("scenarios")
+    if scenarios:
+        console.print(f"\n  [bold]Scenarios:[/bold]")
+        for key in ("bull", "base", "bear"):
+            s = scenarios[key]
+            sc = "green" if key == "bull" else "red" if key == "bear" else "yellow"
+            console.print(f"  [{sc}]{s['label']:5s}[/{sc}] (growth {s['growth']:.0f}%): ₹{s['intrinsic_value']:,.0f}")
+
+    # Bank model
+    bank = data.get("bank_model")
+    if bank:
+        console.print(f"\n  [bold]Bank P/BV Model:[/bold]")
+        console.print(f"  Book Value: ₹{bank['bv_per_share']:,.0f} | ROE: {bank['roe']:.1f}%")
+        console.print(f"  Justified P/BV: {bank['justified_pbv']:.2f}× | Fair Value: ₹{bank['fair_value']:,.0f}")
+
+
+# ── Phase 1: Reverse DCF ─────────────────────────────────────
+
+def reverse_dcf(
+    fcf_cr: float,
+    wacc: float,
+    shares_outstanding: int,
+    net_debt_cr: float = 0.0,
+    current_price: float = 0.0,
+    terminal_growth: float = TERMINAL_GROWTH,
+) -> Optional[float]:
+    """
+    What growth rate does the market imply at the current price?
+
+    Binary search: find growth_rate where intrinsic_value ≈ current_price.
+    Returns implied growth rate (%), or None if can't solve.
+    """
+    if fcf_cr <= 0 or current_price <= 0 or shares_outstanding <= 0:
+        return None
+
+    low, high = -5.0, 50.0
+    for _ in range(50):
+        mid = (low + high) / 2
+        result = compute_dcf(
+            fcf_cr=fcf_cr, growth_rate=mid, wacc=wacc,
+            shares_outstanding=shares_outstanding, net_debt_cr=net_debt_cr,
+            terminal_growth=terminal_growth, current_price=current_price,
+        )
+        if abs(result.intrinsic_value - current_price) < current_price * 0.01:
+            return round(mid, 1)
+        if result.intrinsic_value < current_price:
+            low = mid
+        else:
+            high = mid
+
+    return round((low + high) / 2, 1)
+
+
+# ── Phase 1: FCF Quality Check ───────────────────────────────
+
+def check_fcf_quality(
+    fcf: float,
+    operating_cashflow: float,
+    capex: float,
+    prev_capex: float = 0.0,
+) -> dict:
+    """
+    Assess whether FCF is sustainable.
+
+    Returns dict with quality (HIGH/MEDIUM/LOW) and warnings.
+    """
+    warnings = []
+    quality = "HIGH"
+
+    # FCF vs OCF ratio
+    if operating_cashflow > 0:
+        fcf_ocf_ratio = fcf / operating_cashflow
+        if fcf_ocf_ratio > 0.9:
+            pass  # healthy — FCF close to OCF
+        elif fcf_ocf_ratio > 0.5:
+            quality = "MEDIUM"
+            warnings.append(f"FCF is {fcf_ocf_ratio:.0%} of operating cash flow — moderate capex burden")
+        else:
+            quality = "LOW"
+            warnings.append(f"FCF is only {fcf_ocf_ratio:.0%} of operating cash flow — heavy capex")
+
+    # Capex trend
+    if prev_capex and capex and prev_capex < 0 and capex < 0:
+        capex_change = (abs(capex) - abs(prev_capex)) / abs(prev_capex)
+        if capex_change < -0.3:
+            quality = "LOW"
+            warnings.append(f"Capex dropped {abs(capex_change):.0%} vs prior year — FCF may be temporarily inflated")
+        elif capex_change > 0.3:
+            warnings.append(f"Capex increased {capex_change:.0%} — investing for growth (FCF may dip)")
+
+    if not warnings:
+        warnings.append("FCF closely tracks operating cash flow with stable capex")
+
+    return {"quality": quality, "warnings": warnings}
+
+
+# ── Phase 2: Bank P/BV Model ─────────────────────────────────
+
+def is_bank_stock(sector: Optional[str], industry: Optional[str]) -> bool:
+    """Detect if a stock is a bank based on sector/industry."""
+    if not sector:
+        return False
+    s = sector.lower()
+    i = (industry or "").lower()
+    return "financial" in s and ("bank" in i or "banking" in i)
+
+
+def compute_bank_pbv(
+    book_value_per_share: float,
+    roe: float,
+    cost_of_equity: float = 13.5,
+    current_price: float = 0.0,
+) -> dict:
+    """
+    Gordon Growth P/BV model for banks.
+
+    Justified P/BV = (ROE - g) / (Ke - g)
+    where g = sustainable growth = ROE × retention ratio (assumed 70%)
+    """
+    retention = 0.70
+    g = roe * retention / 100  # sustainable growth rate
+
+    ke = cost_of_equity / 100
+    if ke <= g / 100:
+        justified_pbv = roe / cost_of_equity  # simplified
+    else:
+        justified_pbv = (roe / 100 - g / 100) / (ke - g / 100)
+
+    fair_value = book_value_per_share * justified_pbv
+
+    margin = ((fair_value - current_price) / current_price * 100) if current_price > 0 else 0
+
+    return {
+        "bv_per_share": book_value_per_share,
+        "roe": roe,
+        "cost_of_equity": cost_of_equity,
+        "justified_pbv": round(justified_pbv, 2),
+        "fair_value": round(fair_value, 2),
+        "current_price": current_price,
+        "margin_of_safety": round(margin, 1),
+        "verdict": "UNDERVALUED" if margin > 15 else "OVERVALUED" if margin < -15 else "FAIRLY_VALUED",
+    }
+
+
+# ── Phase 4: Multi-scenario ──────────────────────────────────
+
+def compute_scenarios(
+    fcf_cr: float,
+    wacc: float,
+    shares_outstanding: int,
+    net_debt_cr: float = 0.0,
+    base_growth: float = 10.0,
+    terminal_growth: float = TERMINAL_GROWTH,
+) -> dict:
+    """
+    Compute bull / base / bear DCF scenarios.
+
+    Bull: base_growth × 1.5 (optimistic)
+    Base: base_growth (analyst consensus)
+    Bear: base_growth × 0.4 (conservative)
+    """
+    scenarios = {}
+    configs = [
+        ("bull", "Bull", min(base_growth * 1.5, 30.0)),
+        ("base", "Base", base_growth),
+        ("bear", "Bear", max(base_growth * 0.4, 0.0)),
+    ]
+
+    for key, label, growth in configs:
+        result = compute_dcf(
+            fcf_cr=fcf_cr, growth_rate=growth, wacc=wacc,
+            shares_outstanding=shares_outstanding, net_debt_cr=net_debt_cr,
+            terminal_growth=terminal_growth,
+        )
+        scenarios[key] = {
+            "label": label,
+            "growth": round(growth, 1),
+            "intrinsic_value": result.intrinsic_value,
+            "enterprise_value": result.enterprise_value,
+        }
+
+    return scenarios

--- a/app/repl.py
+++ b/app/repl.py
@@ -1008,14 +1008,51 @@ def run_repl(broker: BrokerAPI) -> None:
                 by = "value" if "--value" in args else "volume"
                 print_most_active(by=by)
 
-    "active", "bulk-deals", "dcf", "deals", "delta-hedge",
-    "earnings", "events", "exports", "flows", "gex", "greeks",
-    "iv-smile", "macro", "memory", "most-active",
-    "oi", "oi-profile", "scan", "smile",
+            elif command in ("bulk-deals", "block-deals", "deals"):
+                from market.bulk_deals import print_deals
+                sym = args[0].upper() if args and not args[0].startswith("-") else None
+                print_deals(symbol=sym)
 
+            elif command in ("oi-profile", "oi"):
+                from market.oi_profile import print_oi_profile
+                sym = args[0].upper() if args else "NIFTY"
+                print_oi_profile(sym)
 
+            elif command in ("iv-smile", "smile"):
+                from analysis.volatility_surface import print_iv_smile
+                sym = args[0].upper() if args else "NIFTY"
+                print_iv_smile(sym)
 
+            elif command == "gex":
+                from analysis.gex import print_gex
+                sym = args[0].upper() if args else "NIFTY"
+                print_gex(sym)
 
+            elif command == "scan":
+                from market.options_scanner import print_scan_results
+                quick = "--quick" in args
+                syms = [a.upper() for a in args if not a.startswith("-")] or None
+                print_scan_results(symbols=syms, quick=quick)
+
+            elif command == "dcf":
+                if not args:
+                    console.print("[red]Usage: dcf SYMBOL [--growth 15] [--wacc 12][/red]")
+                else:
+                    from analysis.dcf import print_dcf
+                    sym = args[0].upper()
+                    growth = None
+                    wacc_val = None
+                    if "--growth" in args:
+                        idx = args.index("--growth")
+                        if idx + 1 < len(args):
+                            try: growth = float(args[idx + 1])
+                            except ValueError: pass
+                    if "--wacc" in args:
+                        idx = args.index("--wacc")
+                        if idx + 1 < len(args):
+                            try: wacc_val = float(args[idx + 1])
+                            except ValueError: pass
+                    print_dcf(sym, growth_rate=growth, wacc=wacc_val)
 
             elif command == "flows":
                 from market.flow_intel import print_flow_report

--- a/tests/test_dcf_improvements.py
+++ b/tests/test_dcf_improvements.py
@@ -1,0 +1,145 @@
+"""Tests for DCF improvements (#75): reverse DCF, FCF quality, bank P/BV, scenarios.
+
+TDD — written before implementation.
+"""
+
+import pytest
+
+
+# ── Phase 1: Reverse DCF ─────────────────────────────────────
+
+class TestReverseDCF:
+    def test_reverse_dcf_finds_implied_growth(self):
+        from analysis.dcf import reverse_dcf
+        # If intrinsic at 10% growth = 500, and stock trades at 1000,
+        # implied growth must be > 10%
+        result = reverse_dcf(
+            fcf_cr=1000, wacc=12.0, shares_outstanding=100_000_000,
+            net_debt_cr=0, current_price=1500.0,
+        )
+        assert result is not None
+        assert result > 5.0  # needs meaningful growth to justify 1500
+
+    def test_reverse_dcf_low_price_low_growth(self):
+        from analysis.dcf import reverse_dcf
+        result = reverse_dcf(
+            fcf_cr=1000, wacc=12.0, shares_outstanding=100_000_000,
+            net_debt_cr=0, current_price=200.0,
+        )
+        assert result is not None
+        assert result < 10.0  # low price justified by low growth
+
+    def test_reverse_dcf_negative_fcf_returns_none(self):
+        from analysis.dcf import reverse_dcf
+        result = reverse_dcf(
+            fcf_cr=-500, wacc=12.0, shares_outstanding=100_000_000,
+            net_debt_cr=0, current_price=100.0,
+        )
+        assert result is None  # can't compute with negative FCF
+
+
+class TestTerminalValueTransparency:
+    def test_terminal_pct_shown(self):
+        from analysis.dcf import compute_dcf
+        result = compute_dcf(
+            fcf_cr=1000, growth_rate=10.0, wacc=12.0,
+            shares_outstanding=100_000_000, net_debt_cr=0,
+        )
+        assert hasattr(result, 'terminal_pct')
+        assert 0 < result.terminal_pct < 100
+
+    def test_terminal_dominates_at_low_growth(self):
+        from analysis.dcf import compute_dcf
+        result = compute_dcf(
+            fcf_cr=1000, growth_rate=2.0, wacc=12.0,
+            shares_outstanding=100_000_000, net_debt_cr=0,
+        )
+        # Low growth → terminal value is a larger % of EV
+        assert result.terminal_pct > 50
+
+
+class TestFCFQuality:
+    def test_fcf_quality_check(self):
+        from analysis.dcf import check_fcf_quality
+        result = check_fcf_quality(
+            fcf=1000, operating_cashflow=1200, capex=-200,
+            prev_capex=-300,
+        )
+        assert "quality" in result
+        assert result["quality"] in ("HIGH", "MEDIUM", "LOW")
+
+    def test_high_quality_fcf(self):
+        from analysis.dcf import check_fcf_quality
+        result = check_fcf_quality(
+            fcf=1100, operating_cashflow=1200, capex=-100,
+            prev_capex=-100,  # stable capex, FCF ~92% of OCF
+        )
+        assert result["quality"] == "HIGH"
+
+    def test_low_quality_declining_capex(self):
+        from analysis.dcf import check_fcf_quality
+        result = check_fcf_quality(
+            fcf=1000, operating_cashflow=1200, capex=-100,
+            prev_capex=-500,  # capex dropped 80% — FCF inflated
+        )
+        assert result["quality"] == "LOW"
+
+
+# ── Phase 2: Bank P/BV Model ─────────────────────────────────
+
+class TestBankValuation:
+    def test_detect_bank(self):
+        from analysis.dcf import is_bank_stock
+        assert is_bank_stock("Financial Services", "Banks—Regional") is True
+        assert is_bank_stock("Technology", "Software") is False
+        assert is_bank_stock("Financial Services", "Insurance") is False
+
+    def test_bank_pbv_model(self):
+        from analysis.dcf import compute_bank_pbv
+        result = compute_bank_pbv(
+            book_value_per_share=500.0,
+            roe=15.0,
+            cost_of_equity=13.5,
+            current_price=800.0,
+        )
+        assert result["justified_pbv"] > 0
+        assert result["fair_value"] > 0
+        assert "verdict" in result
+
+    def test_bank_high_roe_premium(self):
+        from analysis.dcf import compute_bank_pbv
+        low_roe = compute_bank_pbv(book_value_per_share=500, roe=10.0, cost_of_equity=13.5)
+        high_roe = compute_bank_pbv(book_value_per_share=500, roe=20.0, cost_of_equity=13.5)
+        assert high_roe["fair_value"] > low_roe["fair_value"]
+
+
+# ── Phase 4: Multi-scenario ──────────────────────────────────
+
+class TestMultiScenario:
+    def test_scenarios_returns_three(self):
+        from analysis.dcf import compute_scenarios
+        result = compute_scenarios(
+            fcf_cr=1000, wacc=12.0, shares_outstanding=100_000_000,
+            net_debt_cr=0, base_growth=10.0,
+        )
+        assert "bull" in result
+        assert "base" in result
+        assert "bear" in result
+
+    def test_bull_higher_than_bear(self):
+        from analysis.dcf import compute_scenarios
+        result = compute_scenarios(
+            fcf_cr=1000, wacc=12.0, shares_outstanding=100_000_000,
+            net_debt_cr=0, base_growth=10.0,
+        )
+        assert result["bull"]["intrinsic_value"] > result["base"]["intrinsic_value"]
+        assert result["base"]["intrinsic_value"] > result["bear"]["intrinsic_value"]
+
+    def test_scenarios_have_labels(self):
+        from analysis.dcf import compute_scenarios
+        result = compute_scenarios(
+            fcf_cr=1000, wacc=12.0, shares_outstanding=100_000_000,
+            net_debt_cr=0, base_growth=10.0,
+        )
+        assert result["bull"]["label"] == "Bull"
+        assert result["bear"]["label"] == "Bear"


### PR DESCRIPTION
## Summary

4 phases of DCF model improvements:

### Phase 1: Reverse DCF + Transparency
- **Reverse DCF**: "Market implies 22% growth at current price. Analyst consensus is 10.6%."
- **Terminal value %**: "Terminal = 72% of EV" + warning if >80%
- **FCF quality**: HIGH/MEDIUM/LOW based on FCF/OCF ratio + capex trend

### Phase 2: Bank P/BV Model
- Auto-detects banks from sector/industry
- Gordon Growth justified P/BV = (ROE - g) / (Ke - g)
- Banks get P/BV model instead of (broken) DCF

### Phase 3: LLM-Driven Assumptions
- Deep analysis DCF analyst now PICKS its own growth rate with reasoning
- Interprets reverse DCF, assesses FCF quality, picks best scenario

### Phase 4: Multi-Scenario
- Bull (1.5× base), Base, Bear (0.4× base)
- "Bull ₹2,150 | Base ₹630 | Bear ₹350"

## CLI Output (example)

```
dcf RELIANCE

Intrinsic Value: ₹630  vs  CMP: ₹1,350
Margin of Safety: -53.8%  →  OVERVALUED

Reverse DCF: Market implies 22.0% growth at ₹1,350
Gap: market expects +11.4% vs base case — market is more optimistic

FCF Quality: HIGH
  FCF closely tracks operating cash flow with stable capex

Scenarios:
  Bull  (growth 16%): ₹1,120
  Base  (growth 11%): ₹630
  Bear  (growth 4%):  ₹280

Terminal value = 68% of enterprise value
```

## Test plan

- [x] 14 new tests (TDD): reverse DCF, FCF quality, bank P/BV, scenarios
- [x] All 197 tests pass
- [x] Manual: `dcf RELIANCE`, `dcf HDFCBANK` (should show bank P/BV model)

Addresses #75. SOTP deferred to #76.