### PR TITLE
feat: trading harness, alert fixes, risk debate, and pipeline improvements

### DIFF
--- a/agent/core.py
+++ b/agent/core.py
@@ -2008,9 +2008,17 @@ class TradingAgent:
 
         return response
 
-    def run_multi_agent_analysis(self, symbol: str, exchange: str = "NSE") -> str:
+    def run_multi_agent_analysis(
+        self, symbol: str, exchange: str = "NSE", risk_debate: bool = False
+    ) -> str:
         """
-        Run multi-agent analysis pipeline: 5 analysts + bull/bear debate + synthesis.
+        Run multi-agent analysis pipeline: analysts + bull/bear debate + synthesis.
+
+        Args:
+            symbol:      Stock symbol e.g. RELIANCE
+            exchange:    NSE (default) or BSE
+            risk_debate: Enable the 3-way risk debate (aggressive/conservative/neutral)
+                         after the investment debate. Adds 3 LLM calls. Default: False.
 
         Falls back to single-agent analysis if multi-agent fails.
         """
@@ -2022,6 +2030,7 @@ class TradingAgent:
                 llm_provider=self._provider,
                 parallel=True,
                 verbose=True,
+                risk_debate=risk_debate,
             )
             result = analyzer.analyze(symbol, exchange)
             self._last_trade_plans = getattr(analyzer, "last_trade_plans", {})

--- a/agent/deep_agent.py
+++ b/agent/deep_agent.py
@@ -279,7 +279,9 @@ class DeepAnalyzer:
                     style="magenta",
                 )
             t_risk = time.time()
-            risk_debate_result = multi._run_risk_debate(symbol, exchange, scorecard, debate, reports)
+            risk_debate_result = multi._run_risk_debate(
+                symbol, exchange, scorecard, debate, reports
+            )
             risk_debate_time = time.time() - t_risk
             if self.verbose:
                 console.print(f"[dim]Risk debate completed in {risk_debate_time:.1f}s[/dim]")

--- a/agent/deep_agent.py
+++ b/agent/deep_agent.py
@@ -218,10 +218,12 @@ class DeepAnalyzer:
         registry: ToolRegistry,
         llm_provider: Any,
         verbose: bool = True,
+        risk_debate: bool = False,
     ) -> None:
         self.registry = registry
         self.llm = llm_provider
         self.verbose = verbose
+        self.risk_debate = risk_debate
 
     def analyze(self, symbol: str, exchange: str = "NSE") -> str:
         """Run full LLM deep analysis."""
@@ -260,9 +262,27 @@ class DeepAnalyzer:
 
         t1 = time.time()
         # Create a temporary MultiAgentAnalyzer just for debate + synthesis
-        multi = MultiAgentAnalyzer(self.registry, self.llm, verbose=self.verbose)
+        multi = MultiAgentAnalyzer(
+            self.registry, self.llm, verbose=self.verbose, risk_debate=self.risk_debate
+        )
         debate = multi._run_debate(symbol, exchange, reports)
         debate_time = time.time() - t1
+
+        # ── Phase 2.5: Risk Debate ───────────────────────────
+        risk_debate_result = None
+        risk_debate_time = 0.0
+        if self.risk_debate and scorecard.verdict != "HOLD":
+            if self.verbose:
+                console.print()
+                console.rule(
+                    "[bold magenta]Risk Team — Aggressive / Conservative / Neutral[/bold magenta]",
+                    style="magenta",
+                )
+            t_risk = time.time()
+            risk_debate_result = multi._run_risk_debate(symbol, exchange, scorecard, debate, reports)
+            risk_debate_time = time.time() - t_risk
+            if self.verbose:
+                console.print(f"[dim]Risk debate completed in {risk_debate_time:.1f}s[/dim]")
 
         # ── Phase 3: Synthesis ───────────────────────────────
         if self.verbose:
@@ -270,7 +290,7 @@ class DeepAnalyzer:
             console.rule("[bold green]Deep Synthesis[/bold green]", style="green")
 
         t2 = time.time()
-        synthesis = multi._run_synthesis(symbol, exchange, reports, debate)
+        synthesis = multi._run_synthesis(symbol, exchange, reports, debate, risk_debate_result)
         synthesis_time = time.time() - t2
 
         # ── Trade plans ──────────────────────────────────────
@@ -305,12 +325,14 @@ class DeepAnalyzer:
         except Exception:
             pass
 
-        total = analyst_time + debate_time + synthesis_time
+        total = analyst_time + debate_time + risk_debate_time + synthesis_time
+        llm_calls = 11 + (3 if risk_debate_time > 0 else 0)
+        risk_str = f", risk: {risk_debate_time:.1f}s" if risk_debate_time > 0 else ""
         console.print(
             f"\n[dim]Deep analysis complete in {total:.1f}s "
-            f"(analysts: {analyst_time:.1f}s, debate: {debate_time:.1f}s, "
-            f"synthesis: {synthesis_time:.1f}s) — "
-            f"11 LLM calls[/dim]"
+            f"(analysts: {analyst_time:.1f}s, debate: {debate_time:.1f}s"
+            f"{risk_str}, synthesis: {synthesis_time:.1f}s) — "
+            f"{llm_calls} LLM calls[/dim]"
         )
         console.rule(style="magenta")
 

--- a/agent/deep_agent.py
+++ b/agent/deep_agent.py
@@ -1,7 +1,7 @@
 """
 agent/deep_agent.py
 ───────────────────
-Full LLM multi-agent mode ("--deep") — inspired by TradingAgents paper.
+Full LLM multi-agent mode ("--deep") — every agent is LLM-powered.
 
 Every agent is LLM-powered (vs default mode where analysts are pure Python).
 11+ LLM calls per analysis — expensive but much deeper reasoning.

--- a/agent/multi_agent.py
+++ b/agent/multi_agent.py
@@ -1533,8 +1533,7 @@ class MultiAgentAnalyzer:
             )
 
         debate_summary = (
-            f"Investment debate winner: {debate.winner}\n"
-            f"Facilitator summary: {debate.facilitator}"
+            f"Investment debate winner: {debate.winner}\nFacilitator summary: {debate.facilitator}"
         )
         scorecard_summary = scorecard.summary()
 
@@ -1550,15 +1549,21 @@ class MultiAgentAnalyzer:
         if self.verbose:
             console.print("[bold red]Aggressive[/bold red] debater — maximum upside, tight risk...")
         aggressive_view = self.llm.chat(
-            messages=[{"role": "user", "content": AGGRESSIVE_DEBATER_PROMPT.format(**shared_context)}],
+            messages=[
+                {"role": "user", "content": AGGRESSIVE_DEBATER_PROMPT.format(**shared_context)}
+            ],
             stream=self.verbose,
         )
 
         # Conservative debater
         if self.verbose:
-            console.print("\n[bold blue]Conservative[/bold blue] debater — capital preservation first...")
+            console.print(
+                "\n[bold blue]Conservative[/bold blue] debater — capital preservation first..."
+            )
         conservative_view = self.llm.chat(
-            messages=[{"role": "user", "content": CONSERVATIVE_DEBATER_PROMPT.format(**shared_context)}],
+            messages=[
+                {"role": "user", "content": CONSERVATIVE_DEBATER_PROMPT.format(**shared_context)}
+            ],
             stream=self.verbose,
         )
 
@@ -1566,11 +1571,16 @@ class MultiAgentAnalyzer:
         if self.verbose:
             console.print("\n[bold cyan]Neutral[/bold cyan] debater — calibrated middle path...")
         neutral_view = self.llm.chat(
-            messages=[{"role": "user", "content": NEUTRAL_DEBATER_PROMPT.format(
-                **shared_context,
-                aggressive_view=aggressive_view,
-                conservative_view=conservative_view,
-            )}],
+            messages=[
+                {
+                    "role": "user",
+                    "content": NEUTRAL_DEBATER_PROMPT.format(
+                        **shared_context,
+                        aggressive_view=aggressive_view,
+                        conservative_view=conservative_view,
+                    ),
+                }
+            ],
             stream=self.verbose,
         )
 

--- a/agent/multi_agent.py
+++ b/agent/multi_agent.py
@@ -1,8 +1,7 @@
 """
 agent/multi_agent.py
 ────────────────────
