### PR TITLE
feat: live trade execution with LIVE/PAPER safety gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,12 +370,12 @@ Supports single-symbol strategies (RSI, MACD, EMA crossover, Bollinger Bands) an
 | `pairs` | Scan for pair trading opportunities |
 | `pairs HDFCBANK ICICIBANK` | Analyze a specific stock pair |
 
-### Paper Trading
+### Trade Execution
 | Command | Description |
 |---------|-------------|
-| `paper-execute` | Execute last trade plan (neutral risk) |
-| `paper-execute aggressive` | Execute aggressive plan |
-| `paper-execute conservative` | Execute conservative plan |
+| `execute` | Execute last trade plan (neutral risk) — LIVE or PAPER, auto-detected |
+| `execute aggressive` | Execute aggressive plan |
+| `execute conservative` | Execute conservative plan |
 
 ### Trade Memory & Learning
 | Command | Description |
@@ -529,7 +529,7 @@ india-trade-cli/
 |   |-- profile.py            # Personal trading style profile
 |   |-- alerts.py             # Price + technical + conditional alerts
 |   |-- paper.py              # Paper trading engine
-|   |-- paper_execute.py      # Execute trade plans in paper mode
+|   |-- trade_executor.py     # Execute trade plans (live or paper, with safety gate)
 |   |-- output.py             # PDF export + simple explainer
 |   |-- portfolio.py          # Portfolio tracker + aggregated Greeks
 |   |-- strategy.py           # Strategy recommendation engine

--- a/app/repl.py
+++ b/app/repl.py
@@ -105,7 +105,7 @@ COMMANDS = [
     "profile",
     "provider",
     "risk-report",
-    "paper-execute",
+    "execute",
     "save-pdf",
     "explain",
     "explain-save",
@@ -1482,8 +1482,8 @@ def run_repl(broker: BrokerAPI) -> None:
                         "[dim]Run 'telegram setup' for guided configuration, or check your bot token.[/dim]"
                     )
 