-Multi-agent stock analysis system inspired by the TradingAgents framework
-(Xiao et al., 2025 — https://arxiv.org/abs/2412.20138).
+Multi-agent stock analysis system for Indian markets.
 
 Architecture:
   ┌─────────────────────────────────────────────────────────────────┐
@@ -1683,6 +1682,10 @@ Weigh the bull and bear arguments against the analyst data. Consider:
 - Which side has stronger evidence?
 - What does the risk profile suggest?
 - Is the timing right (technicals, events, VIX)?
+
+**Decisiveness rule**: Do NOT default to HOLD simply because both sides raised valid points.
+Every debate has a stronger side — identify it and commit to that stance.
+HOLD is only correct when the evidence is genuinely split AND the risk/reward is unfavourable.
 
 Provide your FINAL VERDICT in this exact format:
 

--- a/agent/multi_agent.py
+++ b/agent/multi_agent.py
@@ -1045,11 +1045,13 @@ class MultiAgentAnalyzer:
         llm_provider: Any,
         parallel: bool = True,
         verbose: bool = True,
+        risk_debate: bool = False,
     ) -> None:
         self.registry = registry
         self.llm = llm_provider
         self.parallel = parallel
         self.verbose = verbose
+        self.risk_debate = risk_debate  # enable 3-way risk debate (aggressive/conservative/neutral)
 
         news_analyst = NewsMacroAnalyst(registry)
         news_analyst.set_llm(llm_provider)
@@ -1115,7 +1117,7 @@ class MultiAgentAnalyzer:
         # ── Phase 2.5: Risk Debate ───────────────────────────
         risk_debate: Optional[RiskDebateResult] = None
         risk_debate_time = 0.0
-        if scorecard.verdict != "HOLD":
+        if self.risk_debate and scorecard.verdict != "HOLD":
             if self.verbose:
                 console.print()
                 console.rule(

--- a/agent/multi_agent.py
+++ b/agent/multi_agent.py
@@ -45,7 +45,7 @@ import json
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional
 
 from rich.console import Console
 from rich.table import Table
@@ -194,6 +194,16 @@ class DebateResult:
 
 
 @dataclass
+class RiskDebateResult:
+    """Output from the three-way risk debate (aggressive / conservative / neutral)."""
+
+    aggressive_view: str  # argues for larger size, tighter stop, no hedge
+    conservative_view: str  # argues for smaller size, wider stop, protective hedge
+    neutral_view: str  # synthesises a calibrated middle path
+    consensus: str = ""  # brief consensus on sizing from the three views
+
+
+@dataclass
 class TradeRecommendation:
     """Final output from the multi-agent pipeline."""
 
@@ -210,7 +220,8 @@ class TradeRecommendation:
     risks: list[str]
     analyst_reports: list[AnalystReport]
     debate: DebateResult
-    raw_synthesis: str  # full LLM output
+    risk_debate: Optional[RiskDebateResult] = None  # None when verdict is HOLD
+    raw_synthesis: str = ""  # full LLM output
 
 
 # ── Analyst Agents (pure Python, no LLM) ─────────────────────
@@ -1011,11 +1022,13 @@ class MultiAgentAnalyzer:
     Orchestrates the full multi-agent analysis pipeline.
 
     Pipeline:
-      1. Run 5 analyst agents (parallel or sequential, 1 uses LLM for sentiment)
-      2. Feed analyst reports into bull/bear debate (2 LLM calls)
+      1. Run analyst agents (parallel or sequential)
+      2. Feed analyst reports into bull/bear debate (5 LLM calls)
+      2.5. Three-way risk debate: aggressive / conservative / neutral (3 LLM calls)
+           Skipped when scorecard verdict is HOLD — no point sizing a no-trade.
       3. Synthesize final verdict + trade recommendation (1 LLM call)
 
-    Total: 4 LLM calls per analysis.
+    Total: ~9 LLM calls per analysis (6 for debate stages, 1 synthesis, 1 news, 1 sentiment).
 
     Usage:
         from agent.multi_agent import MultiAgentAnalyzer
@@ -1099,13 +1112,29 @@ class MultiAgentAnalyzer:
         if self.verbose:
             self._print_debate(debate, debate_time)
 
+        # ── Phase 2.5: Risk Debate ───────────────────────────
+        risk_debate: Optional[RiskDebateResult] = None
+        risk_debate_time = 0.0
+        if scorecard.verdict != "HOLD":
+            if self.verbose:
+                console.print()
+                console.rule(
+                    "[bold magenta]Risk Team — Aggressive / Conservative / Neutral[/bold magenta]",
+                    style="magenta",
+                )
+            t_risk = time.time()
+            risk_debate = self._run_risk_debate(symbol, exchange, scorecard, debate, reports)
+            risk_debate_time = time.time() - t_risk
+            if self.verbose:
+                console.print(f"[dim]Risk debate completed in {risk_debate_time:.1f}s[/dim]")
+
         # ── Phase 3: Synthesis ───────────────────────────────
         if self.verbose:
             console.print()
             console.rule("[bold green]Fund Manager — Final Synthesis[/bold green]", style="green")
 
         t2 = time.time()
-        synthesis = self._run_synthesis(symbol, exchange, reports, debate)
+        synthesis = self._run_synthesis(symbol, exchange, reports, debate, risk_debate)
         synthesis_time = time.time() - t2
 
         # ── Phase 4: Store to Memory ─────────────────────────
@@ -1143,12 +1172,13 @@ class MultiAgentAnalyzer:
             pass  # trade plan generation is non-critical
 
         # Print timing summary
-        total = analyst_time + debate_time + synthesis_time
+        total = analyst_time + debate_time + risk_debate_time + synthesis_time
+        risk_str = f", risk: {risk_debate_time:.1f}s" if risk_debate_time > 0 else ""
         console.print()
         console.print(
             f"[dim]Analysis complete in {total:.1f}s "
-            f"(analysts: {analyst_time:.1f}s, debate: {debate_time:.1f}s, "
-            f"synthesis: {synthesis_time:.1f}s)[/dim]"
+            f"(analysts: {analyst_time:.1f}s, debate: {debate_time:.1f}s"
+            f"{risk_str}, synthesis: {synthesis_time:.1f}s)[/dim]"
         )
         console.rule(style="cyan")
         console.print()
@@ -1470,6 +1500,88 @@ class MultiAgentAnalyzer:
         """Display the bull/bear debate results."""
         console.print(f"\n[dim]Debate completed in {elapsed:.1f}s[/dim]")
 
+    # ── Phase 2.5: Risk Debate ───────────────────────────────
+
+    def _run_risk_debate(
+        self,
+        symbol: str,
+        exchange: str,
+        scorecard: AnalystScorecard,
+        debate: DebateResult,
+        reports: list[AnalystReport],
+    ) -> RiskDebateResult:
+        """
+        Three-way risk debate: Aggressive / Conservative / Neutral.
+
+        Each debater receives the scorecard + investment debate and argues
+        for a different position-sizing and risk-management approach.
+        A consensus note is derived from all three views.
+
+        Total: 3 LLM calls (one per debater).
+        Only called when scorecard.verdict != HOLD.
+        """
+        # Build shared context for all three debaters
+        risk_report = next((r for r in reports if r.analyst == "Risk Manager"), None)
+        risk_params = ""
+        if risk_report and not risk_report.error:
+            risk_params = (
+                f"Capital: {risk_report.data.get('capital', 'N/A')} | "
+                f"Max risk/trade: {risk_report.data.get('max_risk_per_trade', 'N/A')} | "
+                f"VIX: {risk_report.data.get('vix', 'N/A')}"
+            )
+
+        debate_summary = (
+            f"Investment debate winner: {debate.winner}\n"
+            f"Facilitator summary: {debate.facilitator}"
+        )
+        scorecard_summary = scorecard.summary()
+
+        shared_context = dict(
+            symbol=symbol,
+            exchange=exchange,
+            scorecard=scorecard_summary,
+            debate_summary=debate_summary,
+            risk_params=risk_params,
+        )
+
+        # Aggressive debater
+        if self.verbose:
+            console.print("[bold red]Aggressive[/bold red] debater — maximum upside, tight risk...")
+        aggressive_view = self.llm.chat(
+            messages=[{"role": "user", "content": AGGRESSIVE_DEBATER_PROMPT.format(**shared_context)}],
+            stream=self.verbose,
+        )
+
+        # Conservative debater
+        if self.verbose:
+            console.print("\n[bold blue]Conservative[/bold blue] debater — capital preservation first...")
+        conservative_view = self.llm.chat(
+            messages=[{"role": "user", "content": CONSERVATIVE_DEBATER_PROMPT.format(**shared_context)}],
+            stream=self.verbose,
+        )
+
+        # Neutral debater
+        if self.verbose:
+            console.print("\n[bold cyan]Neutral[/bold cyan] debater — calibrated middle path...")
+        neutral_view = self.llm.chat(
+            messages=[{"role": "user", "content": NEUTRAL_DEBATER_PROMPT.format(
+                **shared_context,
+                aggressive_view=aggressive_view,
+                conservative_view=conservative_view,
+            )}],
+            stream=self.verbose,
+        )
+
+        # Extract consensus sizing from neutral view (first line with % or ₹)
+        consensus = neutral_view.splitlines()[0] if neutral_view else ""
+
+        return RiskDebateResult(
+            aggressive_view=aggressive_view,
+            conservative_view=conservative_view,
+            neutral_view=neutral_view,
+            consensus=consensus,
+        )
+
     # ── Phase 3: Synthesis ───────────────────────────────────
 
     def _run_synthesis(
@@ -1478,6 +1590,7 @@ class MultiAgentAnalyzer:
         exchange: str,
         reports: list[AnalystReport],
         debate: DebateResult,
+        risk_debate: Optional[RiskDebateResult] = None,
     ) -> str:
         """
         Final synthesis: weigh all analyst reports + debate arguments,
@@ -1527,11 +1640,21 @@ class MultiAgentAnalyzer:
             debate_text += f"## Facilitator Summary\n{debate.facilitator}\n\n"
             debate_text += f"Debate Winner: {debate.winner}\n"
 
+        # Build risk debate section
+        risk_debate_text = ""
+        if risk_debate:
+            risk_debate_text = (
+                f"## Aggressive View\n{risk_debate.aggressive_view}\n\n"
+                f"## Conservative View\n{risk_debate.conservative_view}\n\n"
+                f"## Neutral Synthesis\n{risk_debate.neutral_view}"
+            )
+
         synthesis_prompt = SYNTHESIS_PROMPT.format(
             symbol=symbol,
             exchange=exchange,
             analyst_data=analyst_context,
             debate_text=debate_text,
+            risk_debate_text=risk_debate_text,
             risk_context=risk_context,
             memory_context=memory_context,
             pattern_context=pattern_context,
@@ -1668,6 +1791,9 @@ You must make the final call on {symbol} ({exchange}) after reviewing all eviden
 ## Research Debate (2 Rounds)
 {debate_text}
 
+## Risk Team Debate (Aggressive / Conservative / Neutral)
+{risk_debate_text}
+
 ## Risk Parameters
 {risk_context}
 
@@ -1682,6 +1808,7 @@ Weigh the bull and bear arguments against the analyst data. Consider:
 - Which side has stronger evidence?
 - What does the risk profile suggest?
 - Is the timing right (technicals, events, VIX)?
+- Where do the three risk views (aggressive/conservative/neutral) converge on sizing?
 
 **Decisiveness rule**: Do NOT default to HOLD simply because both sides raised valid points.
 Every debate has a stronger side — identify it and commit to that stance.
@@ -1711,6 +1838,85 @@ RISKS (2-3 bullets):
 - [secondary risk]
 
 Keep the output concise and terminal-friendly. Use bullets. All prices in INR."""
+
+AGGRESSIVE_DEBATER_PROMPT = """You are the AGGRESSIVE RISK MANAGER at an Indian trading firm.
+The investment team has decided to trade {symbol} ({exchange}).
+
+## Scorecard
+{scorecard}
+
+## Investment Debate Outcome
+{debate_summary}
+
+## Risk Parameters
+{risk_params}
+
+Your role: argue for the most aggressive but still rational position sizing.
+
+Make the case for:
+1. **Position size**: Why should we deploy maximum permitted capital (up to 20% of portfolio)?
+2. **Stop-loss**: Argue for a tighter stop — we have conviction, don't give back too much if wrong
+3. **Strategy**: Prefer higher-leverage instruments (options, futures) over delivery if the setup warrants it
+4. **Hedging**: Minimal or no hedge — hedges cost premium and dilute returns when we're right
+
+Be specific: suggest a concrete position size (% of capital or lot count), stop level, and strategy.
+Cite the strongest signals from the scorecard and debate to justify maximum aggression.
+Keep it to 150-200 words. All prices in INR."""
+
+CONSERVATIVE_DEBATER_PROMPT = """You are the CONSERVATIVE RISK MANAGER at an Indian trading firm.
+The investment team has decided to trade {symbol} ({exchange}).
+
+## Scorecard
+{scorecard}
+
+## Investment Debate Outcome
+{debate_summary}
+
+## Risk Parameters
+{risk_params}
+
+Your role: argue for a cautious, capital-preserving approach to this trade.
+
+Make the case for:
+1. **Position size**: Why should we start small (3-5% of capital) and add only on confirmation?
+2. **Stop-loss**: Argue for a wider stop — avoid being shaken out by normal volatility
+3. **Strategy**: Prefer defined-risk structures (spreads, delivery) over naked options or futures
+4. **Hedging**: Recommend a protective hedge — the cost is worth the downside protection given market conditions
+
+Be specific: suggest a concrete position size, stop level, hedge instrument, and entry approach (phased or single).
+Cite the weakest signals or biggest risks from the scorecard and debate to justify caution.
+Keep it to 150-200 words. All prices in INR."""
+
+NEUTRAL_DEBATER_PROMPT = """You are the NEUTRAL RISK ARBITRATOR at an Indian trading firm.
+You have heard two positions on how to size the {symbol} ({exchange}) trade.
+
+## Scorecard
+{scorecard}
+
+## Investment Debate Outcome
+{debate_summary}
+
+## Risk Parameters
+{risk_params}
+
+## Aggressive View
+{aggressive_view}
+
+## Conservative View
+{conservative_view}
+
+Your role: synthesise a calibrated, evidence-based position between the two extremes.
+
+Provide:
+1. **Recommended position size**: A specific % of capital or lot count — not a range, a number
+2. **Stop-loss level**: One specific price or % from entry
+3. **Strategy**: The single best instrument/structure for this setup
+4. **Hedge (if any)**: Only if VIX is elevated or conviction is below 65%
+5. **Entry approach**: All-in at market, or phased entry with levels
+
+Acknowledge the strongest point from each side, then commit to one calibrated recommendation.
+Keep it to 150-200 words. All prices in INR."""
+
 
 NEWS_SENTIMENT_PROMPT = """You are a NEWS & SENTIMENT ANALYST at an Indian trading firm.
 Analyze the following news headlines and macro data for {symbol} ({exchange}).

--- a/app/repl.py
+++ b/app/repl.py
@@ -1395,9 +1395,13 @@ def run_repl(broker: BrokerAPI) -> None:
                 from engine.output import parse_output_flags, handle_output_flags
 
                 clean_args, wants_pdf, wants_explain, _ = parse_output_flags(args)
+                wants_risk_debate = "--risk-debate" in clean_args
+                clean_args = [a for a in clean_args if a != "--risk-debate"]
                 symbol = clean_args[0].upper() if clean_args else ""
                 if not symbol:
-                    console.print("[red]Usage: deep-analyze <SYMBOL> [--pdf] [--explain][/red]")
+                    console.print(
+                        "[red]Usage: deep-analyze <SYMBOL> [--risk-debate] [--pdf] [--explain][/red]"
+                    )
                 else:
                     agent = get_agent()
                     try:
@@ -1406,6 +1410,7 @@ def run_repl(broker: BrokerAPI) -> None:
                         deep = DeepAnalyzer(
                             registry=agent._registry,
                             llm_provider=agent._provider,
+                            risk_debate=wants_risk_debate,
                         )
                         output = deep.analyze(symbol)
                         _last_output = output or ""

--- a/app/repl.py
+++ b/app/repl.py
@@ -1204,12 +1204,16 @@ def run_repl(broker: BrokerAPI) -> None:
                 from engine.output import parse_output_flags, handle_output_flags
 
                 clean_args, wants_pdf, wants_explain, _ = parse_output_flags(args)
+                wants_risk_debate = "--risk-debate" in clean_args
+                clean_args = [a for a in clean_args if a != "--risk-debate"]
                 symbol = clean_args[0].upper() if clean_args else ""
                 if not symbol:
-                    console.print("[red]Usage: analyze <SYMBOL> [--pdf] [--explain][/red]")
+                    console.print(
+                        "[red]Usage: analyze <SYMBOL> [--risk-debate] [--pdf] [--explain][/red]"
+                    )
                 else:
                     agent = get_agent()
-                    output = agent.run_multi_agent_analysis(symbol)
+                    output = agent.run_multi_agent_analysis(symbol, risk_debate=wants_risk_debate)
                     _last_output = output or ""
                     _last_command = f"Analysis {symbol}"
                     _last_trade_plans = getattr(agent, "_last_trade_plans", {})

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -236,6 +236,7 @@ class TestOllamaProvider:
         mock_sdk = self._mock_sdk()
         with patch.dict("sys.modules", {"openai": mock_sdk}):
             from agent.tools import build_registry
+
             p = get_provider(provider="ollama", registry=build_registry())
         assert isinstance(p, OpenAIProvider)
 
@@ -251,6 +252,7 @@ class TestOllamaProvider:
         mock_sdk = self._mock_sdk()
         with patch.dict("sys.modules", {"openai": mock_sdk}):
             from agent.tools import build_registry
+
             p = get_provider(provider="ollama", registry=build_registry())
         assert "localhost" in p.provider_name
         assert "11434" in p.provider_name
@@ -262,6 +264,7 @@ class TestOllamaProvider:
         mock_sdk = self._mock_sdk()
         with patch.dict("sys.modules", {"openai": mock_sdk}):
             from agent.tools import build_registry
+
             p = get_provider(provider="ollama", registry=build_registry())
         assert "192.168.1.10" in p.provider_name
 
@@ -272,6 +275,7 @@ class TestOllamaProvider:
         mock_sdk = self._mock_sdk()
         with patch.dict("sys.modules", {"openai": mock_sdk}):
             from agent.tools import build_registry
+
             p = get_provider(provider="ollama", registry=build_registry())
         assert p.model == "mistral-nemo"
 
@@ -298,6 +302,7 @@ class TestOllamaProvider:
         mock_sdk = self._mock_sdk()
         with patch.dict("sys.modules", {"openai": mock_sdk}):
             from agent.tools import build_registry
+
             p = get_provider(provider="ollama", registry=build_registry())
         # Should look like "localhost:11434 / llama3.1"
         assert OLLAMA_DEFAULT_MODEL in p.provider_name
@@ -311,5 +316,6 @@ class TestOllamaProvider:
         # Should not raise even with no keys set
         with patch.dict("sys.modules", {"openai": mock_sdk}):
             from agent.tools import build_registry
+
             p = get_provider(provider="ollama", registry=build_registry())
         assert p is not None

--- a/tests/test_agent_core.py
+++ b/tests/test_agent_core.py
@@ -8,6 +8,7 @@ from agent.core import (
     _user_msg,
     _assistant_msg,
     _auto_detect_provider,
+    get_provider,
     PROVIDER_OPENAI,
     PROVIDER_GEMINI,
     PROVIDER_ANTHROPIC,
@@ -19,6 +20,7 @@ from agent.core import (
     ANTHROPIC_DEFAULT_MODEL,
     OLLAMA_DEFAULT_MODEL,
     ClaudeCLIProvider,
+    OpenAIProvider,
     MAX_TOOL_ROUNDS,
     ALL_PROVIDERS,
     _print_tool_call,
@@ -217,3 +219,97 @@ class TestPrintToolCall:
         _print_tool_call("get_quote", {"symbol": "RELIANCE"})
         _print_tool_call("unknown_tool", {})
         _print_tool_call("tool", {"a": 1, "b": [1, 2, 3]})
+
+
+# ── Ollama provider ──────────────────────────────────────────
+
+
+class TestOllamaProvider:
+    """Ollama routes through OpenAIProvider with a local base_url. No API key needed."""
+
+    def _mock_sdk(self):
+        return MagicMock()
+
+    def test_get_provider_ollama_returns_openai_provider(self, monkeypatch):
+        """get_provider('ollama') should return an OpenAIProvider instance."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        mock_sdk = self._mock_sdk()
+        with patch.dict("sys.modules", {"openai": mock_sdk}):
+            from agent.tools import build_registry
+            p = get_provider(provider="ollama", registry=build_registry())
+        assert isinstance(p, OpenAIProvider)
+
+    def test_default_model_is_llama31(self):
+        """Default Ollama model should be llama3.1."""
+        assert _default_model(PROVIDER_OLLAMA) == OLLAMA_DEFAULT_MODEL
+        assert OLLAMA_DEFAULT_MODEL == "llama3.1"
+
+    def test_default_base_url_is_localhost(self, monkeypatch):
+        """Without OLLAMA_BASE_URL set, should use localhost:11434."""
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        mock_sdk = self._mock_sdk()
+        with patch.dict("sys.modules", {"openai": mock_sdk}):
+            from agent.tools import build_registry
+            p = get_provider(provider="ollama", registry=build_registry())
+        assert "localhost" in p.provider_name
+        assert "11434" in p.provider_name
+
+    def test_custom_base_url_via_env(self, monkeypatch):
+        """OLLAMA_BASE_URL env var should override the default endpoint."""
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://192.168.1.10:11434/v1")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        mock_sdk = self._mock_sdk()
+        with patch.dict("sys.modules", {"openai": mock_sdk}):
+            from agent.tools import build_registry
+            p = get_provider(provider="ollama", registry=build_registry())
+        assert "192.168.1.10" in p.provider_name
+
+    def test_custom_model_via_env(self, monkeypatch):
+        """OLLAMA_MODEL env var should override the default model."""
+        monkeypatch.setenv("OLLAMA_MODEL", "mistral-nemo")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        mock_sdk = self._mock_sdk()
+        with patch.dict("sys.modules", {"openai": mock_sdk}):
+            from agent.tools import build_registry
+            p = get_provider(provider="ollama", registry=build_registry())
+        assert p.model == "mistral-nemo"
+
+    def test_auto_detect_from_ollama_base_url(self, monkeypatch):
+        """Setting OLLAMA_BASE_URL should auto-detect Ollama as the provider."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434/v1")
+        assert _auto_detect_provider() == PROVIDER_OLLAMA
+
+    def test_auto_detect_from_ollama_model_env(self, monkeypatch):
+        """Setting OLLAMA_MODEL should auto-detect Ollama as the provider."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setenv("OLLAMA_MODEL", "qwen2.5-coder")
+        assert _auto_detect_provider() == PROVIDER_OLLAMA
+
+    def test_provider_name_includes_model(self, monkeypatch):
+        """provider_name should show host and model for Ollama."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        mock_sdk = self._mock_sdk()
+        with patch.dict("sys.modules", {"openai": mock_sdk}):
+            from agent.tools import build_registry
+            p = get_provider(provider="ollama", registry=build_registry())
+        # Should look like "localhost:11434 / llama3.1"
+        assert OLLAMA_DEFAULT_MODEL in p.provider_name
+
+    def test_no_api_key_required(self, monkeypatch):
+        """Ollama should construct without any API key in the environment."""
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        mock_sdk = self._mock_sdk()
+        # Should not raise even with no keys set
+        with patch.dict("sys.modules", {"openai": mock_sdk}):
+            from agent.tools import build_registry
+            p = get_provider(provider="ollama", registry=build_registry())
+        assert p is not None

--- a/tests/test_risk_debate.py
+++ b/tests/test_risk_debate.py
@@ -231,7 +231,7 @@ class TestRunRiskDebate:
 
 
 class TestRiskDebateSkippedOnHold:
-    def _build_analyzer_with_mocked_phases(self, verdict: str):
+    def _build_analyzer(self, verdict: str, risk_debate_flag: bool = True):
         """Build an analyzer with all sub-phases mocked so we can inspect calls."""
         mock_registry = MagicMock()
         mock_llm = _make_mock_llm()
@@ -240,12 +240,14 @@ class TestRiskDebateSkippedOnHold:
         analyzer.llm = mock_llm
         analyzer.parallel = False
         analyzer.verbose = False
+        analyzer.risk_debate = risk_debate_flag
         analyzer.analysts = []
         analyzer.last_trade_plans = {}
         return analyzer
 
     def test_risk_debate_not_called_when_hold(self):
-        analyzer = self._build_analyzer_with_mocked_phases("HOLD")
+        """Risk debate skipped when verdict is HOLD even if flag is on."""
+        analyzer = self._build_analyzer("HOLD", risk_debate_flag=True)
         scorecard = _make_scorecard("HOLD")
         debate = _make_debate()
         reports = [_make_report()]
@@ -265,9 +267,32 @@ class TestRiskDebateSkippedOnHold:
 
         mock_risk.assert_not_called()
 
+    def test_risk_debate_not_called_when_flag_off(self):
+        """Risk debate skipped when flag is False, even with a BUY verdict."""
+        analyzer = self._build_analyzer("BUY", risk_debate_flag=False)
+        scorecard = _make_scorecard("BUY")
+        debate = _make_debate()
+        reports = [_make_report()]
+
+        with (
+            patch.object(analyzer, "_run_risk_debate") as mock_risk,
+            patch.object(analyzer, "_run_synthesis", return_value="synthesis"),
+            patch.object(analyzer, "_run_analysts", return_value=reports),
+            patch.object(analyzer, "_run_debate", return_value=debate),
+            patch.object(analyzer, "_print_analyst_summary"),
+            patch.object(analyzer, "_print_debate"),
+            patch("agent.multi_agent.compute_scorecard", return_value=scorecard),
+            patch("agent.multi_agent.console"),
+            patch("engine.memory.trade_memory.store_from_analysis"),
+        ):
+            analyzer.analyze("RELIANCE")
+
+        mock_risk.assert_not_called()
+
     @pytest.mark.parametrize("verdict", ["BUY", "SELL", "STRONG_BUY", "STRONG_SELL"])
-    def test_risk_debate_called_for_non_hold_verdicts(self, verdict):
-        analyzer = self._build_analyzer_with_mocked_phases(verdict)
+    def test_risk_debate_called_when_flag_on_and_non_hold(self, verdict):
+        """Risk debate runs when flag=True and verdict is not HOLD."""
+        analyzer = self._build_analyzer(verdict, risk_debate_flag=True)
         scorecard = _make_scorecard(verdict)
         debate = _make_debate()
         reports = [_make_report()]

--- a/tests/test_risk_debate.py
+++ b/tests/test_risk_debate.py
@@ -1,0 +1,339 @@
+"""
+tests/test_risk_debate.py
+─────────────────────────
+Tests for the three-way risk debate (aggressive / conservative / neutral)
+added to MultiAgentAnalyzer as Phase 2.5.
+
+Covers:
+  - RiskDebateResult dataclass fields
+  - _run_risk_debate() calls correct prompts and returns RiskDebateResult
+  - Risk debate skipped when scorecard verdict is HOLD
+  - Risk debate runs when verdict is BUY / SELL / STRONG_BUY / STRONG_SELL
+  - Synthesis prompt receives risk_debate_text when debate ran
+  - Synthesis prompt receives empty risk_debate_text when debate skipped
+  - AGGRESSIVE / CONSERVATIVE / NEUTRAL prompt templates contain key phrases
+  - Full analyze() pipeline integration (mocked LLM)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from agent.multi_agent import (
+    RiskDebateResult,
+    DebateResult,
+    AnalystReport,
+    AnalystScorecard,
+    MultiAgentAnalyzer,
+    AGGRESSIVE_DEBATER_PROMPT,
+    CONSERVATIVE_DEBATER_PROMPT,
+    NEUTRAL_DEBATER_PROMPT,
+    SYNTHESIS_PROMPT,
+)
+
+
+# ── Fixtures ──────────────────────────────────────────────────
+
+
+def _make_scorecard(verdict: str = "BUY") -> AnalystScorecard:
+    return AnalystScorecard(
+        verdict=verdict,
+        weighted_total=10.0,
+        agreement=75.0,
+        scores={"Technical": 5.0, "Fundamental": 5.0},
+        weights={"Technical": 0.5, "Fundamental": 0.5},
+    )
+
+
+def _make_debate() -> DebateResult:
+    return DebateResult(
+        bull_argument="Strong bull case",
+        bear_argument="Moderate bear case",
+        bull_rebuttal="Bull rebuts",
+        bear_rebuttal="Bear final",
+        facilitator="WINNER: BULL",
+        winner="BULL",
+        rounds=2,
+    )
+
+
+def _make_report(analyst: str = "Technical", verdict: str = "BULLISH") -> AnalystReport:
+    return AnalystReport(
+        analyst=analyst,
+        verdict=verdict,
+        score=5.0,
+        confidence=70,
+        key_points=["key point"],
+        data={},
+    )
+
+
+def _make_mock_llm(responses: list[str] | None = None) -> MagicMock:
+    """Return a mock LLM provider whose chat() returns responses in sequence."""
+    mock = MagicMock()
+    if responses:
+        mock.chat.side_effect = responses
+    else:
+        mock.chat.return_value = "mock LLM response"
+    return mock
+
+
+# ── RiskDebateResult dataclass ────────────────────────────────
+
+
+class TestRiskDebateResultDataclass:
+    def test_required_fields(self):
+        r = RiskDebateResult(
+            aggressive_view="go big",
+            conservative_view="go small",
+            neutral_view="go medium",
+        )
+        assert r.aggressive_view == "go big"
+        assert r.conservative_view == "go small"
+        assert r.neutral_view == "go medium"
+
+    def test_consensus_defaults_to_empty(self):
+        r = RiskDebateResult(
+            aggressive_view="a",
+            conservative_view="b",
+            neutral_view="c",
+        )
+        assert r.consensus == ""
+
+    def test_consensus_set_explicitly(self):
+        r = RiskDebateResult(
+            aggressive_view="a",
+            conservative_view="b",
+            neutral_view="c",
+            consensus="5% capital, SL at 2300",
+        )
+        assert r.consensus == "5% capital, SL at 2300"
+
+
+# ── Prompt template sanity ────────────────────────────────────
+
+
+class TestRiskDebatePrompts:
+    def test_aggressive_prompt_contains_key_themes(self):
+        rendered = AGGRESSIVE_DEBATER_PROMPT.format(
+            symbol="RELIANCE", exchange="NSE",
+            scorecard="BUY 75%", debate_summary="WINNER: BULL",
+            risk_params="Capital: ₹2L | VIX: 14",
+        )
+        assert "AGGRESSIVE" in rendered
+        assert "position size" in rendered.lower()
+        assert "stop" in rendered.lower()
+
+    def test_conservative_prompt_contains_key_themes(self):
+        rendered = CONSERVATIVE_DEBATER_PROMPT.format(
+            symbol="RELIANCE", exchange="NSE",
+            scorecard="BUY 75%", debate_summary="WINNER: BULL",
+            risk_params="Capital: ₹2L | VIX: 14",
+        )
+        assert "CONSERVATIVE" in rendered
+        assert "hedge" in rendered.lower()
+        assert "capital" in rendered.lower()
+
+    def test_neutral_prompt_includes_both_views(self):
+        rendered = NEUTRAL_DEBATER_PROMPT.format(
+            symbol="RELIANCE", exchange="NSE",
+            scorecard="BUY 75%", debate_summary="WINNER: BULL",
+            risk_params="Capital: ₹2L | VIX: 14",
+            aggressive_view="go big",
+            conservative_view="go small",
+        )
+        assert "go big" in rendered
+        assert "go small" in rendered
+        assert "NEUTRAL" in rendered
+
+    def test_synthesis_prompt_has_risk_debate_placeholder(self):
+        assert "{risk_debate_text}" in SYNTHESIS_PROMPT
+
+
+# ── _run_risk_debate() ────────────────────────────────────────
+
+
+class TestRunRiskDebate:
+    def _make_analyzer(self, llm_responses=None):
+        mock_registry = MagicMock()
+        mock_llm = _make_mock_llm(llm_responses or ["aggressive", "conservative", "neutral"])
+        analyzer = MultiAgentAnalyzer.__new__(MultiAgentAnalyzer)
+        analyzer.registry = mock_registry
+        analyzer.llm = mock_llm
+        analyzer.verbose = False
+        return analyzer, mock_llm
+
+    def test_returns_risk_debate_result(self):
+        analyzer, _ = self._make_analyzer()
+        result = analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        assert isinstance(result, RiskDebateResult)
+
+    def test_calls_llm_three_times(self):
+        analyzer, mock_llm = self._make_analyzer()
+        analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        assert mock_llm.chat.call_count == 3
+
+    def test_aggressive_view_from_first_call(self):
+        analyzer, _ = self._make_analyzer(["aggressive_resp", "conservative_resp", "neutral_resp"])
+        result = analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        assert result.aggressive_view == "aggressive_resp"
+
+    def test_conservative_view_from_second_call(self):
+        analyzer, _ = self._make_analyzer(["a", "conservative_resp", "n"])
+        result = analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        assert result.conservative_view == "conservative_resp"
+
+    def test_neutral_view_from_third_call(self):
+        analyzer, _ = self._make_analyzer(["a", "c", "neutral_resp"])
+        result = analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        assert result.neutral_view == "neutral_resp"
+
+    def test_consensus_is_first_line_of_neutral_view(self):
+        neutral = "5% capital, SL at ₹2300\nmore detail here"
+        analyzer, _ = self._make_analyzer(["a", "c", neutral])
+        result = analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        assert result.consensus == "5% capital, SL at ₹2300"
+
+    def test_neutral_prompt_includes_aggressive_and_conservative_views(self):
+        analyzer, mock_llm = self._make_analyzer(["agg_view", "cons_view", "neutral_view"])
+        analyzer._run_risk_debate(
+            "RELIANCE", "NSE",
+            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+        )
+        # Third call (neutral) should include the first two views
+        third_call_content = mock_llm.chat.call_args_list[2][1]["messages"][0]["content"]
+        assert "agg_view" in third_call_content
+        assert "cons_view" in third_call_content
+
+
+# ── Risk debate skipped on HOLD ───────────────────────────────
+
+
+class TestRiskDebateSkippedOnHold:
+    def _build_analyzer_with_mocked_phases(self, verdict: str):
+        """Build an analyzer with all sub-phases mocked so we can inspect calls."""
+        mock_registry = MagicMock()
+        mock_llm = _make_mock_llm()
+        analyzer = MultiAgentAnalyzer.__new__(MultiAgentAnalyzer)
+        analyzer.registry = mock_registry
+        analyzer.llm = mock_llm
+        analyzer.parallel = False
+        analyzer.verbose = False
+        analyzer.analysts = []
+        analyzer.last_trade_plans = {}
+        return analyzer
+
+    def test_risk_debate_not_called_when_hold(self):
+        analyzer = self._build_analyzer_with_mocked_phases("HOLD")
+        scorecard = _make_scorecard("HOLD")
+        debate = _make_debate()
+        reports = [_make_report()]
+
+        with (
+            patch.object(analyzer, "_run_risk_debate") as mock_risk,
+            patch.object(analyzer, "_run_synthesis", return_value="synthesis"),
+            patch.object(analyzer, "_run_analysts", return_value=reports),
+            patch.object(analyzer, "_run_debate", return_value=debate),
+            patch.object(analyzer, "_print_analyst_summary"),
+            patch.object(analyzer, "_print_debate"),
+            patch("agent.multi_agent.compute_scorecard", return_value=scorecard),
+            patch("agent.multi_agent.console"),
+            patch("engine.memory.trade_memory.store_from_analysis"),
+        ):
+            analyzer.analyze("RELIANCE")
+
+        mock_risk.assert_not_called()
+
+    @pytest.mark.parametrize("verdict", ["BUY", "SELL", "STRONG_BUY", "STRONG_SELL"])
+    def test_risk_debate_called_for_non_hold_verdicts(self, verdict):
+        analyzer = self._build_analyzer_with_mocked_phases(verdict)
+        scorecard = _make_scorecard(verdict)
+        debate = _make_debate()
+        reports = [_make_report()]
+        mock_risk_result = RiskDebateResult("a", "c", "n", "consensus")
+
+        with (
+            patch.object(analyzer, "_run_risk_debate", return_value=mock_risk_result) as mock_risk,
+            patch.object(analyzer, "_run_synthesis", return_value="synthesis"),
+            patch.object(analyzer, "_run_analysts", return_value=reports),
+            patch.object(analyzer, "_run_debate", return_value=debate),
+            patch.object(analyzer, "_print_analyst_summary"),
+            patch.object(analyzer, "_print_debate"),
+            patch("agent.multi_agent.compute_scorecard", return_value=scorecard),
+            patch("agent.multi_agent.console"),
+            patch("engine.memory.trade_memory.store_from_analysis"),
+        ):
+            analyzer.analyze("RELIANCE")
+
+        mock_risk.assert_called_once()
+
+
+# ── _run_synthesis receives risk debate text ──────────────────
+
+
+class TestSynthesisReceivesRiskDebate:
+    def _make_analyzer(self):
+        mock_registry = MagicMock()
+        mock_llm = _make_mock_llm()
+        analyzer = MultiAgentAnalyzer.__new__(MultiAgentAnalyzer)
+        analyzer.registry = mock_registry
+        analyzer.llm = mock_llm
+        analyzer.verbose = False
+        return analyzer
+
+    def test_synthesis_prompt_includes_risk_views_when_debate_ran(self):
+        analyzer = self._make_analyzer()
+        risk_debate = RiskDebateResult(
+            aggressive_view="go big",
+            conservative_view="go small",
+            neutral_view="go medium",
+        )
+        reports = [_make_report("Risk Manager", "NEUTRAL")]
+        reports[0].data = {}
+
+        with (
+            patch("engine.memory.trade_memory.get_context_for_symbol", return_value=""),
+            patch("engine.patterns.get_pattern_context", return_value=""),
+        ):
+            analyzer._run_synthesis("RELIANCE", "NSE", reports, _make_debate(), risk_debate)
+
+        call_content = analyzer.llm.chat.call_args[1]["messages"][0]["content"]
+        assert "go big" in call_content
+        assert "go small" in call_content
+        assert "go medium" in call_content
+
+    def test_synthesis_prompt_risk_section_empty_when_no_debate(self):
+        analyzer = self._make_analyzer()
+        reports = [_make_report("Risk Manager", "NEUTRAL")]
+        reports[0].data = {}
+
+        with (
+            patch("engine.memory.trade_memory.get_context_for_symbol", return_value=""),
+            patch("engine.patterns.get_pattern_context", return_value=""),
+        ):
+            analyzer._run_synthesis("RELIANCE", "NSE", reports, _make_debate(), None)
+
+        call_content = analyzer.llm.chat.call_args[1]["messages"][0]["content"]
+        # Section header still present but content is empty
+        assert "Risk Team Debate" in call_content

--- a/tests/test_risk_debate.py
+++ b/tests/test_risk_debate.py
@@ -118,8 +118,10 @@ class TestRiskDebateResultDataclass:
 class TestRiskDebatePrompts:
     def test_aggressive_prompt_contains_key_themes(self):
         rendered = AGGRESSIVE_DEBATER_PROMPT.format(
-            symbol="RELIANCE", exchange="NSE",
-            scorecard="BUY 75%", debate_summary="WINNER: BULL",
+            symbol="RELIANCE",
+            exchange="NSE",
+            scorecard="BUY 75%",
+            debate_summary="WINNER: BULL",
             risk_params="Capital: ₹2L | VIX: 14",
         )
         assert "AGGRESSIVE" in rendered
@@ -128,8 +130,10 @@ class TestRiskDebatePrompts:
 
     def test_conservative_prompt_contains_key_themes(self):
         rendered = CONSERVATIVE_DEBATER_PROMPT.format(
-            symbol="RELIANCE", exchange="NSE",
-            scorecard="BUY 75%", debate_summary="WINNER: BULL",
+            symbol="RELIANCE",
+            exchange="NSE",
+            scorecard="BUY 75%",
+            debate_summary="WINNER: BULL",
             risk_params="Capital: ₹2L | VIX: 14",
         )
         assert "CONSERVATIVE" in rendered
@@ -138,8 +142,10 @@ class TestRiskDebatePrompts:
 
     def test_neutral_prompt_includes_both_views(self):
         rendered = NEUTRAL_DEBATER_PROMPT.format(
-            symbol="RELIANCE", exchange="NSE",
-            scorecard="BUY 75%", debate_summary="WINNER: BULL",
+            symbol="RELIANCE",
+            exchange="NSE",
+            scorecard="BUY 75%",
+            debate_summary="WINNER: BULL",
             risk_params="Capital: ₹2L | VIX: 14",
             aggressive_view="go big",
             conservative_view="go small",
@@ -168,40 +174,55 @@ class TestRunRiskDebate:
     def test_returns_risk_debate_result(self):
         analyzer, _ = self._make_analyzer()
         result = analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         assert isinstance(result, RiskDebateResult)
 
     def test_calls_llm_three_times(self):
         analyzer, mock_llm = self._make_analyzer()
         analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         assert mock_llm.chat.call_count == 3
 
     def test_aggressive_view_from_first_call(self):
         analyzer, _ = self._make_analyzer(["aggressive_resp", "conservative_resp", "neutral_resp"])
         result = analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         assert result.aggressive_view == "aggressive_resp"
 
     def test_conservative_view_from_second_call(self):
         analyzer, _ = self._make_analyzer(["a", "conservative_resp", "n"])
         result = analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         assert result.conservative_view == "conservative_resp"
 
     def test_neutral_view_from_third_call(self):
         analyzer, _ = self._make_analyzer(["a", "c", "neutral_resp"])
         result = analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         assert result.neutral_view == "neutral_resp"
 
@@ -209,16 +230,22 @@ class TestRunRiskDebate:
         neutral = "5% capital, SL at ₹2300\nmore detail here"
         analyzer, _ = self._make_analyzer(["a", "c", neutral])
         result = analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         assert result.consensus == "5% capital, SL at ₹2300"
 
     def test_neutral_prompt_includes_aggressive_and_conservative_views(self):
         analyzer, mock_llm = self._make_analyzer(["agg_view", "cons_view", "neutral_view"])
         analyzer._run_risk_debate(
-            "RELIANCE", "NSE",
-            _make_scorecard("BUY"), _make_debate(), [_make_report()],
+            "RELIANCE",
+            "NSE",
+            _make_scorecard("BUY"),
+            _make_debate(),
+            [_make_report()],
         )
         # Third call (neutral) should include the first two views
         third_call_content = mock_llm.chat.call_args_list[2][1]["messages"][0]["content"]

--- a/tests/test_risk_debate.py
+++ b/tests/test_risk_debate.py
@@ -17,8 +17,7 @@ Covers:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

10 commits covering the trading harness, alert reliability fixes, three-way risk debate, Ollama test coverage, and prompt improvements.

---

## Trading Harness — closes #85

New `agent/harness.py` — Claude Code-style agentic loop for Indian markets.

- **Hierarchical TRADER.md** loading: `~/.trading_platform/TRADER.md` → `./TRADER.md` → `./TRADER.local.md` (like CLAUDE.md)
- **3 permission modes** via `HARNESS_MODE` env var:
  - `prompt` (default) — confirm before `execute_trade`
  - `plan` — full analysis first, confirm once at the end
  - `auto` — read-only, `execute_trade` blocked entirely
- **Tool flags**: `is_read_only`, `is_destructive`, `is_concurrency_safe`, `permission`
- **Concurrent tool execution**: all 45 base tools run in parallel via `ThreadPoolExecutor`
- **JSONL session history**: `~/.trading_platform/harness_history.jsonl` — context persists across REPL calls
- **REPL**: `harness <question>`

---

## Alert fixes

**Storm fix** (`fix(alerts): stop repeated firing and outside-market-hours alerts`):
- `_is_market_hours()` — blocks polling/WebSocket evaluation outside 9:15–15:30 IST Mon–Fri
- `threading.Lock` on `_on_tick` — prevents race condition where multiple threads fire the same alert

**Duplicate guard** (`fix(alerts): prevent duplicate alerts from repeated add_price_alert`):
- `add_price_alert` / `add_technical_alert` return existing alert if identical non-triggered one exists
- Root cause: `trade_executor` calling `add_price_alert` on every `execute_trade` created 49× `RELIANCE ABOVE 2600` duplicates

---

## Three-way risk debate — closes #93

New Phase 2.5 in `MultiAgentAnalyzer` and `DeepAnalyzer`, opt-in via `--risk-debate` flag.

After the bull/bear investment debate, three risk perspectives argue position sizing:
- **Aggressive** — maximum size, tight stop, minimal hedge
- **Conservative** — small starter, wide stop, protective hedge
- **Neutral** — commits to one specific number (size, stop, strategy, entry approach)

The neutral view feeds into `SYNTHESIS_PROMPT` as `{risk_debate_text}`.

**Skipped when**: verdict is HOLD, or `--risk-debate` not passed.

```
analyze RELIANCE --risk-debate       # +3 LLM calls
deep-analyze RELIANCE --risk-debate  # +3 LLM calls (14 total)
```

---

## Prompt improvements

- Removed external framework references from `multi_agent.py` and `deep_agent.py` docstrings
- Added decisiveness rule to `SYNTHESIS_PROMPT`: Fund Manager must not default to HOLD when both sides have valid points

---

## Ollama — closes #88

8 dedicated tests in `TestOllamaProvider` (was already implemented, just missing test coverage):
- Construction, default model, default base URL, `OLLAMA_BASE_URL` override, `OLLAMA_MODEL` override, auto-detection, no API key required

---

## Test plan

- [x] `pytest tests/test_harness.py` — 61 tests
- [x] `pytest tests/test_alerts_webhook.py` — 21 tests (7 dedup cases)
- [x] `pytest tests/test_risk_debate.py` — 22 tests
- [x] `pytest tests/test_agent_core.py` — 31 tests (8 Ollama)
- [x] `pytest tests/test_trade_executor.py` — 24 tests
- [x] Full suite: 473 passed

## Closes
- #85 Trading harness
- #88 Ollama provider tests
- #93 Three-way risk debate