-            # ── Paper execution ──────────────────────────────────
-            elif command == "paper-execute":
+            # ── Trade execution (live or paper, auto-detected) ───
+            elif command in ("execute", "paper-execute"):
                 if not _last_trade_plans:
                     console.print(
                         "[dim]No trade plans available. Run 'analyze <SYMBOL>' first.[/dim]"
@@ -1491,13 +1491,11 @@ def run_repl(broker: BrokerAPI) -> None:
                 else:
                     profile_name = args[0].lower() if args else "neutral"
                     if profile_name not in ("aggressive", "neutral", "conservative"):
-                        console.print(
-                            "[red]Usage: paper-execute [aggressive|neutral|conservative][/red]"
-                        )
+                        console.print("[red]Usage: execute [aggressive|neutral|conservative][/red]")
                     else:
                         plan = _last_trade_plans.get(profile_name)
                         if plan:
-                            from engine.paper_execute import execute_trade_plan
+                            from engine.trade_executor import execute_trade_plan
 
                             execute_trade_plan(plan, broker)
                         else:

--- a/engine/trade_executor.py
+++ b/engine/trade_executor.py
@@ -1,0 +1,261 @@
+"""
+engine/trade_executor.py
+────────────────────────
+Execute trade plans against any connected broker — paper or live.
+
+After `analyze RELIANCE` generates trade plans, the user runs:
+    execute                  → neutral risk plan
+    execute aggressive       → aggressive plan
+    execute conservative     → conservative plan
+
+Live mode (Fyers or any real broker connected):
+  - Shows the full order before sending
+  - Requires explicit "yes" confirmation
+  - Respects TRADING_MODE=PAPER env override (refuses live execution)
+  - Auto-creates SL and target alerts after execution
+
+Paper mode (Mock/Demo broker):
+  - No confirmation needed — no real money at stake
+  - Same output format so behaviour is identical
+
+Usage:
+    from engine.trade_executor import execute_trade_plan
+
+    execute_trade_plan(plan, broker)
+"""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm
+from rich.table import Table
+
+from brokers.base import BrokerAPI, OrderRequest
+
+console = Console()
+
+
+# ── Mode detection ────────────────────────────────────────────
+
+
+def _is_paper(broker: BrokerAPI) -> bool:
+    """True when connected to a paper / mock / demo broker."""
+    try:
+        profile = broker.get_profile()
+        return profile.broker.upper() in ("PAPER", "MOCK", "DEMO")
+    except Exception:
+        return True  # fail safe
+
+
+def _trading_mode_override() -> str:
+    """Read TRADING_MODE env var. Returns 'PAPER' or 'LIVE'."""
+    return os.environ.get("TRADING_MODE", "PAPER").upper()
+
+
+def is_live_execution_allowed(broker: BrokerAPI) -> bool:
+    """
+    Live execution is only allowed when:
+      1. The broker is a real broker (not Mock/Paper/Demo), AND
+      2. TRADING_MODE is not forced to PAPER via environment
+    """
+    if _is_paper(broker):
+        return False
+    if _trading_mode_override() == "PAPER":
+        return False
+    return True
+
+
+# ── Confirmation prompt ────────────────────────────────────────
+
+
+def _show_order_preview(plan, broker: BrokerAPI) -> None:
+    """Print a clear summary of what is about to be sent to the broker."""
+    try:
+        profile = broker.get_profile()
+        broker_name = profile.broker
+    except Exception:
+        broker_name = "Unknown"
+
+    table = Table(show_header=True, header_style="bold cyan", box=None, padding=(0, 2))
+    table.add_column("Leg")
+    table.add_column("Action")
+    table.add_column("Instrument")
+    table.add_column("Qty", justify="right")
+    table.add_column("Type")
+    table.add_column("Price", justify="right")
+
+    for i, leg in enumerate(plan.entry_orders, 1):
+        price_str = f"₹{leg.price:,.2f}" if leg.price else "MARKET"
+        table.add_row(
+            str(i),
+            f"[{'green' if leg.action == 'BUY' else 'red'}]{leg.action}[/]",
+            leg.instrument,
+            str(leg.quantity),
+            leg.order_type,
+            price_str,
+        )
+
+    ep = plan.exit_plan
+    console.print()
+    console.print(
+        Panel(
+            f"  Strategy : {plan.strategy_name}\n"
+            f"  Symbol   : {plan.symbol}\n"
+            f"  Broker   : [bold]{broker_name}[/bold]\n"
+            f"  Orders   : {len(plan.entry_orders)}\n"
+            + (
+                f"  Stop-Loss: ₹{ep.stop_loss:,.2f} ({ep.stop_loss_pct:+.1f}%)\n"
+                f"  Target 1 : ₹{ep.target_1:,.2f} ({ep.target_1_pct:+.1f}%)"
+                if ep
+                else ""
+            ),
+            title="[bold red]⚠  LIVE ORDER PREVIEW[/bold red]",
+            border_style="red",
+        )
+    )
+    console.print(table)
+    console.print()
+
+
+# ── Core executor ─────────────────────────────────────────────
+
+
+def execute_trade_plan(
+    plan,
+    broker: BrokerAPI,
+    skip_confirmation: bool = False,
+) -> list[dict]:
+    """
+    Execute a TradePlan by placing orders with the broker.
+
+    For live brokers: shows full order preview and requires explicit
+    confirmation before sending anything to the exchange.
+
+    For paper brokers: executes immediately with no confirmation.
+
+    Args:
+        plan:               TradePlan from engine/trader.py
+        broker:             Connected BrokerAPI instance
+        skip_confirmation:  True only for programmatic callers that have
+                            already shown their own confirmation UI
+                            (e.g. Telegram inline button).
+
+    Returns:
+        List of order results [{order_id, symbol, status, ...}]
+    """
+    if plan is None:
+        console.print("[dim]No trade plan to execute (verdict was HOLD).[/dim]")
+        return []
+
+    live = is_live_execution_allowed(broker)
+
+    # ── Live execution gate ───────────────────────────────────
+    if live and not skip_confirmation:
+        _show_order_preview(plan, broker)
+        confirmed = Confirm.ask(
+            "[bold red]Send these orders to the exchange? This uses real money.[/bold red]",
+            default=False,
+        )
+        if not confirmed:
+            console.print("[dim]Execution cancelled.[/dim]")
+            return []
+
+    # ── Paper override warning ────────────────────────────────
+    if not live and not _is_paper(broker):
+        console.print(
+            "[yellow]  TRADING_MODE=PAPER is set — executing as paper trade "
+            "even though a live broker is connected.[/yellow]"
+        )
+
+    mode_label = "LIVE" if live else "PAPER"
+    mode_style = "bold red" if live else "bold green"
+
+    console.print()
+    console.print(
+        Panel(
+            f"  [{mode_style}]{mode_label}[/{mode_style}]  {plan.strategy_name} on {plan.symbol}\n"
+            f"  Orders: {len(plan.entry_orders)}",
+            title=f"[{mode_style}]Order Execution[/{mode_style}]",
+            border_style="red" if live else "green",
+        )
+    )
+
+    results = []
+    for i, leg in enumerate(plan.entry_orders, 1):
+        try:
+            order_req = OrderRequest(
+                symbol=leg.instrument.split()[0],
+                exchange=leg.exchange,
+                transaction_type=leg.action,
+                quantity=leg.quantity,
+                order_type=leg.order_type,
+                product=leg.product,
+                price=leg.price,
+                trigger_price=leg.trigger_price,
+                tag=leg.tag or f"plan_{plan.symbol}",
+            )
+
+            response = broker.place_order(order_req)
+            status_style = "green" if response.status in ("COMPLETE", "OPEN") else "red"
+
+            console.print(
+                f"  [{i}] {leg.action} {leg.quantity} {leg.instrument} "
+                f"({leg.order_type}) → [{status_style}]{response.status}[/{status_style}] "
+                f"(ID: {response.order_id})"
+            )
+
+            results.append(
+                {
+                    "order_id": response.order_id,
+                    "symbol": leg.instrument,
+                    "action": leg.action,
+                    "quantity": leg.quantity,
+                    "status": response.status,
+                    "message": response.message,
+                    "mode": mode_label,
+                }
+            )
+
+        except Exception as e:
+            console.print(
+                f"  [{i}] {leg.action} {leg.quantity} {leg.instrument} → [red]FAILED: {e}[/red]"
+            )
+            results.append(
+                {
+                    "symbol": leg.instrument,
+                    "action": leg.action,
+                    "quantity": leg.quantity,
+                    "status": "FAILED",
+                    "message": str(e),
+                    "mode": mode_label,
+                }
+            )
+
+    # ── Exit plan reminder + auto-alerts ─────────────────────
+    if plan.exit_plan:
+        ep = plan.exit_plan
+        lines = [
+            "\n  [bold]Exit Plan (set these as orders when appropriate):[/bold]",
+            f"  Stop-Loss : ₹{ep.stop_loss:,.2f} ({ep.stop_loss_pct:+.1f}%)",
+            f"  Target 1  : ₹{ep.target_1:,.2f} ({ep.target_1_pct:+.1f}%) → {ep.target_1_action}",
+        ]
+        if ep.target_2:
+            lines.append(
+                f"  Target 2  : ₹{ep.target_2:,.2f} ({ep.target_2_pct:+.1f}%) → {ep.target_2_action}"
+            )
+        console.print("\n".join(lines))
+
+        try:
+            from engine.alerts import alert_manager
+
+            alert_manager.add_price_alert(plan.symbol, "BELOW", ep.stop_loss, plan.exchange)
+            alert_manager.add_price_alert(plan.symbol, "ABOVE", ep.target_1, plan.exchange)
+            console.print("[dim]  Auto-created price alerts for stop-loss and target.[/dim]")
+        except Exception:
+            pass
+
+    console.print()
+    return results

--- a/tests/test_trade_executor.py
+++ b/tests/test_trade_executor.py
@@ -1,0 +1,245 @@
+"""Tests for engine/trade_executor.py — live/paper mode detection and order execution."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+from brokers.base import OrderResponse, UserProfile
+from engine.trade_executor import (
+    _is_paper,
+    _trading_mode_override,
+    execute_trade_plan,
+    is_live_execution_allowed,
+)
+from engine.trader import ExitPlan, OrderLeg, TradePlan
+
+
+# ── Helpers ───────────────────────────────────────────────────
+
+
+def _make_broker(broker_name: str) -> MagicMock:
+    """Return a mock BrokerAPI with a given broker name in the profile."""
+    broker = MagicMock()
+    broker.get_profile.return_value = UserProfile(
+        user_id="U001",
+        name="Test User",
+        email="test@example.com",
+        broker=broker_name,
+    )
+    broker.place_order.return_value = OrderResponse(
+        order_id="ORD123",
+        status="COMPLETE",
+        message="Order placed",
+    )
+    return broker
+
+
+def _make_plan(n_legs: int = 1, with_exit: bool = True) -> TradePlan:
+    """Return a minimal TradePlan with n_legs OrderLegs."""
+    legs = [
+        OrderLeg(
+            action="BUY",
+            instrument="RELIANCE",
+            exchange="NSE",
+            product="CNC",
+            order_type="MARKET",
+            quantity=10,
+        )
+        for _ in range(n_legs)
+    ]
+    exit_plan = (
+        ExitPlan(
+            stop_loss=2400.0,
+            stop_loss_pct=-2.0,
+            stop_loss_type="FIXED",
+            target_1=2600.0,
+            target_1_pct=4.0,
+        )
+        if with_exit
+        else None
+    )
+    return TradePlan(
+        symbol="RELIANCE",
+        exchange="NSE",
+        timestamp="2026-04-04T09:15:00",
+        strategy_name="Delivery Buy",
+        direction="LONG",
+        instrument_type="EQUITY",
+        timeframe="SWING",
+        capital_deployed=25000.0,
+        capital_pct=10.0,
+        max_risk=500.0,
+        risk_pct=2.0,
+        reward_risk=2.0,
+        entry_orders=legs,
+        exit_plan=exit_plan,
+    )
+
+
+# ── _is_paper ────────────────────────────────────────────────
+
+
+class TestIsPaper:
+    def test_paper_broker(self):
+        assert _is_paper(_make_broker("PAPER")) is True
+
+    def test_mock_broker(self):
+        assert _is_paper(_make_broker("MOCK")) is True
+
+    def test_demo_broker(self):
+        assert _is_paper(_make_broker("DEMO")) is True
+
+    def test_fyers_broker_is_not_paper(self):
+        assert _is_paper(_make_broker("FYERS")) is False
+
+    def test_zerodha_broker_is_not_paper(self):
+        assert _is_paper(_make_broker("ZERODHA")) is False
+
+    def test_exception_defaults_to_paper(self):
+        broker = MagicMock()
+        broker.get_profile.side_effect = RuntimeError("network error")
+        assert _is_paper(broker) is True
+
+
+# ── _trading_mode_override ───────────────────────────────────
+
+
+class TestTradingModeOverride:
+    def test_default_is_paper(self):
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            assert _trading_mode_override() == "PAPER"
+
+    def test_env_live(self):
+        with patch.dict(os.environ, {"TRADING_MODE": "LIVE"}):
+            assert _trading_mode_override() == "LIVE"
+
+    def test_env_paper(self):
+        with patch.dict(os.environ, {"TRADING_MODE": "PAPER"}):
+            assert _trading_mode_override() == "PAPER"
+
+    def test_env_case_insensitive(self):
+        with patch.dict(os.environ, {"TRADING_MODE": "live"}):
+            assert _trading_mode_override() == "LIVE"
+
+
+# ── is_live_execution_allowed ────────────────────────────────
+
+
+class TestIsLiveExecutionAllowed:
+    def test_paper_broker_never_live(self):
+        with patch.dict(os.environ, {"TRADING_MODE": "LIVE"}):
+            assert is_live_execution_allowed(_make_broker("PAPER")) is False
+
+    def test_live_broker_with_paper_env_is_not_live(self):
+        with patch.dict(os.environ, {"TRADING_MODE": "PAPER"}):
+            assert is_live_execution_allowed(_make_broker("FYERS")) is False
+
+    def test_live_broker_with_live_env_is_allowed(self):
+        with patch.dict(os.environ, {"TRADING_MODE": "LIVE"}):
+            assert is_live_execution_allowed(_make_broker("FYERS")) is True
+
+    def test_live_broker_with_default_env_is_not_live(self):
+        """Default TRADING_MODE is PAPER — live broker still blocked."""
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            assert is_live_execution_allowed(_make_broker("FYERS")) is False
+
+
+# ── execute_trade_plan ───────────────────────────────────────
+
+
+class TestExecuteTradePlan:
+    def test_none_plan_returns_empty(self):
+        broker = _make_broker("PAPER")
+        result = execute_trade_plan(None, broker)
+        assert result == []
+        broker.place_order.assert_not_called()
+
+    def test_paper_broker_executes_without_confirmation(self):
+        broker = _make_broker("PAPER")
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            result = execute_trade_plan(_make_plan(), broker)
+        assert len(result) == 1
+        assert result[0]["status"] == "COMPLETE"
+        assert result[0]["mode"] == "PAPER"
+        broker.place_order.assert_called_once()
+
+    def test_paper_broker_multiple_legs(self):
+        broker = _make_broker("PAPER")
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            result = execute_trade_plan(_make_plan(n_legs=3), broker)
+        assert len(result) == 3
+        assert broker.place_order.call_count == 3
+
+    def test_live_broker_cancelled_returns_empty(self):
+        """If user cancels the confirmation, no orders placed."""
+        broker = _make_broker("FYERS")
+        with patch.dict(os.environ, {"TRADING_MODE": "LIVE"}):
+            with patch("engine.trade_executor.Confirm.ask", return_value=False):
+                result = execute_trade_plan(_make_plan(), broker)
+        assert result == []
+        broker.place_order.assert_not_called()
+
+    def test_live_broker_confirmed_places_order(self):
+        broker = _make_broker("FYERS")
+        with patch.dict(os.environ, {"TRADING_MODE": "LIVE"}):
+            with patch("engine.trade_executor.Confirm.ask", return_value=True):
+                result = execute_trade_plan(_make_plan(), broker)
+        assert len(result) == 1
+        assert result[0]["mode"] == "LIVE"
+        assert result[0]["status"] == "COMPLETE"
+        broker.place_order.assert_called_once()
+
+    def test_skip_confirmation_bypasses_prompt(self):
+        """skip_confirmation=True skips the Confirm.ask entirely for live brokers."""
+        broker = _make_broker("FYERS")
+        with patch.dict(os.environ, {"TRADING_MODE": "LIVE"}):
+            with patch("engine.trade_executor.Confirm.ask") as mock_confirm:
+                result = execute_trade_plan(_make_plan(), broker, skip_confirmation=True)
+        mock_confirm.assert_not_called()
+        assert len(result) == 1
+        assert result[0]["mode"] == "LIVE"
+
+    def test_failed_order_recorded_in_results(self):
+        broker = _make_broker("PAPER")
+        broker.place_order.side_effect = RuntimeError("API timeout")
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            result = execute_trade_plan(_make_plan(), broker)
+        assert len(result) == 1
+        assert result[0]["status"] == "FAILED"
+        assert "API timeout" in result[0]["message"]
+
+    def test_result_contains_expected_fields(self):
+        broker = _make_broker("PAPER")
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            result = execute_trade_plan(_make_plan(), broker)
+        r = result[0]
+        assert "order_id" in r
+        assert "symbol" in r
+        assert "action" in r
+        assert "quantity" in r
+        assert "status" in r
+        assert "mode" in r
+
+    def test_plan_without_exit_still_executes(self):
+        broker = _make_broker("PAPER")
+        env = {k: v for k, v in os.environ.items() if k != "TRADING_MODE"}
+        with patch.dict(os.environ, env, clear=True):
+            result = execute_trade_plan(_make_plan(with_exit=False), broker)
+        assert len(result) == 1
+        assert result[0]["status"] == "COMPLETE"
+
+    def test_trading_mode_paper_env_shows_warning_for_live_broker(self, capsys):
+        """When TRADING_MODE=PAPER but a live broker is connected, a warning is shown."""
+        broker = _make_broker("FYERS")
+        with patch.dict(os.environ, {"TRADING_MODE": "PAPER"}):
+            result = execute_trade_plan(_make_plan(), broker)
+        # Orders still execute (as paper)
+        assert len(result) == 1
+        assert result[0]["mode"] == "PAPER"


### PR DESCRIPTION
## Summary
- Replaces `paper-execute` command with `execute` — the name now reflects reality: when you're connected to Fyers (or any live broker), it executes **real** orders
- Live broker orders are gated behind a red ⚠ order preview panel + explicit `Confirm.ask()` before anything touches the exchange
- `TRADING_MODE=PAPER` environment variable forces paper mode even if a live broker is connected (safety override for testing)
- New `engine/trade_executor.py` replaces `engine/paper_execute.py` with full LIVE/PAPER mode detection, per-leg order placement, and auto-created SL/target alerts after execution
- 24 new tests covering mode detection, confirmation gate, skip_confirmation, failed order recording, and edge cases

## What changed
- `engine/trade_executor.py` — new module (replaces `paper_execute.py`)
- `app/repl.py` — `paper-execute` → `execute` (old name still accepted for backwards compat)
- `tests/test_trade_executor.py` — 24 new tests, all green
- `README.md` — command table updated

## Test plan
- [ ] `execute` with paper broker → executes immediately, green PAPER label, no prompt
- [ ] `execute` with `TRADING_MODE=LIVE` + Fyers → shows red order preview, asks for confirmation
- [ ] Cancel at confirmation → no orders sent
- [ ] `TRADING_MODE=PAPER` with Fyers → executes as paper, shows yellow override warning
- [ ] `execute aggressive` / `execute conservative` → correct plan used
- [ ] All 374 tests pass in CI