### PR TITLE
feat(#52): options strategy template library — 26 curated strategies with learn & use commands

### DIFF
--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -4,12 +4,15 @@ app/commands/strategy.py
 Interactive strategy builder command.
 
 Subcommands:
-  strategy new [description] [--simple]   — AI-guided strategy creation
-  strategy list                           — show saved strategies
-  strategy backtest <name> [--period 2y]  — re-backtest a saved strategy
-  strategy run <name> [symbol] [--paper]  — generate signal + paper trade
-  strategy show <name>                    — view code + metadata
-  strategy delete <name>                  — remove a saved strategy
+  strategy new [description] [--simple]             — AI-guided strategy creation
+  strategy list                                     — show saved strategies
+  strategy backtest <name> [--period 2y]            — re-backtest a saved strategy
+  strategy run <name> [symbol] [--paper]            — generate signal + paper trade
+  strategy show <name>                              — view code + metadata
+  strategy delete <name>                            — remove a saved strategy
+  strategy library [category]                       — browse the strategy template library
+  strategy learn <name>                             — detailed explanation of a template
+  strategy use <name> SYMBOL [--lots N] [--dte N]  — apply a template with live market data
 """
 
 from __future__ import annotations
@@ -38,15 +41,24 @@ def run(args: list[str]) -> None:
         _cmd_show(args[1:])
     elif sub == "delete":
         _cmd_delete(args[1:])
+    elif sub == "library":
+        _cmd_library(args[1:])
+    elif sub == "learn":
+        _cmd_learn(args[1:])
+    elif sub == "use":
+        _cmd_use(args[1:])
     else:
         console.print(
             "[dim]Usage:\n"
-            "  strategy new [description] [--simple]  Create a new strategy\n"
-            "  strategy list                          List saved strategies\n"
-            "  strategy backtest <name> [--period 2y] Re-backtest\n"
-            "  strategy run <name> [symbol] [--paper] Generate signal\n"
-            "  strategy show <name>                   View code\n"
-            "  strategy delete <name>                 Delete[/dim]"
+            "  strategy new [description] [--simple]             Create a new strategy\n"
+            "  strategy list                                     List saved strategies\n"
+            "  strategy backtest <name> [--period 2y]            Re-backtest\n"
+            "  strategy run <name> [symbol] [--paper]            Generate signal\n"
+            "  strategy show <name>                              View code\n"
+            "  strategy delete <name>                            Delete\n"
+            "  strategy library [category]                       Browse strategy templates\n"
+            "  strategy learn <name>                             Explain a template\n"
+            "  strategy use <name> SYMBOL [--lots N] [--dte N]  Apply template with live data[/dim]"
         )
 
 
@@ -482,3 +494,311 @@ def _cmd_delete(args: list[str]) -> None:
         console.print(f"[dim]Strategy '{name}' deleted.[/dim]")
     else:
         console.print("[dim]Cancelled.[/dim]")
+
+
+# ── strategy library ─────────────────────────────────────────
+
+
+def _cmd_library(args: list[str]) -> None:
+    """Browse the curated options strategy template library."""
+    from engine.strategy_library import strategy_library, CATEGORIES
+
+    category = args[0].lower() if args else ""
+
+    if category and category not in CATEGORIES:
+        # Try it as a search query
+        matches = strategy_library.search(category)
+        if matches:
+            console.print(
+                f"[yellow]Unknown category '{category}'. Showing search results instead:[/yellow]\n"
+            )
+            _print_library_table(matches)
+        else:
+            console.print(
+                f"[red]Unknown category '{category}'.[/red] Valid: {', '.join(CATEGORIES)}"
+            )
+        return
+
+    templates = (
+        strategy_library.list_by_category(category) if category else strategy_library.list_all()
+    )
+
+    title = f"Strategy Library — {category.title()}" if category else "Strategy Library"
+    console.print(f"\n[bold cyan]{title}[/bold cyan] [dim]({len(templates)} strategies)[/dim]\n")
+    _print_library_table(templates)
+    console.print("\n[dim]Run: [bold]strategy learn <id>[/bold]  to see full explanation[/dim]")
+    console.print(
+        "[dim]Run: [bold]strategy use <id> SYMBOL[/bold]  to apply with live data[/dim]\n"
+    )
+
+
+def _print_library_table(templates) -> None:
+    """Render a Rich table of strategy templates."""
+    from rich.table import Table
+
+    current_cat = None
+
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("ID", style="cyan", width=28)
+    table.add_column("Name", width=24)
+    table.add_column("Category", width=12)
+    table.add_column("View", width=12)
+    table.add_column("IV", width=6)
+    table.add_column("DTE", width=10)
+    table.add_column("Complexity", width=14)
+
+    for t in templates:
+        if t.category != current_cat:
+            if current_cat is not None:
+                table.add_section()
+            current_cat = t.category
+
+        view_str = "/".join(v[:4] for v in t.views)
+        dte_str = f"{t.ideal_dte[0]}–{t.ideal_dte[1]}d"
+        complexity_color = {
+            "beginner": "green",
+            "intermediate": "yellow",
+            "advanced": "red",
+        }.get(t.complexity, "white")
+
+        table.add_row(
+            t.id,
+            t.name,
+            t.category,
+            view_str,
+            t.ideal_iv,
+            dte_str,
+            f"[{complexity_color}]{t.complexity}[/{complexity_color}]",
+        )
+
+    console.print(table)
+
+
+# ── strategy learn ────────────────────────────────────────────
+
+
+def _cmd_learn(args: list[str]) -> None:
+    """Show a detailed explanation panel for a strategy template."""
+    from engine.strategy_library import strategy_library
+    from rich.panel import Panel
+
+    if not args:
+        console.print("[red]Usage: strategy learn <strategy_id>[/red]")
+        console.print("[dim]Run 'strategy library' to see all available strategy IDs.[/dim]")
+        return
+
+    name = args[0].lower()
+    try:
+        t = strategy_library.get(name)
+    except KeyError:
+        matches = strategy_library.search(name)
+        if matches:
+            console.print(f"[yellow]Strategy '{name}' not found. Did you mean:[/yellow]")
+            for m in matches[:3]:
+                console.print(f"  [cyan]{m.id}[/cyan] — {m.name}")
+        else:
+            console.print(
+                f"[red]Strategy '{name}' not found.[/red] "
+                "Run [bold]strategy library[/bold] to see all."
+            )
+        return
+
+    # Build legs description
+    leg_lines = []
+    for leg in t.legs:
+        offset_desc = ""
+        if leg.strike_offset_pct == 0.0:
+            offset_desc = "ATM"
+        elif leg.strike_offset_pct > 0:
+            offset_desc = f"+{leg.strike_offset_pct * 100:.0f}% OTM"
+        else:
+            offset_desc = f"{leg.strike_offset_pct * 100:.0f}% OTM"
+        multi = f" ×{leg.lots_multiplier}" if leg.lots_multiplier > 1 else ""
+        leg_lines.append(f"  {leg.action:<5} {leg.option_type} ({offset_desc}){multi}")
+
+    complexity_colors = {"beginner": "green", "intermediate": "yellow", "advanced": "red"}
+    comp_color = complexity_colors.get(t.complexity, "white")
+
+    content = (
+        f"[dim]{t.category.upper()} · [{comp_color}]{t.complexity}[/{comp_color}] · "
+        f"Ideal IV: {t.ideal_iv} · DTE: {t.ideal_dte[0]}–{t.ideal_dte[1]} days · "
+        f"Capital: {t.capital_type}[/dim]\n\n"
+        f"[bold]LEGS[/bold]\n"
+        + "\n".join(leg_lines)
+        + f"\n\n[bold]WHAT IT IS[/bold]\n{t.explanation}\n\n"
+        f"[bold]WHEN TO USE[/bold]\n{t.when_to_use}\n\n"
+        f"[bold]WHEN NOT TO USE[/bold]\n{t.when_not_to_use}\n\n"
+        f"[bold]MAX PROFIT[/bold]  {t.max_profit}\n"
+        f"[bold]MAX LOSS[/bold]    {t.max_loss}\n\n"
+        f"[bold]RISKS[/bold]\n"
+        + "\n".join(f"  • {r}" for r in t.risks)
+        + f"\n\n[dim]Tags: {' '.join(t.tags)}[/dim]"
+    )
+
+    console.print(
+        Panel(
+            content,
+            title=f"[bold]{t.name}[/bold]",
+            border_style="cyan",
+            padding=(1, 2),
+        )
+    )
+    console.print(f"\n[dim]Apply with live data: [bold]strategy use {t.id} SYMBOL[/bold][/dim]\n")
+
+
+# ── strategy use ──────────────────────────────────────────────
+
+
+def _cmd_use(args: list[str]) -> None:
+    """Apply a strategy template to a real symbol using live ATM data."""
+    from engine.strategy_library import strategy_library, apply_template
+    from engine.strategy import get_atm_data
+    from rich.panel import Panel
+    from rich.table import Table
+
+    strategy_id, symbol, lots, dte = _parse_use_args(args)
+
+    if not strategy_id:
+        console.print("[red]Usage: strategy use <strategy_id> SYMBOL [--lots N] [--dte N][/red]")
+        console.print("[dim]Run 'strategy library' to see all strategy IDs.[/dim]")
+        return
+
+    if not symbol:
+        console.print("[red]Usage: strategy use <strategy_id> SYMBOL [--lots N] [--dte N][/red]")
+        return
+
+    try:
+        template = strategy_library.get(strategy_id)
+    except KeyError:
+        matches = strategy_library.search(strategy_id)
+        if matches:
+            console.print(f"[yellow]Strategy '{strategy_id}' not found. Did you mean:[/yellow]")
+            for m in matches[:3]:
+                console.print(f"  [cyan]{m.id}[/cyan] — {m.name}")
+        else:
+            console.print(
+                f"[red]Strategy '{strategy_id}' not found.[/red] "
+                "Run [bold]strategy library[/bold] to see all."
+            )
+        return
+
+    # Warn if stock-leg strategy applied to index
+    indices = {"NIFTY", "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY", "SENSEX"}
+    if template.capital_type == "stock" and symbol.upper() in indices:
+        console.print(
+            f"[yellow]Note: '{template.name}' involves a stock leg. "
+            f"Applying to an index ({symbol}) gives approximate results.[/yellow]"
+        )
+
+    # Fetch spot price
+    spot = None
+    try:
+        from market.quotes import get_ltp
+
+        ltp = get_ltp(f"NSE:{symbol}")
+        if ltp and ltp > 0:
+            spot = float(ltp)
+    except Exception:
+        pass
+
+    if not spot:
+        try:
+            from rich.prompt import FloatPrompt
+
+            spot = FloatPrompt.ask(f"Enter current spot price for {symbol}")
+        except Exception:
+            console.print(
+                f"[red]Could not fetch spot price for {symbol}. Provide it manually.[/red]"
+            )
+            return
+
+    # Fetch ATM data
+    console.print(f"[dim]Fetching ATM data for {symbol} @ ₹{spot:,.0f}...[/dim]")
+    try:
+        atm_ce_prem, atm_pe_prem, atm_strike, lot_size = get_atm_data(symbol, spot)
+    except Exception as e:
+        console.print(f"[red]Could not fetch ATM data: {e}[/red]")
+        return
+
+    # Apply the template
+    result = apply_template(
+        template=template,
+        symbol=symbol,
+        spot=spot,
+        atm_ce_prem=atm_ce_prem,
+        atm_pe_prem=atm_pe_prem,
+        atm_strike=atm_strike,
+        lot_size=lot_size,
+        lots=lots,
+        dte=dte,
+    )
+
+    # Display result
+    console.print(f"\n[bold cyan]{result.name}[/bold cyan] — {symbol} @ ₹{spot:,.0f}\n")
+
+    # Legs table
+    leg_table = Table(show_header=True, header_style="bold dim", box=None, pad_edge=False)
+    leg_table.add_column("Action", width=8)
+    leg_table.add_column("Type", width=8)
+    leg_table.add_column("Strike", justify="right", width=10)
+    leg_table.add_column("Premium", justify="right", width=10)
+    leg_table.add_column("Lots", justify="right", width=6)
+
+    for leg in result.legs:
+        action_color = "green" if leg["action"] == "BUY" else "red"
+        leg_table.add_row(
+            f"[{action_color}]{leg['action']}[/{action_color}]",
+            leg.get("type", "STOCK"),
+            f"₹{leg.get('strike', 0):,.0f}",
+            f"₹{leg.get('premium', 0):.0f}" if "premium" in leg else "—",
+            str(leg.get("lots", lots)),
+        )
+
+    console.print(leg_table)
+
+    # P&L summary panel
+    mp_str = f"₹{result.max_profit:,.0f}" if result.max_profit < 1e9 else "Unlimited"
+    ml_str = f"₹{abs(result.max_loss):,.0f}" if result.max_loss > -1e9 else "Unlimited"
+    be_str = " / ".join(f"₹{b:,.0f}" for b in result.breakeven)
+
+    summary = (
+        f"  Capital Needed : [bold]₹{result.capital_needed:,.0f}[/bold]\n"
+        f"  Max Profit     : [green]↑ {mp_str}[/green]\n"
+        f"  Max Loss       : [red]↓ {ml_str}[/red]\n"
+        f"  Breakeven      : {be_str}\n"
+        f"  R:R Ratio      : {result.rr_ratio}×\n"
+        f"  Best for       : [dim]{result.best_for}[/dim]\n"
+        f"  Risks          : [dim]{result.risks}[/dim]"
+    )
+    console.print(Panel(summary, title="P&L Summary", border_style="dim", padding=(0, 2)))
+    console.print(
+        f"\n[dim]For placement: [bold]trade {symbol} {' / '.join(template.views)}[/bold][/dim]\n"
+    )
+
+
+def _parse_use_args(args: list[str]) -> tuple[str, str, int, int]:
+    """Parse args for 'strategy use'. Returns (strategy_id, symbol, lots, dte)."""
+    lots = 1
+    dte = 30
+    clean: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--lots" and i + 1 < len(args):
+            try:
+                lots = int(args[i + 1])
+            except ValueError:
+                pass
+            i += 2
+        elif args[i] == "--dte" and i + 1 < len(args):
+            try:
+                dte = int(args[i + 1])
+            except ValueError:
+                pass
+            i += 2
+        else:
+            clean.append(args[i])
+            i += 1
+
+    strategy_id = clean[0].lower() if len(clean) > 0 else ""
+    symbol = clean[1].upper() if len(clean) > 1 else ""
+    return strategy_id, symbol, lots, dte

--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -623,9 +623,10 @@ def _cmd_learn(args: list[str]) -> None:
         f"[dim]{t.category.upper()} · [{comp_color}]{t.complexity}[/{comp_color}] · "
         f"Ideal IV: {t.ideal_iv} · DTE: {t.ideal_dte[0]}–{t.ideal_dte[1]} days · "
         f"Capital: {t.capital_type}[/dim]\n\n"
+        f"[bold yellow]IN PLAIN ENGLISH[/bold yellow]\n{t.layman_explanation}\n\n"
         f"[bold]LEGS[/bold]\n"
         + "\n".join(leg_lines)
-        + f"\n\n[bold]WHAT IT IS[/bold]\n{t.explanation}\n\n"
+        + f"\n\n[bold]HOW IT WORKS[/bold]\n{t.explanation}\n\n"
         f"[bold]WHEN TO USE[/bold]\n{t.when_to_use}\n\n"
         f"[bold]WHEN NOT TO USE[/bold]\n{t.when_not_to_use}\n\n"
         f"[bold]MAX PROFIT[/bold]  {t.max_profit}\n"

--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -574,6 +574,87 @@ def _print_library_table(templates) -> None:
     console.print(table)
 
 
+# ── Leg formatter helpers ─────────────────────────────────────
+
+
+def _leg_strike_plain(leg) -> str:
+    """Human-readable strike location: 'at current price', '3% above current price', etc."""
+    pct = leg.strike_offset_pct
+    if leg.option_type == "STOCK":
+        return "at current market price"
+    if pct == 0.0:
+        return "at current price (ATM — at-the-money)"
+    if pct > 0:
+        return f"{pct * 100:.0f}% above current price (OTM — out-of-the-money)"
+    return f"{abs(pct) * 100:.0f}% below current price (OTM — out-of-the-money)"
+
+
+def _leg_plain_description(leg) -> str:
+    """One sentence explaining what each leg means for the trader."""
+    action = leg.action
+    otype = leg.option_type
+    multi = leg.lots_multiplier
+
+    multi_note = f" (×{multi} contracts)" if multi > 1 else ""
+
+    if otype == "STOCK":
+        if action == "BUY":
+            return "Own the actual shares — full upside, but also full downside if the stock falls."
+        return "Short-sell the shares — profit if price falls, unlimited loss if it rises."
+
+    if otype == "CE":  # Call option
+        if action == "BUY":
+            return (
+                f"Pay a premium{multi_note} for the right to profit if the stock rises above this level. "
+                f"Loss is limited to the premium paid."
+            )
+        else:
+            return (
+                f"Collect premium{multi_note} now; in return you're obligated to sell shares if the "
+                f"stock rises past this level. Acts as a profit ceiling or a hedge."
+            )
+
+    # PE — Put option
+    if action == "BUY":
+        return (
+            f"Pay a premium{multi_note} for the right to profit if the stock falls below this level. "
+            f"Loss is limited to the premium paid."
+        )
+    return (
+        f"Collect premium{multi_note} now; in return you're obligated to buy shares if the "
+        f"stock falls past this level. Acts as a floor or a hedge."
+    )
+
+
+def _format_legs(legs) -> str:
+    """
+    Format strategy legs with strike location + plain-English role explanation.
+
+    Example output (Iron Condor):
+      SELL  CE  3% above current price (OTM)
+              → Collect premium; obligated to sell if stock rises past this. Acts as a ceiling.
+
+      BUY   CE  6% above current price (OTM)
+              → Pay premium; protects you if stock blows past the short call above.
+      ...
+    """
+    lines = []
+    for leg in legs:
+        otype = leg.option_type
+        action = leg.action
+        strike_loc = _leg_strike_plain(leg)
+        description = _leg_plain_description(leg)
+        multi = f" ×{leg.lots_multiplier}" if leg.lots_multiplier > 1 else ""
+
+        action_color = "green" if action == "BUY" else "red"
+        lines.append(
+            f"  [{action_color}]{action:<5}[/{action_color}] {otype}{multi}  "
+            f"[dim]{strike_loc}[/dim]\n"
+            f"         [dim]→ {description}[/dim]"
+        )
+    return "\n\n".join(lines)
+
+
 # ── strategy learn ────────────────────────────────────────────
 
 
@@ -603,19 +684,6 @@ def _cmd_learn(args: list[str]) -> None:
             )
         return
 
-    # Build legs description
-    leg_lines = []
-    for leg in t.legs:
-        offset_desc = ""
-        if leg.strike_offset_pct == 0.0:
-            offset_desc = "ATM"
-        elif leg.strike_offset_pct > 0:
-            offset_desc = f"+{leg.strike_offset_pct * 100:.0f}% OTM"
-        else:
-            offset_desc = f"{leg.strike_offset_pct * 100:.0f}% OTM"
-        multi = f" ×{leg.lots_multiplier}" if leg.lots_multiplier > 1 else ""
-        leg_lines.append(f"  {leg.action:<5} {leg.option_type} ({offset_desc}){multi}")
-
     complexity_colors = {"beginner": "green", "intermediate": "yellow", "advanced": "red"}
     comp_color = complexity_colors.get(t.complexity, "white")
 
@@ -624,8 +692,8 @@ def _cmd_learn(args: list[str]) -> None:
         f"Ideal IV: {t.ideal_iv} · DTE: {t.ideal_dte[0]}–{t.ideal_dte[1]} days · "
         f"Capital: {t.capital_type}[/dim]\n\n"
         f"[bold yellow]IN PLAIN ENGLISH[/bold yellow]\n{t.layman_explanation}\n\n"
-        f"[bold]LEGS[/bold]\n"
-        + "\n".join(leg_lines)
+        f"[bold]LEGS[/bold]  [dim](what you actually trade)[/dim]\n"
+        + _format_legs(t.legs)
         + f"\n\n[bold]HOW IT WORKS[/bold]\n{t.explanation}\n\n"
         f"[bold]WHEN TO USE[/bold]\n{t.when_to_use}\n\n"
         f"[bold]WHEN NOT TO USE[/bold]\n{t.when_not_to_use}\n\n"

--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -576,6 +576,18 @@ def _print_library_table(templates) -> None:
 
 # ── Leg formatter helpers ─────────────────────────────────────
 
+# Hypothetical spot used for concrete examples throughout the learn panel.
+# ₹24,000 is close to NIFTY and a round number that's easy to reason about.
+_EXAMPLE_SPOT = 24_000
+
+
+def _example_strike(leg) -> int:
+    """Compute the example strike from _EXAMPLE_SPOT and the leg's offset."""
+    if leg.option_type == "STOCK":
+        return _EXAMPLE_SPOT
+    raw = _EXAMPLE_SPOT * (1 + leg.strike_offset_pct)
+    return int(round(raw / 100) * 100)  # round to nearest 100 (Indian index convention)
+
 
 def _leg_strike_plain(leg) -> str:
     """Human-readable strike location: 'at current price', '3% above current price', etc."""
@@ -594,7 +606,6 @@ def _leg_plain_description(leg) -> str:
     action = leg.action
     otype = leg.option_type
     multi = leg.lots_multiplier
-
     multi_note = f" (×{multi} contracts)" if multi > 1 else ""
 
     if otype == "STOCK":
@@ -602,55 +613,101 @@ def _leg_plain_description(leg) -> str:
             return "Own the actual shares — full upside, but also full downside if the stock falls."
         return "Short-sell the shares — profit if price falls, unlimited loss if it rises."
 
-    if otype == "CE":  # Call option
+    if otype == "CE":
         if action == "BUY":
             return (
                 f"Pay a premium{multi_note} for the right to profit if the stock rises above this level. "
-                f"Loss is limited to the premium paid."
+                "Loss is limited to the premium paid."
             )
-        else:
-            return (
-                f"Collect premium{multi_note} now; in return you're obligated to sell shares if the "
-                f"stock rises past this level. Acts as a profit ceiling or a hedge."
-            )
+        return (
+            f"Collect premium{multi_note} now; in return you're obligated to sell if the "
+            "stock rises past this level. Acts as a profit ceiling or a hedge."
+        )
 
-    # PE — Put option
+    # PE
     if action == "BUY":
         return (
             f"Pay a premium{multi_note} for the right to profit if the stock falls below this level. "
-            f"Loss is limited to the premium paid."
+            "Loss is limited to the premium paid."
         )
     return (
-        f"Collect premium{multi_note} now; in return you're obligated to buy shares if the "
-        f"stock falls past this level. Acts as a floor or a hedge."
+        f"Collect premium{multi_note} now; in return you're obligated to buy if the "
+        "stock falls past this level. Acts as a floor or a hedge."
+    )
+
+
+def _leg_scenarios(leg, strike: int) -> tuple[str, str]:
+    """
+    Return (good_scenario, bad_scenario) as plain-English strings for a leg.
+    Uses the concrete example strike so the user can picture real numbers.
+    """
+    action = leg.action
+    otype = leg.option_type
+    s = f"₹{strike:,}"
+
+    if otype == "STOCK":
+        if action == "BUY":
+            return (
+                f"Stock rises above {s} → you profit ₹1 for every ₹1 it goes up",
+                f"Stock falls below {s} → you lose ₹1 for every ₹1 it goes down",
+            )
+        return (
+            f"Stock falls below {s} → you profit as price drops",
+            f"Stock rises above {s} → unlimited loss",
+        )
+
+    if otype == "CE":
+        if action == "BUY":
+            return (
+                f"Stock closes above {s} at expiry → your call gains value, you profit",
+                f"Stock closes at or below {s} → call expires worthless, you lose only the premium paid",
+            )
+        return (
+            f"Stock stays below {s} at expiry → call expires worthless, you keep the full premium",
+            f"Stock rises above {s} → you're obligated to sell at {s}; loss grows the higher it goes",
+        )
+
+    # PE
+    if action == "BUY":
+        return (
+            f"Stock closes below {s} at expiry → your put gains value, you profit",
+            f"Stock closes at or above {s} → put expires worthless, you lose only the premium paid",
+        )
+    return (
+        f"Stock stays above {s} at expiry → put expires worthless, you keep the full premium",
+        f"Stock falls below {s} → you're obligated to buy at {s}; loss grows the lower it goes",
     )
 
 
 def _format_legs(legs) -> str:
     """
-    Format strategy legs with strike location + plain-English role explanation.
+    Format each leg with: location, plain description, and concrete example scenarios.
 
-    Example output (Iron Condor):
+    Example (one Iron Condor leg):
       SELL  CE  3% above current price (OTM)
-              → Collect premium; obligated to sell if stock rises past this. Acts as a ceiling.
-
-      BUY   CE  6% above current price (OTM)
-              → Pay premium; protects you if stock blows past the short call above.
-      ...
+               → Collect premium; obligated to sell if stock rises past this.
+               Example if stock is at ₹24,000 → this strike is ₹24,700
+                 ✓ Stock stays below ₹24,700: call expires worthless, you keep the full premium
+                 ✗ Stock rises above ₹24,700: you're obligated to sell; loss grows the higher it goes
     """
     lines = []
     for leg in legs:
-        otype = leg.option_type
         action = leg.action
+        otype = leg.option_type
+        strike = _example_strike(leg)
         strike_loc = _leg_strike_plain(leg)
         description = _leg_plain_description(leg)
+        good, bad = _leg_scenarios(leg, strike)
         multi = f" ×{leg.lots_multiplier}" if leg.lots_multiplier > 1 else ""
 
         action_color = "green" if action == "BUY" else "red"
         lines.append(
             f"  [{action_color}]{action:<5}[/{action_color}] {otype}{multi}  "
             f"[dim]{strike_loc}[/dim]\n"
-            f"         [dim]→ {description}[/dim]"
+            f"         [dim]→ {description}[/dim]\n"
+            f"         [dim]Example (stock @ ₹{_EXAMPLE_SPOT:,}): this strike = ₹{strike:,}[/dim]\n"
+            f"           [green]✓[/green] [dim]{good}[/dim]\n"
+            f"           [red]✗[/red] [dim]{bad}[/dim]"
         )
     return "\n\n".join(lines)
 

--- a/engine/strategy.py
+++ b/engine/strategy.py
@@ -97,7 +97,7 @@ def recommend(
     view_up = view.upper()
 
     # Get ATM options data for the symbol
-    atm_ce_premium, atm_pe_premium, atm_strike, lot_size = _get_atm_data(symbol, spot)
+    atm_ce_premium, atm_pe_premium, atm_strike, lot_size = get_atm_data(symbol, spot)
 
     results: list[StrategyResult] = []
 
@@ -361,7 +361,7 @@ def recommend(
 # ── Market data helpers ───────────────────────────────────────
 
 
-def _get_atm_data(symbol: str, spot: float) -> tuple[float, float, float, int]:
+def get_atm_data(symbol: str, spot: float) -> tuple[float, float, float, int]:
     """
     Fetch ATM CE/PE premiums and lot size from the options chain.
     Returns (ce_premium, pe_premium, atm_strike, lot_size).
@@ -395,6 +395,7 @@ def _get_atm_data(symbol: str, spot: float) -> tuple[float, float, float, int]:
     atm = round(spot, -2)
     approx = spot * iv * math.sqrt(t) * 0.4  # rough ATM premium estimate
     lot = _default_lot(symbol)
+
     return round(approx, 2), round(approx, 2), atm, lot
 
 

--- a/engine/strategy_library.py
+++ b/engine/strategy_library.py
@@ -72,7 +72,8 @@ class StrategyTemplate:
     max_loss: str  # e.g. "Net debit paid"
     ideal_iv: str  # "low" | "high" | "any"
     ideal_dte: tuple[int, int]  # (min_days, max_days)
-    explanation: str  # 2-4 sentence plain-English description
+    layman_explanation: str  # 1-2 sentences in plain language, zero jargon
+    explanation: str  # 2-4 sentence technical description
     when_to_use: str  # 1-2 sentences
     when_not_to_use: str  # 1-2 sentences
     risks: list[str]  # bullet-point risks
@@ -95,6 +96,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Limited to premium paid",
         ideal_iv="low",
         ideal_dte=(7, 45),
+        layman_explanation=(
+            "You pay a small fee today for the right to buy a stock at today's price later. "
+            "If the stock goes up, you profit. If it doesn't, you only lose the fee you paid — nothing more."
+        ),
         explanation=(
             "Buy an ATM call option for the right to buy the underlying at the strike price. "
             "Profit is unlimited if the stock rises strongly; loss is capped at the premium paid. "
@@ -124,6 +129,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Net debit paid",
         ideal_iv="low",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "You bet the stock will rise, but only moderately. "
+            "You buy one call and sell another at a higher price to cut your cost — "
+            "your profit is capped, but so is what you can lose."
+        ),
         explanation=(
             "Buy an ATM call and sell an OTM call at the same expiry. "
             "The short call reduces cost but caps your upside at the short strike. "
@@ -153,6 +163,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Spread width minus net credit",
         ideal_iv="high",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "Someone pays you money now to bet the stock won't fall below a certain level. "
+            "If you're right, you keep the cash. If you're wrong, your loss is capped."
+        ),
         explanation=(
             "Sell an OTM put and buy a further OTM put for protection. "
             "You collect a net credit upfront; keep it all if the stock stays above the short put. "
@@ -182,6 +196,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Effectively unlimited on the downside (put assignment risk)",
         ideal_iv="any",
         ideal_dte=(30, 90),
+        layman_explanation=(
+            "It acts just like owning the stock — rises and falls with it — "
+            "but you only put up a fraction of the capital. "
+            "The catch: if it falls, you lose just as much as if you owned the shares."
+        ),
         explanation=(
             "Buy an ATM call and sell an ATM put at the same strike and expiry. "
             "The payoff mimics owning the stock — unlimited upside, full downside — "
@@ -212,6 +231,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Maximum loss between the two strikes near expiry",
         ideal_iv="low",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "You sell one expensive bet and use the money to buy two cheaper bets on a bigger move. "
+            "You win big if the stock shoots up or crashes — "
+            "but lose if it just drifts to a middle level."
+        ),
         explanation=(
             "Sell 1 ATM call and buy 2 OTM calls. The position profits from a large rally "
             "or a sharp fall (if entered for a net credit). The loss zone is between the two strikes. "
@@ -239,6 +263,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Limited to premium paid",
         ideal_iv="low",
         ideal_dte=(7, 45),
+        layman_explanation=(
+            "You pay a small fee to profit if the stock falls. "
+            "Think of it as insurance that pays out when prices drop — "
+            "if the stock rises instead, you only lose the fee."
+        ),
         explanation=(
             "Buy an ATM put option for the right to sell the underlying at the strike. "
             "Profits grow as the stock falls; max loss is the premium paid if stock rises or stays flat. "
@@ -268,6 +297,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Net debit paid",
         ideal_iv="low",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "You bet the stock will fall, but not by a lot. "
+            "Buying one put and selling another cheaper one cuts your upfront cost — "
+            "you give up some profit potential but pay less to enter."
+        ),
         explanation=(
             "Buy an ATM put and sell an OTM put at the same expiry. "
             "Profits from a moderate decline; the short put caps the downside gain "
@@ -297,6 +331,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Spread width minus net credit",
         ideal_iv="high",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "Someone pays you money now to bet the stock won't rise above a certain level. "
+            "If you're right, you keep the cash. If the stock surges past your limit, your loss is capped."
+        ),
         explanation=(
             "Sell an OTM call and buy a further OTM call for protection. "
             "Collect a net credit; keep it if the stock stays below the short call. "
@@ -326,6 +364,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Effectively unlimited on the upside (call assignment risk)",
         ideal_iv="any",
         ideal_dte=(30, 90),
+        layman_explanation=(
+            "It acts like short-selling the stock without actually borrowing shares — "
+            "you profit as the price falls. "
+            "But if the stock shoots up, you lose just as much as a short-seller would."
+        ),
         explanation=(
             "Buy an ATM put and sell an ATM call at the same strike and expiry. "
             "The payoff mimics short-selling the stock without actually borrowing shares. "
@@ -355,6 +398,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Maximum loss between the two strikes near expiry",
         ideal_iv="low",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "Same idea as the call ratio backspread but for a falling market — "
+            "you sell one expensive put and buy two cheaper ones on a bigger drop. "
+            "Win on a crash or a rally; lose if the stock lands in the middle."
+        ),
         explanation=(
             "Sell 1 ATM put and buy 2 OTM puts. Profits from a large decline "
             "or a sharp rally (if entered for a net credit). Loss zone is between the two strikes. "
@@ -387,6 +435,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Wing width minus net credit (defined)",
         ideal_iv="high",
         ideal_dte=(20, 45),
+        layman_explanation=(
+            "You collect rent by betting the stock will stay parked between two price levels. "
+            "As long as it doesn't go too high or too low by expiry, you keep all the money. "
+            "Think of it as drawing a profit box around the current price."
+        ),
         explanation=(
             "Sell an OTM call spread and an OTM put spread simultaneously. "
             "Profits if the underlying stays between the two short strikes through expiry. "
@@ -426,6 +479,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Wing width minus net credit",
         ideal_iv="high",
         ideal_dte=(15, 30),
+        layman_explanation=(
+            "Like an iron condor but with a tighter profit zone right at the current price. "
+            "You collect more cash upfront, but the stock needs to land almost exactly where it is now for you to keep it."
+        ),
         explanation=(
             "Sell ATM call and put (straddle) and buy OTM wings for protection. "
             "Higher credit than an iron condor because the short strikes are ATM, "
@@ -455,6 +512,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Unlimited in either direction",
         ideal_iv="high",
         ideal_dte=(15, 30),
+        layman_explanation=(
+            "You collect rent from both the bulls and the bears, betting the stock goes nowhere. "
+            "Great income if the stock stays flat — but if it makes a big move either way, your losses are unlimited."
+        ),
         explanation=(
             "Sell an ATM call and an ATM put at the same strike and expiry. "
             "You collect the combined premium; the stock must stay near the strike to profit. "
@@ -484,6 +545,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Unlimited in either direction",
         ideal_iv="high",
         ideal_dte=(15, 30),
+        layman_explanation=(
+            "A roomier version of the short straddle — you give the stock more space to wander "
+            "before it hurts you, but you collect less cash. Still unlimited loss if it moves big."
+        ),
         explanation=(
             "Sell an OTM call and an OTM put at the same expiry. "
             "The profit zone is wider than a short straddle (between the two short strikes) "
@@ -513,6 +578,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Stock falls to zero minus premium received",
         ideal_iv="any",
         ideal_dte=(20, 45),
+        layman_explanation=(
+            "You own a stock and charge someone a fee for the option to buy it from you at a higher price. "
+            "You earn extra income every month — but if the stock rockets, they take your shares at the agreed price."
+        ),
         explanation=(
             "Own the stock and sell an OTM call against it each month. "
             "The premium reduces your cost basis and provides income; "
@@ -540,6 +609,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Short put strike minus premium (stock falls to zero)",
         ideal_iv="any",
         ideal_dte=(20, 45),
+        layman_explanation=(
+            "You tell the market: 'I'm happy to buy this stock if it falls to ₹X — pay me now for that promise.' "
+            "You earn cash upfront. If the stock stays above ₹X, you keep the cash and do it again next month."
+        ),
         explanation=(
             "Sell an OTM put and set aside the capital to buy the shares if assigned. "
             "You earn the premium and may acquire the stock at a price you are happy to own it. "
@@ -570,6 +643,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Put spread width minus total credit (downside risk only)",
         ideal_iv="high",
         ideal_dte=(20, 40),
+        layman_explanation=(
+            "You collect rent from three bets at once and engineer it so there's no way to lose if the stock rises. "
+            "The only way you lose is if the stock falls hard — and even that loss is capped."
+        ),
         explanation=(
             "Sell an OTM call, sell an OTM put, and buy a further OTM put for protection. "
             "The total credit exceeds the call strike distance, eliminating upside risk. "
@@ -600,6 +677,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Total premium paid for both legs",
         ideal_iv="low",
         ideal_dte=(15, 60),
+        layman_explanation=(
+            "You don't know which way the stock will move, but you're sure it'll move a lot. "
+            "So you buy both a 'goes up' bet and a 'goes down' bet — "
+            "whichever direction it explodes in, you win."
+        ),
         explanation=(
             "Buy an ATM call and an ATM put at the same strike and expiry. "
             "Profits from a large move in either direction; the exact direction does not matter. "
@@ -629,6 +711,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Total premium paid (less than straddle)",
         ideal_iv="low",
         ideal_dte=(15, 60),
+        layman_explanation=(
+            "Same idea as a straddle — bet on a big move in either direction — "
+            "but cheaper because you buy slightly out-of-the-money bets. "
+            "The trade-off: the stock needs to move even more before you start making money."
+        ),
         explanation=(
             "Buy an OTM call and an OTM put at the same expiry. "
             "Cheaper than a straddle because both legs are OTM; "
@@ -659,6 +746,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Net debit paid (far premium minus near premium received)",
         ideal_iv="any",
         ideal_dte=(15, 45),
+        layman_explanation=(
+            "You rent out a short-term bet to someone while holding a longer-term one yourself. "
+            "The short-term rent expires and loses value faster — you pocket that difference. "
+            "Works best if the stock stays near its current price in the short run."
+        ),
         explanation=(
             "Sell a near-term ATM call and buy a longer-term ATM call at the same strike. "
             "The near-term leg decays faster; you profit from the difference in theta decay rates. "
@@ -689,6 +781,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Net debit paid (far premium minus near credit received)",
         ideal_iv="any",
         ideal_dte=(20, 60),
+        layman_explanation=(
+            "You buy a long-term bullish bet and partially fund it by selling a short-term, smaller bet. "
+            "You stay bullish overall while collecting near-term rent to reduce your cost."
+        ),
         explanation=(
             "Sell a near-term OTM call and buy a far-term ATM call — different strikes and expiries. "
             "Combines the theta benefit of the short near leg with the directional benefit of the long far leg. "
@@ -719,6 +815,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="(Stock price - put strike + put premium) per share × lot size",
         ideal_iv="any",
         ideal_dte=(30, 90),
+        layman_explanation=(
+            "You own a stock and buy insurance against it falling. "
+            "Like car insurance — you pay a premium, and if something bad happens (a big drop), the policy pays out. "
+            "Your upside is still unlimited; your downside is capped."
+        ),
         explanation=(
             "Own the stock and buy a slightly OTM put as insurance. "
             "If the stock falls, the put gains value and limits your downside. "
@@ -749,6 +850,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="(Stock price - long put strike + net option debit) — defined",
         ideal_iv="any",
         ideal_dte=(30, 90),
+        layman_explanation=(
+            "You put a safety floor under your stock and fund it by agreeing to sell at a ceiling price. "
+            "Your loss is limited and the hedge is often free — but you give up gains above the ceiling."
+        ),
         explanation=(
             "Own the stock, buy a downside put for protection, and sell an upside call to fund the put. "
             "The sold call partially or fully offsets the cost of the protective put. "
@@ -778,6 +883,11 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Put premium paid (stock is protected at ATM strike)",
         ideal_iv="any",
         ideal_dte=(30, 60),
+        layman_explanation=(
+            "You buy a stock and full insurance at the same time. "
+            "If the stock crashes to zero, your insurance policy pays out dollar-for-dollar — "
+            "the most you can ever lose is the insurance premium."
+        ),
         explanation=(
             "Buy the stock and simultaneously buy an ATM put. "
             "The put fully protects the position — if the stock falls, the put gains dollar-for-dollar. "
@@ -808,6 +918,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="Put spread width minus total net credit received — defined downside",
         ideal_iv="high",
         ideal_dte=(30, 90),
+        layman_explanation=(
+            "You build a cheap safety net under your portfolio by selling two different bets to fund it. "
+            "Often costs nothing or pays you a small credit — you're hedged below and capped above."
+        ),
         explanation=(
             "Buy an OTM put, sell a further OTM put, and sell an OTM call. "
             "The put spread provides cheap downside protection; the short call funds it. "
@@ -838,6 +952,10 @@ TEMPLATES: dict[str, StrategyTemplate] = {
         max_loss="(Stock price - put strike - net credit) if stock falls below put",
         ideal_iv="any",
         ideal_dte=(30, 60),
+        layman_explanation=(
+            "You buy cheap downside insurance and let someone else pay for it by giving up your upside. "
+            "It's like getting free flood insurance on your house by agreeing to sell it below market if prices rise."
+        ),
         explanation=(
             "Buy a slightly OTM put and sell a further OTM call (no stock position). "
             "The short call funds the put and provides a net credit or near-zero cost hedge. "

--- a/engine/strategy_library.py
+++ b/engine/strategy_library.py
@@ -1,0 +1,1445 @@
+"""
+engine/strategy_library.py
+──────────────────────────
+Curated library of 26 well-known options strategies for Indian markets.
+
+Each strategy is a StrategyTemplate — a data-driven, symbol-agnostic description
+of a strategy's structure (legs, capital type, ideal conditions) plus educational
+content (explanation, when to use, risks, tags).
+
+Templates are resolved to live StrategyResult objects via apply_template(), which
+takes real ATM market data and returns the same StrategyResult type that
+engine/strategy.py produces — so all existing display code works unchanged.
+
+Usage:
+    from engine.strategy_library import strategy_library, apply_template
+
+    template = strategy_library.get("iron_condor")
+    result = apply_template(template, symbol="NIFTY", spot=24000, ...)
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from engine.strategy import StrategyResult
+
+try:
+    from analysis.options import PayoffLeg, payoff as calc_payoff
+
+    _PAYOFF_AVAILABLE = True
+except Exception:
+    _PAYOFF_AVAILABLE = False
+
+
+# ── Constants ─────────────────────────────────────────────────
+
+CATEGORIES = ("bullish", "bearish", "income", "volatility", "hedging")
+
+
+# ── Dataclasses ───────────────────────────────────────────────
+
+
+@dataclass
+class TemplateLeg:
+    """Abstract leg for a strategy template.
+
+    strike_offset_pct is relative to spot:
+      0.0   = ATM
+     +0.03  = 3% OTM on the call side (strike above spot)
+     -0.03  = 3% OTM on the put side (strike below spot)
+
+    For STOCK legs, strike_offset_pct is unused (always purchased at spot).
+    """
+
+    option_type: str  # "CE" | "PE" | "STOCK"
+    action: str  # "BUY" | "SELL"
+    strike_offset_pct: float  # signed percentage of spot
+    lots_multiplier: int = 1  # relative lot count (2 = double leg for ratio spreads)
+
+
+@dataclass
+class StrategyTemplate:
+    """Metadata and educational content for a named options strategy."""
+
+    id: str  # snake_case unique key
+    name: str  # Display name
+    category: str  # one of CATEGORIES
+    views: list[str]  # e.g. ["BULLISH"] — views this strategy suits
+    legs: list[TemplateLeg]  # abstract leg definitions
+    max_profit: str  # human description, e.g. "Capped at spread width minus debit"
+    max_loss: str  # e.g. "Net debit paid"
+    ideal_iv: str  # "low" | "high" | "any"
+    ideal_dte: tuple[int, int]  # (min_days, max_days)
+    explanation: str  # 2-4 sentence plain-English description
+    when_to_use: str  # 1-2 sentences
+    when_not_to_use: str  # 1-2 sentences
+    risks: list[str]  # bullet-point risks
+    tags: list[str]  # searchable tags
+    capital_type: str = "debit"  # "debit" | "credit" | "margin" | "stock"
+    complexity: str = "beginner"  # "beginner" | "intermediate" | "advanced"
+
+
+# ── Template definitions ──────────────────────────────────────
+
+TEMPLATES: dict[str, StrategyTemplate] = {
+    # ── BULLISH ───────────────────────────────────────────────
+    "long_call": StrategyTemplate(
+        id="long_call",
+        name="Long Call",
+        category="bullish",
+        views=["BULLISH"],
+        legs=[TemplateLeg("CE", "BUY", 0.0)],
+        max_profit="Unlimited — profits as stock rises above breakeven",
+        max_loss="Limited to premium paid",
+        ideal_iv="low",
+        ideal_dte=(7, 45),
+        explanation=(
+            "Buy an ATM call option for the right to buy the underlying at the strike price. "
+            "Profit is unlimited if the stock rises strongly; loss is capped at the premium paid. "
+            "This is the simplest leveraged bullish trade with defined risk."
+        ),
+        when_to_use="Strong directional conviction; expecting a fast, large move before expiry.",
+        when_not_to_use="When IV is elevated — you pay a high premium and need a larger move to profit.",
+        risks=[
+            "Full premium lost if stock does not move above breakeven by expiry",
+            "Theta decay accelerates in the last 2 weeks — avoid holding too long",
+            "High IV at entry makes breakeven very far from current price",
+        ],
+        tags=["directional", "debit", "unlimited_profit", "defined_risk", "beginner"],
+        capital_type="debit",
+        complexity="beginner",
+    ),
+    "bull_call_spread": StrategyTemplate(
+        id="bull_call_spread",
+        name="Bull Call Spread",
+        category="bullish",
+        views=["BULLISH"],
+        legs=[
+            TemplateLeg("CE", "BUY", 0.0),
+            TemplateLeg("CE", "SELL", 0.03),
+        ],
+        max_profit="Capped — spread width minus net debit, multiplied by lot size",
+        max_loss="Net debit paid",
+        ideal_iv="low",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Buy an ATM call and sell an OTM call at the same expiry. "
+            "The short call reduces cost but caps your upside at the short strike. "
+            "Ideal when you expect a moderate bullish move, not a parabolic rally."
+        ),
+        when_to_use="Moderately bullish; want to reduce premium outlay vs a naked long call.",
+        when_not_to_use="When expecting a very large move — profits are capped at the short strike.",
+        risks=[
+            "Max profit capped if stock rallies past the short call strike",
+            "Both legs lose value if stock falls — full debit at risk",
+            "Wider spreads need more capital and a bigger move to profit",
+        ],
+        tags=["directional", "debit", "defined_risk", "spread", "beginner"],
+        capital_type="debit",
+        complexity="beginner",
+    ),
+    "bull_put_spread": StrategyTemplate(
+        id="bull_put_spread",
+        name="Bull Put Spread",
+        category="bullish",
+        views=["BULLISH", "NEUTRAL"],
+        legs=[
+            TemplateLeg("PE", "SELL", -0.02),
+            TemplateLeg("PE", "BUY", -0.05),
+        ],
+        max_profit="Net credit received",
+        max_loss="Spread width minus net credit",
+        ideal_iv="high",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Sell an OTM put and buy a further OTM put for protection. "
+            "You collect a net credit upfront; keep it all if the stock stays above the short put. "
+            "This is a credit spread that profits from time decay and upward price action."
+        ),
+        when_to_use="Moderately bullish or neutral; high IV inflating put premiums.",
+        when_not_to_use="When strongly bearish or expecting a sharp fall below the short put.",
+        risks=[
+            "Full spread-width loss if stock falls below the long put strike",
+            "Margin required — can tie up capital even though loss is defined",
+            "Profit capped at the initial credit — no upside beyond that",
+        ],
+        tags=["credit", "defined_risk", "spread", "theta", "intermediate"],
+        capital_type="credit",
+        complexity="intermediate",
+    ),
+    "synthetic_long": StrategyTemplate(
+        id="synthetic_long",
+        name="Synthetic Long",
+        category="bullish",
+        views=["BULLISH"],
+        legs=[
+            TemplateLeg("CE", "BUY", 0.0),
+            TemplateLeg("PE", "SELL", 0.0),
+        ],
+        max_profit="Unlimited — mirrors stock ownership",
+        max_loss="Effectively unlimited on the downside (put assignment risk)",
+        ideal_iv="any",
+        ideal_dte=(30, 90),
+        explanation=(
+            "Buy an ATM call and sell an ATM put at the same strike and expiry. "
+            "The payoff mimics owning the stock — unlimited upside, full downside — "
+            "but requires far less capital. Used by traders who want stock-like exposure "
+            "without deploying full stock capital."
+        ),
+        when_to_use="Strong bullish conviction; want stock-like leverage with less capital outlay.",
+        when_not_to_use="When uncertain — the put sale gives you unlimited downside, same as stock.",
+        risks=[
+            "Unlimited downside risk via short put assignment",
+            "High margin required for the short put leg",
+            "Early assignment risk if deep ITM near expiry",
+        ],
+        tags=["directional", "margin", "unlimited_risk", "leverage", "advanced"],
+        capital_type="margin",
+        complexity="advanced",
+    ),
+    "call_ratio_backspread": StrategyTemplate(
+        id="call_ratio_backspread",
+        name="Call Ratio Backspread",
+        category="bullish",
+        views=["BULLISH"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.0, lots_multiplier=1),
+            TemplateLeg("CE", "BUY", 0.03, lots_multiplier=2),
+        ],
+        max_profit="Unlimited above the long strike; also profits if stock falls sharply",
+        max_loss="Maximum loss between the two strikes near expiry",
+        ideal_iv="low",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Sell 1 ATM call and buy 2 OTM calls. The position profits from a large rally "
+            "or a sharp fall (if entered for a net credit). The loss zone is between the two strikes. "
+            "Traders use this to get leveraged upside with a credit or near-zero cost."
+        ),
+        when_to_use="Expecting a large breakout up; also acceptable for a crash scenario.",
+        when_not_to_use="When the stock is expected to stay range-bound — maximum loss occurs there.",
+        risks=[
+            "Maximum loss if stock pins between the short and long strikes at expiry",
+            "Requires 2× the long legs — more commission",
+            "Complex to manage and exit",
+        ],
+        tags=["directional", "ratio", "unlimited_profit", "advanced"],
+        capital_type="credit",
+        complexity="advanced",
+    ),
+    # ── BEARISH ───────────────────────────────────────────────
+    "long_put": StrategyTemplate(
+        id="long_put",
+        name="Long Put",
+        category="bearish",
+        views=["BEARISH"],
+        legs=[TemplateLeg("PE", "BUY", 0.0)],
+        max_profit="Substantial — profits as stock falls below breakeven",
+        max_loss="Limited to premium paid",
+        ideal_iv="low",
+        ideal_dte=(7, 45),
+        explanation=(
+            "Buy an ATM put option for the right to sell the underlying at the strike. "
+            "Profits grow as the stock falls; max loss is the premium paid if stock rises or stays flat. "
+            "The mirror image of the long call for bearish directional trades."
+        ),
+        when_to_use="Strong bearish conviction; expecting a fast, meaningful decline before expiry.",
+        when_not_to_use="When IV is high — premium is expensive and the stock must fall more to profit.",
+        risks=[
+            "Full premium lost if stock stays flat or rises",
+            "Theta decay: put loses value every day if stock doesn't move",
+            "Stock can only fall to zero — downside is capped unlike short stock",
+        ],
+        tags=["directional", "debit", "defined_risk", "beginner"],
+        capital_type="debit",
+        complexity="beginner",
+    ),
+    "bear_put_spread": StrategyTemplate(
+        id="bear_put_spread",
+        name="Bear Put Spread",
+        category="bearish",
+        views=["BEARISH"],
+        legs=[
+            TemplateLeg("PE", "BUY", 0.0),
+            TemplateLeg("PE", "SELL", -0.03),
+        ],
+        max_profit="Capped — spread width minus net debit",
+        max_loss="Net debit paid",
+        ideal_iv="low",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Buy an ATM put and sell an OTM put at the same expiry. "
+            "Profits from a moderate decline; the short put caps the downside gain "
+            "but meaningfully reduces the premium outlay vs a naked long put."
+        ),
+        when_to_use="Moderately bearish; want cheaper downside exposure than a naked put.",
+        when_not_to_use="When expecting a crash — profits are capped at the short put strike.",
+        risks=[
+            "Max profit capped at the short put strike",
+            "Full debit lost if stock rises or stays flat",
+            "Needs the stock to fall at least to breakeven to profit",
+        ],
+        tags=["directional", "debit", "defined_risk", "spread", "beginner"],
+        capital_type="debit",
+        complexity="beginner",
+    ),
+    "bear_call_spread": StrategyTemplate(
+        id="bear_call_spread",
+        name="Bear Call Spread",
+        category="bearish",
+        views=["BEARISH", "NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.02),
+            TemplateLeg("CE", "BUY", 0.05),
+        ],
+        max_profit="Net credit received",
+        max_loss="Spread width minus net credit",
+        ideal_iv="high",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Sell an OTM call and buy a further OTM call for protection. "
+            "Collect a net credit; keep it if the stock stays below the short call. "
+            "A credit spread that benefits from time decay and bearish or sideways price action."
+        ),
+        when_to_use="Moderately bearish or neutral; high IV inflating call premiums.",
+        when_not_to_use="When strongly bullish — you have unlimited loss above the long call if not hedged.",
+        risks=[
+            "Full spread-width loss if stock rallies above the long call strike",
+            "Requires margin for the short call",
+            "Profit capped at the initial credit received",
+        ],
+        tags=["credit", "defined_risk", "spread", "theta", "intermediate"],
+        capital_type="credit",
+        complexity="intermediate",
+    ),
+    "synthetic_short": StrategyTemplate(
+        id="synthetic_short",
+        name="Synthetic Short",
+        category="bearish",
+        views=["BEARISH"],
+        legs=[
+            TemplateLeg("PE", "BUY", 0.0),
+            TemplateLeg("CE", "SELL", 0.0),
+        ],
+        max_profit="Substantial — mirrors short stock downside",
+        max_loss="Effectively unlimited on the upside (call assignment risk)",
+        ideal_iv="any",
+        ideal_dte=(30, 90),
+        explanation=(
+            "Buy an ATM put and sell an ATM call at the same strike and expiry. "
+            "The payoff mimics short-selling the stock without actually borrowing shares. "
+            "Profits on a decline; exposed to unlimited loss if the stock rallies."
+        ),
+        when_to_use="Strong bearish conviction; want stock-short-like exposure without a margin account.",
+        when_not_to_use="When uncertain — the short call carries unlimited upside risk.",
+        risks=[
+            "Unlimited upside risk via short call assignment",
+            "Large margin requirement for the short call",
+            "Early assignment risk near expiry",
+        ],
+        tags=["directional", "margin", "unlimited_risk", "leverage", "advanced"],
+        capital_type="margin",
+        complexity="advanced",
+    ),
+    "put_ratio_backspread": StrategyTemplate(
+        id="put_ratio_backspread",
+        name="Put Ratio Backspread",
+        category="bearish",
+        views=["BEARISH"],
+        legs=[
+            TemplateLeg("PE", "SELL", 0.0, lots_multiplier=1),
+            TemplateLeg("PE", "BUY", -0.03, lots_multiplier=2),
+        ],
+        max_profit="Substantial below the long put strike; also profits on a sharp rally",
+        max_loss="Maximum loss between the two strikes near expiry",
+        ideal_iv="low",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Sell 1 ATM put and buy 2 OTM puts. Profits from a large decline "
+            "or a sharp rally (if entered for a net credit). Loss zone is between the two strikes. "
+            "Mirror of the call ratio backspread for bearish directional bets."
+        ),
+        when_to_use="Expecting a large breakdown; also works for a crash hedge.",
+        when_not_to_use="Range-bound markets — maximum loss occurs between the two strikes.",
+        risks=[
+            "Maximum loss if stock pins between short and long strikes at expiry",
+            "2× the long legs means higher commissions",
+            "Difficult to manage once in the loss zone",
+        ],
+        tags=["directional", "ratio", "advanced"],
+        capital_type="credit",
+        complexity="advanced",
+    ),
+    # ── INCOME ────────────────────────────────────────────────
+    "iron_condor": StrategyTemplate(
+        id="iron_condor",
+        name="Iron Condor",
+        category="income",
+        views=["NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.03),
+            TemplateLeg("CE", "BUY", 0.06),
+            TemplateLeg("PE", "SELL", -0.03),
+            TemplateLeg("PE", "BUY", -0.06),
+        ],
+        max_profit="Net credit received",
+        max_loss="Wing width minus net credit (defined)",
+        ideal_iv="high",
+        ideal_dte=(20, 45),
+        explanation=(
+            "Sell an OTM call spread and an OTM put spread simultaneously. "
+            "Profits if the underlying stays between the two short strikes through expiry. "
+            "The net credit received is the maximum profit; the wing width limits the loss."
+        ),
+        when_to_use="After an IV spike when you expect range-bound action; high VIX environment.",
+        when_not_to_use="When a strong directional catalyst is pending or IV is already low.",
+        risks=[
+            "Full wing-width loss if price breaks out of the profit zone",
+            "Requires four legs — higher transaction costs",
+            "Assignment risk if a short leg goes deep ITM near expiry",
+        ],
+        tags=[
+            "neutral",
+            "income",
+            "defined_risk",
+            "credit",
+            "high_iv",
+            "four_legs",
+            "intermediate",
+        ],
+        capital_type="credit",
+        complexity="intermediate",
+    ),
+    "iron_butterfly": StrategyTemplate(
+        id="iron_butterfly",
+        name="Iron Butterfly",
+        category="income",
+        views=["NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.0),
+            TemplateLeg("CE", "BUY", 0.04),
+            TemplateLeg("PE", "SELL", 0.0),
+            TemplateLeg("PE", "BUY", -0.04),
+        ],
+        max_profit="Net credit received (both short legs at ATM)",
+        max_loss="Wing width minus net credit",
+        ideal_iv="high",
+        ideal_dte=(15, 30),
+        explanation=(
+            "Sell ATM call and put (straddle) and buy OTM wings for protection. "
+            "Higher credit than an iron condor because the short strikes are ATM, "
+            "but the profit zone is narrower — stock must pin near the short strikes."
+        ),
+        when_to_use="Very high IV around a specific price level; expecting a pin at expiry.",
+        when_not_to_use="When any meaningful move is expected — profit zone is tight.",
+        risks=[
+            "Profit zone is very narrow; any significant move causes a loss",
+            "ATM short strikes have high gamma risk near expiry",
+            "More expensive to close early due to wide bid-ask on 4 legs",
+        ],
+        tags=["neutral", "income", "credit", "high_iv", "four_legs", "intermediate"],
+        capital_type="credit",
+        complexity="intermediate",
+    ),
+    "short_straddle": StrategyTemplate(
+        id="short_straddle",
+        name="Short Straddle",
+        category="income",
+        views=["NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.0),
+            TemplateLeg("PE", "SELL", 0.0),
+        ],
+        max_profit="Net credit (both ATM premiums)",
+        max_loss="Unlimited in either direction",
+        ideal_iv="high",
+        ideal_dte=(15, 30),
+        explanation=(
+            "Sell an ATM call and an ATM put at the same strike and expiry. "
+            "You collect the combined premium; the stock must stay near the strike to profit. "
+            "This is the highest-credit income strategy but carries unlimited risk on both sides."
+        ),
+        when_to_use="Extreme IV crush expected (post-earnings, post-event); very high VIX.",
+        when_not_to_use="When any directional move is expected — losses are unlimited.",
+        risks=[
+            "Unlimited loss if stock makes a large move in either direction",
+            "High margin requirement — broker may require 15-20% of notional",
+            "Gamma risk is severe in the last week before expiry",
+        ],
+        tags=["neutral", "income", "margin", "unlimited_risk", "high_iv", "advanced"],
+        capital_type="margin",
+        complexity="advanced",
+    ),
+    "short_strangle": StrategyTemplate(
+        id="short_strangle",
+        name="Short Strangle",
+        category="income",
+        views=["NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.03),
+            TemplateLeg("PE", "SELL", -0.03),
+        ],
+        max_profit="Net credit (both OTM premiums)",
+        max_loss="Unlimited in either direction",
+        ideal_iv="high",
+        ideal_dte=(15, 30),
+        explanation=(
+            "Sell an OTM call and an OTM put at the same expiry. "
+            "The profit zone is wider than a short straddle (between the two short strikes) "
+            "but the credit collected is smaller. Still carries unlimited risk on both sides."
+        ),
+        when_to_use="Expecting range-bound action after high-IV event; wider comfort zone than straddle.",
+        when_not_to_use="When any large directional move is possible — unlimited loss potential.",
+        risks=[
+            "Unlimited loss outside the short strikes",
+            "Requires large margin",
+            "One losing leg can exceed many months of premium income",
+        ],
+        tags=["neutral", "income", "margin", "unlimited_risk", "high_iv", "advanced"],
+        capital_type="margin",
+        complexity="advanced",
+    ),
+    "covered_call": StrategyTemplate(
+        id="covered_call",
+        name="Covered Call",
+        category="income",
+        views=["NEUTRAL", "BULLISH"],
+        legs=[
+            TemplateLeg("STOCK", "BUY", 0.0),
+            TemplateLeg("CE", "SELL", 0.03),
+        ],
+        max_profit="Capped — (short call strike - stock buy price + premium received)",
+        max_loss="Stock falls to zero minus premium received",
+        ideal_iv="any",
+        ideal_dte=(20, 45),
+        explanation=(
+            "Own the stock and sell an OTM call against it each month. "
+            "The premium reduces your cost basis and provides income; "
+            "the call caps your upside if the stock rallies past the strike. "
+            "Best suited for stocks you plan to hold long-term."
+        ),
+        when_to_use="Already own shares; want to generate monthly income and are willing to sell if called.",
+        when_not_to_use="When expecting a large rally — the call caps your gains.",
+        risks=[
+            "Stock position still has full downside (premium provides only small buffer)",
+            "Opportunity cost if stock surges past the short strike",
+            "Tax implications of stock assignment",
+        ],
+        tags=["income", "stock", "theta", "beginner"],
+        capital_type="stock",
+        complexity="beginner",
+    ),
+    "cash_secured_put": StrategyTemplate(
+        id="cash_secured_put",
+        name="Cash-Secured Put",
+        category="income",
+        views=["NEUTRAL", "BULLISH"],
+        legs=[TemplateLeg("PE", "SELL", -0.03)],
+        max_profit="Net premium received",
+        max_loss="Short put strike minus premium (stock falls to zero)",
+        ideal_iv="any",
+        ideal_dte=(20, 45),
+        explanation=(
+            "Sell an OTM put and set aside the capital to buy the shares if assigned. "
+            "You earn the premium and may acquire the stock at a price you are happy to own it. "
+            "If the stock stays above the strike, you keep the premium and repeat."
+        ),
+        when_to_use="Willing to buy a stock at a lower price; want to earn income while waiting.",
+        when_not_to_use="When you would not actually want to own the stock at the strike price.",
+        risks=[
+            "Obligated to buy shares at strike even if stock keeps falling",
+            "Premium earned may not cover a large price decline",
+            "Capital is tied up as margin/collateral",
+        ],
+        tags=["income", "margin", "theta", "beginner"],
+        capital_type="margin",
+        complexity="beginner",
+    ),
+    "jade_lizard": StrategyTemplate(
+        id="jade_lizard",
+        name="Jade Lizard",
+        category="income",
+        views=["NEUTRAL", "BULLISH"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.03),
+            TemplateLeg("PE", "SELL", -0.03),
+            TemplateLeg("PE", "BUY", -0.06),
+        ],
+        max_profit="Net credit received (no upside risk if credit > call strike distance)",
+        max_loss="Put spread width minus total credit (downside risk only)",
+        ideal_iv="high",
+        ideal_dte=(20, 40),
+        explanation=(
+            "Sell an OTM call, sell an OTM put, and buy a further OTM put for protection. "
+            "The total credit exceeds the call strike distance, eliminating upside risk. "
+            "All risk is on the downside, limited to the put spread width minus the credit received."
+        ),
+        when_to_use="Bullish to neutral; high IV; want no upside risk and defined downside.",
+        when_not_to_use="Bearish outlook — all risk is on the downside put spread.",
+        risks=[
+            "Put spread width loss if stock falls sharply",
+            "Short call can still lose if stock rallies but credit is insufficient",
+            "Three legs require more commission and management",
+        ],
+        tags=["income", "credit", "high_iv", "defined_risk", "advanced"],
+        capital_type="credit",
+        complexity="advanced",
+    ),
+    # ── VOLATILITY ────────────────────────────────────────────
+    "long_straddle": StrategyTemplate(
+        id="long_straddle",
+        name="Long Straddle",
+        category="volatility",
+        views=["BULLISH", "BEARISH"],
+        legs=[
+            TemplateLeg("CE", "BUY", 0.0),
+            TemplateLeg("PE", "BUY", 0.0),
+        ],
+        max_profit="Unlimited in either direction",
+        max_loss="Total premium paid for both legs",
+        ideal_iv="low",
+        ideal_dte=(15, 60),
+        explanation=(
+            "Buy an ATM call and an ATM put at the same strike and expiry. "
+            "Profits from a large move in either direction; the exact direction does not matter. "
+            "Best entered when IV is low and a big event (earnings, RBI, budget) is upcoming."
+        ),
+        when_to_use="Large move expected but direction uncertain; IV is low before a known catalyst.",
+        when_not_to_use="When IV is already high — you pay a large premium and need an even bigger move.",
+        risks=[
+            "Full combined premium lost if stock stays near the strike",
+            "IV crush after the event can wipe out gains even if the stock moves",
+            "Expensive — both legs are ATM so total premium is high",
+        ],
+        tags=["volatility", "debit", "unlimited_profit", "event_driven", "beginner"],
+        capital_type="debit",
+        complexity="beginner",
+    ),
+    "long_strangle": StrategyTemplate(
+        id="long_strangle",
+        name="Long Strangle",
+        category="volatility",
+        views=["BULLISH", "BEARISH"],
+        legs=[
+            TemplateLeg("CE", "BUY", 0.03),
+            TemplateLeg("PE", "BUY", -0.03),
+        ],
+        max_profit="Unlimited in either direction beyond the breakevens",
+        max_loss="Total premium paid (less than straddle)",
+        ideal_iv="low",
+        ideal_dte=(15, 60),
+        explanation=(
+            "Buy an OTM call and an OTM put at the same expiry. "
+            "Cheaper than a straddle because both legs are OTM; "
+            "however, the stock needs to move more to profit. "
+            "Suits traders who want volatility exposure with a lower absolute cost."
+        ),
+        when_to_use="Large move expected; want lower premium cost than a straddle.",
+        when_not_to_use="Slow-moving markets — the required move to breakeven is larger than a straddle.",
+        risks=[
+            "Needs a bigger move than a straddle to start profiting",
+            "Both legs can expire worthless if the stock stays range-bound",
+            "IV crush after events can hurt even if the stock moves",
+        ],
+        tags=["volatility", "debit", "event_driven", "beginner"],
+        capital_type="debit",
+        complexity="beginner",
+    ),
+    "long_calendar_spread": StrategyTemplate(
+        id="long_calendar_spread",
+        name="Long Calendar Spread",
+        category="volatility",
+        views=["NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.0),  # near-term expiry (shorter)
+            TemplateLeg("CE", "BUY", 0.0),  # far-term expiry (longer)
+        ],
+        max_profit="Near-term premium captured as near leg decays; far leg retains value",
+        max_loss="Net debit paid (far premium minus near premium received)",
+        ideal_iv="any",
+        ideal_dte=(15, 45),
+        explanation=(
+            "Sell a near-term ATM call and buy a longer-term ATM call at the same strike. "
+            "The near-term leg decays faster; you profit from the difference in theta decay rates. "
+            "Note: this template approximates both legs at the same expiry for display purposes — "
+            "in practice the two legs have different expiry dates."
+        ),
+        when_to_use="Expecting stock to stay near the strike in the near term but move later.",
+        when_not_to_use="When a large near-term move is expected — the short near-term call is exposed.",
+        risks=[
+            "Large near-term move causes the short leg to lose faster than the long leg gains",
+            "IV differential risk — if near-term IV rises more than far-term IV",
+            "Requires rolling the near leg at expiry if position is to continue",
+        ],
+        tags=["volatility", "debit", "theta", "calendar", "intermediate"],
+        capital_type="debit",
+        complexity="intermediate",
+    ),
+    "diagonal_spread": StrategyTemplate(
+        id="diagonal_spread",
+        name="Diagonal Spread",
+        category="volatility",
+        views=["BULLISH", "NEUTRAL"],
+        legs=[
+            TemplateLeg("CE", "SELL", 0.02),  # near-term slightly OTM
+            TemplateLeg("CE", "BUY", 0.0),  # far-term ATM
+        ],
+        max_profit="Near-term credit plus intrinsic value of far leg if stock rises moderately",
+        max_loss="Net debit paid (far premium minus near credit received)",
+        ideal_iv="any",
+        ideal_dte=(20, 60),
+        explanation=(
+            "Sell a near-term OTM call and buy a far-term ATM call — different strikes and expiries. "
+            "Combines the theta benefit of the short near leg with the directional benefit of the long far leg. "
+            "This is a hybrid between a covered call and a calendar spread."
+        ),
+        when_to_use="Mildly bullish; want to reduce far-leg cost by selling near-term premium.",
+        when_not_to_use="When expecting a fast, large move — the short near call caps immediate gains.",
+        risks=[
+            "Short near call can be challenged if stock rallies quickly",
+            "Complex to manage — two different expiry dates",
+            "Vega sensitivity differs between the two legs",
+        ],
+        tags=["volatility", "debit", "calendar", "theta", "advanced"],
+        capital_type="debit",
+        complexity="advanced",
+    ),
+    # ── HEDGING ───────────────────────────────────────────────
+    "protective_put": StrategyTemplate(
+        id="protective_put",
+        name="Protective Put",
+        category="hedging",
+        views=["BULLISH"],
+        legs=[
+            TemplateLeg("STOCK", "BUY", 0.0),
+            TemplateLeg("PE", "BUY", -0.02),
+        ],
+        max_profit="Unlimited — stock upside minus put premium cost",
+        max_loss="(Stock price - put strike + put premium) per share × lot size",
+        ideal_iv="any",
+        ideal_dte=(30, 90),
+        explanation=(
+            "Own the stock and buy a slightly OTM put as insurance. "
+            "If the stock falls, the put gains value and limits your downside. "
+            "If the stock rises, you keep the full upside minus the put premium paid."
+        ),
+        when_to_use="Already own the stock and want downside protection before a risky event.",
+        when_not_to_use="When the cost of protection (put premium) is too high relative to position size.",
+        risks=[
+            "Put premium is a recurring cost — erodes returns if paid every month",
+            "If stock stays flat, you lose the premium repeatedly",
+            "High IV makes protective puts expensive",
+        ],
+        tags=["hedging", "debit", "defined_risk", "stock", "insurance", "beginner"],
+        capital_type="stock",
+        complexity="beginner",
+    ),
+    "collar": StrategyTemplate(
+        id="collar",
+        name="Collar",
+        category="hedging",
+        views=["NEUTRAL", "BULLISH"],
+        legs=[
+            TemplateLeg("STOCK", "BUY", 0.0),
+            TemplateLeg("PE", "BUY", -0.05),
+            TemplateLeg("CE", "SELL", 0.05),
+        ],
+        max_profit="Capped — (short call strike - stock price + net option credit/debit)",
+        max_loss="(Stock price - long put strike + net option debit) — defined",
+        ideal_iv="any",
+        ideal_dte=(30, 90),
+        explanation=(
+            "Own the stock, buy a downside put for protection, and sell an upside call to fund the put. "
+            "The sold call partially or fully offsets the cost of the protective put. "
+            "Both upside and downside are bounded — this is a zero-cost or near-zero-cost hedge."
+        ),
+        when_to_use="Holding a large stock position; want cheap or free downside protection.",
+        when_not_to_use="When expecting a strong rally — the short call caps your upside.",
+        risks=[
+            "Upside capped at the short call strike",
+            "Still exposed to downside between stock price and put strike",
+            "Tax implications if short call is assigned",
+        ],
+        tags=["hedging", "stock", "defined_risk", "zero_cost", "intermediate"],
+        capital_type="stock",
+        complexity="intermediate",
+    ),
+    "married_put": StrategyTemplate(
+        id="married_put",
+        name="Married Put",
+        category="hedging",
+        views=["BULLISH"],
+        legs=[
+            TemplateLeg("STOCK", "BUY", 0.0),
+            TemplateLeg("PE", "BUY", 0.0),
+        ],
+        max_profit="Unlimited — stock upside minus ATM put premium",
+        max_loss="Put premium paid (stock is protected at ATM strike)",
+        ideal_iv="any",
+        ideal_dte=(30, 60),
+        explanation=(
+            "Buy the stock and simultaneously buy an ATM put. "
+            "The put fully protects the position — if the stock falls, the put gains dollar-for-dollar. "
+            "Maximum loss is just the put premium. Effectively a call option on the stock."
+        ),
+        when_to_use="Initiating a new stock position with full downside protection from day one.",
+        when_not_to_use="When protection cost is high — ATM puts are expensive and eat into returns.",
+        risks=[
+            "ATM put premium is substantial — expensive insurance",
+            "Stock must rise more than the put premium to be profitable",
+            "If stock stays flat, put expires worthless and you lose the premium",
+        ],
+        tags=["hedging", "stock", "defined_risk", "insurance", "beginner"],
+        capital_type="stock",
+        complexity="beginner",
+    ),
+    "seagull": StrategyTemplate(
+        id="seagull",
+        name="Seagull Spread",
+        category="hedging",
+        views=["NEUTRAL", "BULLISH"],
+        legs=[
+            TemplateLeg("PE", "BUY", -0.03),
+            TemplateLeg("PE", "SELL", -0.06),
+            TemplateLeg("CE", "SELL", 0.05),
+        ],
+        max_profit="Net credit or near-zero cost; profits if stock holds or rises moderately",
+        max_loss="Put spread width minus total net credit received — defined downside",
+        ideal_iv="high",
+        ideal_dte=(30, 90),
+        explanation=(
+            "Buy an OTM put, sell a further OTM put, and sell an OTM call. "
+            "The put spread provides cheap downside protection; the short call funds it. "
+            "The three-way structure typically costs near-zero or generates a small credit, "
+            "making it popular for cost-efficient portfolio hedging."
+        ),
+        when_to_use="Want cheap downside protection on a stock you own; high IV reduces cost further.",
+        when_not_to_use="When expecting a large upside rally — the short call caps gains significantly.",
+        risks=[
+            "Short call caps upside beyond the call strike",
+            "Still exposed below the short put strike (put spread does not protect fully)",
+            "Three legs require more commission and careful management",
+        ],
+        tags=["hedging", "credit", "defined_risk", "three_legs", "intermediate"],
+        capital_type="credit",
+        complexity="intermediate",
+    ),
+    "long_fence": StrategyTemplate(
+        id="long_fence",
+        name="Long Fence",
+        category="hedging",
+        views=["NEUTRAL", "BULLISH"],
+        legs=[
+            TemplateLeg("PE", "BUY", -0.03),
+            TemplateLeg("CE", "SELL", 0.05),
+        ],
+        max_profit="Capped at the short call strike — profitable if stock stays in range or rises to call",
+        max_loss="(Stock price - put strike - net credit) if stock falls below put",
+        ideal_iv="any",
+        ideal_dte=(30, 60),
+        explanation=(
+            "Buy a slightly OTM put and sell a further OTM call (no stock position). "
+            "The short call funds the put and provides a net credit or near-zero cost hedge. "
+            "Used as a standalone position or to hedge an existing stock holding cheaply."
+        ),
+        when_to_use="Cheap downside protection when you don't want to pay full put premium.",
+        when_not_to_use="When expecting a big rally — the short call caps gains significantly.",
+        risks=[
+            "Upside capped by the short call",
+            "Still exposed below the put strike (downside not fully protected)",
+            "Short call carries assignment risk if stock rallies sharply",
+        ],
+        tags=["hedging", "credit", "defined_risk", "intermediate"],
+        capital_type="credit",
+        complexity="intermediate",
+    ),
+}
+
+
+# ── StrategyLibrary class ─────────────────────────────────────
+
+
+class StrategyLibrary:
+    """Registry and search interface for the options strategy template library."""
+
+    def __init__(self, templates: dict[str, StrategyTemplate]) -> None:
+        self._templates = templates
+
+    def list_all(self) -> list[StrategyTemplate]:
+        """Return all templates sorted by category (CATEGORIES order) then name."""
+        cat_order = {c: i for i, c in enumerate(CATEGORIES)}
+        return sorted(
+            self._templates.values(),
+            key=lambda t: (cat_order.get(t.category, 99), t.name),
+        )
+
+    def list_by_category(self, category: str) -> list[StrategyTemplate]:
+        """Filter by category (case-insensitive). Raises ValueError for unknown categories."""
+        cat = category.lower()
+        if cat not in CATEGORIES:
+            raise ValueError(
+                f"Unknown category '{category}'. Valid categories: {', '.join(CATEGORIES)}"
+            )
+        return [t for t in self.list_all() if t.category == cat]
+
+    def get(self, id: str) -> StrategyTemplate:
+        """Exact-match lookup by id. Raises KeyError if not found."""
+        if id not in self._templates:
+            raise KeyError(
+                f"Strategy '{id}' not found. Run 'strategy library' to see all available strategies."
+            )
+        return self._templates[id]
+
+    def search(self, query: str) -> list[StrategyTemplate]:
+        """
+        Case-insensitive search across id, name, tags, views, and explanation.
+        Returns list sorted by relevance (name/id matches rank highest).
+        """
+        q = query.lower()
+        results: list[tuple[int, StrategyTemplate]] = []
+        for t in self._templates.values():
+            score = 0
+            if q in t.id:
+                score += 3
+            if q in t.name.lower():
+                score += 3
+            if any(q in tag for tag in t.tags):
+                score += 2
+            if any(q in v.lower() for v in t.views):
+                score += 1
+            if q in t.explanation.lower():
+                score += 1
+            if score > 0:
+                results.append((score, t))
+        results.sort(key=lambda x: x[0], reverse=True)
+        return [t for _, t in results]
+
+
+# ── Module-level singleton ────────────────────────────────────
+
+strategy_library = StrategyLibrary(TEMPLATES)
+
+
+# ── Premium resolution helpers ────────────────────────────────
+
+
+def _resolve_premium(
+    leg: TemplateLeg,
+    atm_ce_prem: float,
+    atm_pe_prem: float,
+) -> float:
+    """
+    Estimate the premium for a leg given ATM premiums.
+
+    Uses exponential moneyness decay consistent with market behaviour:
+    - k=10 gives ~74% of ATM at 3% OTM, ~55% at 6% OTM.
+    - ITM options are scaled up proportionally.
+    """
+    if leg.option_type == "STOCK":
+        return 0.0
+
+    offset = leg.strike_offset_pct
+    abs_offset = abs(offset)
+
+    if leg.option_type == "CE":
+        base = atm_ce_prem
+        if offset > 0:
+            # OTM call — apply decay
+            resolved = base * math.exp(-10 * abs_offset)
+        elif offset < 0:
+            # ITM call — premium increases
+            resolved = base * (1 + abs_offset * 3)
+        else:
+            resolved = base
+    else:  # PE
+        base = atm_pe_prem
+        if offset < 0:
+            # OTM put — apply decay
+            resolved = base * math.exp(-10 * abs_offset)
+        elif offset > 0:
+            # ITM put — premium increases
+            resolved = base * (1 + abs_offset * 3)
+        else:
+            resolved = base
+
+    return max(1.0, round(resolved, 2))
+
+
+def _resolve_strike(atm_strike: float, spot: float, leg: TemplateLeg) -> float:
+    """Resolve the absolute strike for a template leg."""
+    if leg.option_type == "STOCK":
+        return spot
+    raw = atm_strike + spot * leg.strike_offset_pct
+    return round(raw / 100) * 100  # round to nearest 100 (Indian index strikes)
+
+
+def _fit_score(template: StrategyTemplate, dte: int) -> int:
+    """
+    Score 0–100 how well the given DTE fits the template's ideal range.
+    80 = within range, 60 = within 50% of range, 40 = well outside.
+    """
+    lo, hi = template.ideal_dte
+    if lo <= dte <= hi:
+        return 80
+    margin = (hi - lo) * 0.5
+    if (lo - margin) <= dte <= (hi + margin):
+        return 60
+    return 40
+
+
+def _build_description(
+    template: StrategyTemplate,
+    resolved: list[tuple[TemplateLeg, float, float]],  # (leg, strike, premium)
+    symbol: str,
+) -> str:
+    """One-line description: 'Buy 24000CE @ ₹150 + Sell 25000CE @ ₹55'."""
+    parts = []
+    for leg, strike, premium in resolved:
+        if leg.option_type == "STOCK":
+            parts.append(f"{leg.action} {symbol} stock @ ₹{strike:,.0f}")
+        else:
+            multiplier = f"×{leg.lots_multiplier} " if leg.lots_multiplier > 1 else ""
+            parts.append(f"{leg.action} {multiplier}{strike:.0f}{leg.option_type} @ ₹{premium:.0f}")
+    return " + ".join(parts)
+
+
+def _build_legs_dicts(
+    resolved: list[tuple[TemplateLeg, float, float]],
+    lots: int,
+) -> list[dict]:
+    """Build leg dicts in the same format as engine/strategy.py."""
+    legs = []
+    for leg, strike, premium in resolved:
+        d: dict = {
+            "action": leg.action,
+            "type": leg.option_type,
+            "strike": strike,
+            "lots": lots * leg.lots_multiplier,
+        }
+        if leg.option_type != "STOCK":
+            d["premium"] = premium
+        legs.append(d)
+    return legs
+
+
+# ── apply_template() ──────────────────────────────────────────
+
+
+def apply_template(
+    template: StrategyTemplate,
+    symbol: str,
+    spot: float,
+    atm_ce_prem: float,
+    atm_pe_prem: float,
+    atm_strike: float,
+    lot_size: int,
+    lots: int = 1,
+    dte: int = 30,
+) -> StrategyResult:
+    """
+    Resolve a StrategyTemplate with live market data and return a StrategyResult.
+
+    Args:
+        template:     The template to apply
+        symbol:       NSE symbol (e.g. "NIFTY")
+        spot:         Current spot price
+        atm_ce_prem:  ATM call premium
+        atm_pe_prem:  ATM put premium
+        atm_strike:   ATM strike price
+        lot_size:     Lot size for this symbol
+        lots:         Number of lots to trade (default 1)
+        dte:          Days to expiry (default 30)
+
+    Returns:
+        StrategyResult compatible with engine/strategy.py output format.
+    """
+    # Step 1: resolve each leg to (leg, strike, premium)
+    resolved: list[tuple[TemplateLeg, float, float]] = []
+    for leg in template.legs:
+        strike = _resolve_strike(atm_strike, spot, leg)
+        premium = _resolve_premium(leg, atm_ce_prem, atm_pe_prem)
+        resolved.append((leg, strike, premium))
+
+    unit = lot_size * lots  # total contracts in one lot-set
+
+    # Step 2: compute P&L metrics by capital_type
+    capital_needed, max_profit, max_loss, breakeven = _compute_pnl(
+        template, resolved, spot, atm_strike, unit
+    )
+
+    # Step 3: build payoff chart (options legs only)
+    pf = None
+    if _PAYOFF_AVAILABLE:
+        try:
+            payoff_legs = []
+            for leg, strike, premium in resolved:
+                if leg.option_type == "STOCK":
+                    continue
+                payoff_legs.append(
+                    PayoffLeg(
+                        option_type=leg.option_type,
+                        transaction=leg.action,
+                        strike=strike,
+                        premium=premium,
+                        lot_size=lot_size,
+                        lots=lots * leg.lots_multiplier,
+                    )
+                )
+            if payoff_legs:
+                pf = calc_payoff(payoff_legs, (spot * 0.80, spot * 1.20))
+        except Exception:
+            pf = None
+
+    # Step 4: assemble StrategyResult
+    rr = 0.0
+    if max_loss and max_loss != float("-inf") and max_profit and max_profit != float("inf"):
+        rr = round(abs(max_profit / max_loss), 2) if max_loss != 0 else 0.0
+
+    return StrategyResult(
+        name=template.name,
+        description=_build_description(template, resolved, symbol),
+        legs=_build_legs_dicts(resolved, lots),
+        capital_needed=round(capital_needed, 2),
+        max_profit=round(max_profit, 2),
+        max_loss=round(max_loss, 2),
+        breakeven=breakeven,
+        rr_ratio=rr,
+        fit_score=_fit_score(template, dte),
+        best_for=template.when_to_use,
+        risks="; ".join(template.risks[:2]),
+        payoff=pf,
+    )
+
+
+def _compute_pnl(
+    template: StrategyTemplate,
+    resolved: list[tuple[TemplateLeg, float, float]],
+    spot: float,
+    atm_strike: float,
+    unit: int,
+) -> tuple[float, float, float, list[float]]:
+    """
+    Compute (capital_needed, max_profit, max_loss, breakeven) for a template.
+
+    Dispatches on template.capital_type for the appropriate formula.
+    Returns approximate values for complex multi-expiry structures.
+    """
+    # Helpers
+    buy_prems = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "BUY" and leg.option_type != "STOCK"
+    ]
+    sell_prems = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "SELL" and leg.option_type != "STOCK"
+    ]
+    stock_legs = [(leg, s, p) for leg, s, p in resolved if leg.option_type == "STOCK"]
+
+    total_buy = sum(p * leg.lots_multiplier for leg, _, p in buy_prems)
+    total_sell = sum(p * leg.lots_multiplier for leg, _, p in sell_prems)
+    net_debit = total_buy - total_sell
+    net_credit = total_sell - total_buy
+
+    cap_type = template.capital_type
+
+    if cap_type == "debit" and not stock_legs:
+        return _pnl_debit(template, resolved, net_debit, unit, atm_strike)
+
+    if cap_type == "credit" and not stock_legs:
+        return _pnl_credit(template, resolved, net_credit, net_debit, unit, atm_strike, spot)
+
+    if cap_type == "margin" and not stock_legs:
+        return _pnl_margin(template, resolved, net_credit, unit, spot)
+
+    if cap_type in ("stock", "debit", "credit") and stock_legs:
+        return _pnl_stock(template, resolved, net_credit, net_debit, unit, spot)
+
+    # Fallback: generic debit
+    capital = abs(net_debit) * unit
+    return capital, capital * 2, -capital, [atm_strike + net_debit]
+
+
+def _pnl_debit(
+    template: StrategyTemplate,
+    resolved: list[tuple[TemplateLeg, float, float]],
+    net_debit: float,
+    unit: int,
+    atm_strike: float,
+) -> tuple[float, float, float, list[float]]:
+    """P&L for pure debit strategies (long call, bear put spread, straddle, etc.)."""
+    capital = net_debit * unit
+    max_loss = -capital
+
+    legs_list = resolved
+    buy_ce = [
+        (leg, s, p) for leg, s, p in legs_list if leg.action == "BUY" and leg.option_type == "CE"
+    ]
+    buy_pe = [
+        (leg, s, p) for leg, s, p in legs_list if leg.action == "BUY" and leg.option_type == "PE"
+    ]
+    sell_ce = [
+        (leg, s, p) for leg, s, p in legs_list if leg.action == "SELL" and leg.option_type == "CE"
+    ]
+    sell_pe = [
+        (leg, s, p) for leg, s, p in legs_list if leg.action == "SELL" and leg.option_type == "PE"
+    ]
+
+    has_ce = bool(buy_ce)
+    has_pe = bool(buy_pe)
+    has_short_ce = bool(sell_ce)
+    has_short_pe = bool(sell_pe)
+
+    if has_ce and has_pe and not has_short_ce and not has_short_pe:
+        # Straddle / strangle — two breakevens
+        ce_strike = buy_ce[0][1]
+        pe_strike = buy_pe[0][1]
+        be_up = ce_strike + net_debit
+        be_dn = pe_strike - net_debit
+        max_profit = unit * (atm_strike * 0.25)  # large representative value
+        return capital, round(max_profit, 2), max_loss, sorted([round(be_dn, 2), round(be_up, 2)])
+
+    if has_ce and has_short_ce:
+        # Bull call spread / calendar
+        long_strike = buy_ce[0][1]
+        short_strike = sell_ce[0][1]
+        spread_width = abs(short_strike - long_strike)
+        if spread_width == 0:
+            # Calendar — same strike, approximate
+            max_profit = buy_ce[0][2] * unit * 0.5  # near leg premium capture estimate
+        else:
+            max_profit = (spread_width - net_debit) * unit
+        be = round(long_strike + net_debit, 2)
+        return capital, round(max_profit, 2), max_loss, [be]
+
+    if has_pe and has_short_pe:
+        # Bear put spread
+        long_strike = buy_pe[0][1]
+        short_strike = sell_pe[0][1]
+        spread_width = abs(long_strike - short_strike)
+        max_profit = (spread_width - net_debit) * unit
+        be = round(long_strike - net_debit, 2)
+        return capital, round(max_profit, 2), max_loss, [be]
+
+    if has_ce and not has_short_ce:
+        # Naked long call
+        ce_strike = buy_ce[0][1]
+        prem = buy_ce[0][2]
+        be = round(ce_strike + prem, 2)
+        max_profit = unit * ce_strike * 0.20  # representative uncapped value
+        return capital, round(max_profit, 2), max_loss, [be]
+
+    if has_pe and not has_short_pe:
+        # Naked long put
+        pe_strike = buy_pe[0][1]
+        prem = buy_pe[0][2]
+        be = round(pe_strike - prem, 2)
+        max_profit = unit * pe_strike * 0.20  # representative value
+        return capital, round(max_profit, 2), max_loss, [be]
+
+    # Fallback
+    return capital, capital * 2.0, max_loss, [atm_strike]
+
+
+def _pnl_credit(
+    template: StrategyTemplate,
+    resolved: list[tuple[TemplateLeg, float, float]],
+    net_credit: float,
+    net_debit: float,
+    unit: int,
+    atm_strike: float,
+    spot: float,
+) -> tuple[float, float, float, list[float]]:
+    """P&L for credit strategies (spreads, iron condor, jade lizard, ratio backspreads)."""
+    sell_ce = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "SELL" and leg.option_type == "CE"
+    ]
+    buy_ce = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "BUY" and leg.option_type == "CE"
+    ]
+    sell_pe = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "SELL" and leg.option_type == "PE"
+    ]
+    buy_pe = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "BUY" and leg.option_type == "PE"
+    ]
+
+    is_iron = bool(sell_ce and buy_ce and sell_pe and buy_pe)
+    is_call_spread = bool(sell_ce and buy_ce and not sell_pe and not buy_pe)
+    is_put_spread = bool(sell_pe and buy_pe and not sell_ce and not buy_ce)
+    is_ratio = any(leg.lots_multiplier > 1 for leg, _, _ in resolved)
+
+    if is_iron:
+        call_width = abs(buy_ce[0][1] - sell_ce[0][1])
+        put_width = abs(buy_pe[0][1] - sell_pe[0][1])
+        wing = max(call_width, put_width)
+        max_profit = net_credit * unit
+        capital = (wing - net_credit) * unit
+        max_loss = -(wing - net_credit) * unit
+        be_up = round(sell_ce[0][1] + net_credit, 2)
+        be_dn = round(sell_pe[0][1] - net_credit, 2)
+        return capital, round(max_profit, 2), round(max_loss, 2), sorted([be_dn, be_up])
+
+    if is_call_spread:
+        # Bear call spread
+        short_strike = sell_ce[0][1]
+        long_strike = buy_ce[0][1]
+        spread_width = abs(long_strike - short_strike)
+        max_profit = net_credit * unit
+        capital = (spread_width - net_credit) * unit
+        max_loss = -capital
+        be = round(short_strike + net_credit, 2)
+        return capital, round(max_profit, 2), round(max_loss, 2), [be]
+
+    if is_put_spread:
+        # Bull put spread
+        short_strike = sell_pe[0][1]
+        long_strike = buy_pe[0][1]
+        spread_width = abs(short_strike - long_strike)
+        max_profit = net_credit * unit
+        capital = (spread_width - net_credit) * unit
+        max_loss = -capital
+        be = round(short_strike - net_credit, 2)
+        return capital, round(max_profit, 2), round(max_loss, 2), [be]
+
+    if is_ratio:
+        # Ratio backspread (sell 1 ATM, buy 2 OTM)
+        # Net is usually a small credit or near-zero debit
+        if net_credit >= 0:
+            capital = max(0.0, spot * unit * 0.05)  # approximate margin for 1 short leg
+        else:
+            capital = abs(net_debit) * unit
+
+        # Max loss is at the long strike (between short and long)
+        if buy_ce:
+            loss_zone = abs(buy_ce[0][1] - sell_ce[0][1]) if sell_ce else spot * 0.05
+        elif buy_pe:
+            loss_zone = abs(sell_pe[0][1] - buy_pe[0][1]) if sell_pe else spot * 0.05
+        else:
+            loss_zone = spot * 0.05
+
+        max_loss = -(loss_zone - net_credit) * unit
+        max_profit = unit * spot * 0.20  # large representative value
+        return capital, round(max_profit, 2), round(max_loss, 2), [atm_strike]
+
+    # Jade lizard / other mixed credit
+    if sell_ce and sell_pe and buy_pe:
+        # Jade lizard: short OTM call + short OTM put + long further OTM put
+        put_spread_width = abs(buy_pe[0][1] - sell_pe[0][1])
+        max_profit = net_credit * unit
+        capital = max(0.0, (put_spread_width - net_credit) * unit)
+        max_loss = -capital
+        be = round(sell_pe[0][1] - net_credit, 2)
+        return capital, round(max_profit, 2), round(max_loss, 2), [be]
+
+    # Generic credit fallback
+    capital = max(net_credit * unit * 2, unit * spot * 0.05)
+    return capital, net_credit * unit, -capital, [atm_strike]
+
+
+def _pnl_margin(
+    template: StrategyTemplate,
+    resolved: list[tuple[TemplateLeg, float, float]],
+    net_credit: float,
+    unit: int,
+    spot: float,
+) -> tuple[float, float, float, list[float]]:
+    """P&L for naked sells (short straddle, short strangle, synthetic long/short)."""
+    sell_ce = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "SELL" and leg.option_type == "CE"
+    ]
+    buy_ce = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "BUY" and leg.option_type == "CE"
+    ]
+    sell_pe = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "SELL" and leg.option_type == "PE"
+    ]
+    buy_pe = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "BUY" and leg.option_type == "PE"
+    ]
+
+    # Margin approximation: ~15% of notional per short leg
+    short_count = len(sell_ce) + len(sell_pe)
+    capital = round(spot * unit * 0.15 * short_count, 2)
+    max_profit = net_credit * unit
+
+    # Short straddle / strangle
+    if sell_ce and sell_pe and not buy_ce and not buy_pe:
+        be_up = round(sell_ce[0][1] + net_credit, 2)
+        be_dn = round(sell_pe[0][1] - net_credit, 2)
+        max_loss = -(spot * unit * 0.15)  # representative large loss
+        return capital, round(max_profit, 2), round(max_loss, 2), sorted([be_dn, be_up])
+
+    # Synthetic long (buy CE, sell PE)
+    if buy_ce and sell_pe:
+        be = round(buy_ce[0][1] - (sell_pe[0][2] - buy_ce[0][2]), 2)
+        max_profit = unit * spot * 0.20
+        max_loss = -(unit * spot * 0.20)
+        return capital, round(max_profit, 2), round(max_loss, 2), [be]
+
+    # Synthetic short (buy PE, sell CE)
+    if buy_pe and sell_ce:
+        be = round(buy_pe[0][1] + (sell_ce[0][2] - buy_pe[0][2]), 2)
+        max_profit = unit * spot * 0.20
+        max_loss = -(unit * spot * 0.20)
+        return capital, round(max_profit, 2), round(max_loss, 2), [be]
+
+    return capital, round(max_profit, 2), -(capital), [spot]
+
+
+def _pnl_stock(
+    template: StrategyTemplate,
+    resolved: list[tuple[TemplateLeg, float, float]],
+    net_credit: float,
+    net_debit: float,
+    unit: int,
+    spot: float,
+) -> tuple[float, float, float, list[float]]:
+    """P&L for strategies involving a stock position (covered call, collar, etc.)."""
+    sell_ce = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "SELL" and leg.option_type == "CE"
+    ]
+    buy_pe = [
+        (leg, s, p) for leg, s, p in resolved if leg.action == "BUY" and leg.option_type == "PE"
+    ]
+
+    stock_cost = spot * unit
+    option_net = (
+        net_credit  # positive = net credit (covered call), negative = net debit (protective put)
+    )
+
+    # Capital = stock purchase minus any net credit from options
+    capital = max(stock_cost - option_net * unit, stock_cost * 0.5)
+
+    if sell_ce and not buy_pe:
+        # Covered call
+        call_strike = sell_ce[0][1]
+        call_prem = sell_ce[0][2]
+        max_profit_val = (call_strike - spot + call_prem) * unit
+        # Max loss = stock falls to zero - premium received
+        max_loss_val = -(spot - call_prem) * unit
+        be = round(spot - call_prem, 2)
+        return capital, round(max_profit_val, 2), round(max_loss_val, 2), [be]
+
+    if buy_pe and sell_ce:
+        # Collar
+        put_strike = buy_pe[0][1]
+        put_prem = buy_pe[0][2]
+        call_strike = sell_ce[0][1]
+        call_prem = sell_ce[0][2]
+        net_opt = call_prem - put_prem  # net credit/debit on options
+        max_profit_val = (call_strike - spot + net_opt) * unit
+        max_loss_val = -(spot - put_strike - net_opt) * unit
+        be = round(spot - net_opt, 2)
+        return capital, round(max_profit_val, 2), round(max_loss_val, 2), [be]
+
+    if buy_pe and not sell_ce:
+        # Protective put / married put
+        put_strike = buy_pe[0][1]
+        put_prem = buy_pe[0][2]
+        max_profit_val = spot * unit * 0.20  # large representative upside
+        # Loss is capped at (stock price - put strike + put premium)
+        max_loss_val = -(spot - put_strike + put_prem) * unit
+        be = round(spot + put_prem, 2)
+        return capital, round(max_profit_val, 2), round(max_loss_val, 2), [be]
+
+    # Fallback
+    return capital, capital * 0.15, -(capital * 0.85), [spot]

--- a/tests/test_strategy_library.py
+++ b/tests/test_strategy_library.py
@@ -83,6 +83,7 @@ class TestStrategyTemplate:
             max_loss="Premium paid",
             ideal_iv="low",
             ideal_dte=(15, 45),
+            layman_explanation="You pay a fee and profit if the stock goes up.",
             explanation="Buy a call option.",
             when_to_use="When strongly bullish.",
             when_not_to_use="When IV is high.",
@@ -165,6 +166,7 @@ class TestTemplatesDict:
             assert t.category in CATEGORIES, f"{sid}: invalid category"
             assert t.views, f"{sid}: empty views"
             assert t.legs, f"{sid}: no legs"
+            assert t.layman_explanation, f"{sid}: no layman_explanation"
             assert t.explanation, f"{sid}: no explanation"
             assert t.when_to_use, f"{sid}: no when_to_use"
             assert t.when_not_to_use, f"{sid}: no when_not_to_use"

--- a/tests/test_strategy_library.py
+++ b/tests/test_strategy_library.py
@@ -1,0 +1,497 @@
+"""
+tests/test_strategy_library.py
+───────────────────────────────
+Tests for engine/strategy_library.py — the curated options strategy template library.
+
+Covers:
+  - TemplateLeg and StrategyTemplate dataclass construction
+  - StrategyLibrary.list_all(), list_by_category(), get(), search()
+  - All 26 templates present with required fields
+  - apply_template() returns correct StrategyResult for each capital_type
+  - Breakeven, max_profit, max_loss, capital_needed calculations
+  - Fit score based on DTE
+  - Premium resolution (ATM, OTM scaling)
+  - Error handling: unknown id, unknown category
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from engine.strategy_library import (
+    CATEGORIES,
+    TEMPLATES,
+    StrategyLibrary,
+    StrategyTemplate,
+    TemplateLeg,
+    apply_template,
+    strategy_library,
+)
+from engine.strategy import StrategyResult
+
+
+# ── Shared ATM data for apply_template tests ──────────────────
+
+
+ATM_PARAMS = dict(
+    symbol="NIFTY",
+    spot=24000.0,
+    atm_ce_prem=150.0,
+    atm_pe_prem=140.0,
+    atm_strike=24000.0,
+    lot_size=75,
+    lots=1,
+    dte=30,
+)
+
+
+# ── TemplateLeg dataclass ─────────────────────────────────────
+
+
+class TestTemplateLeg:
+    def test_basic_construction(self):
+        leg = TemplateLeg(option_type="CE", action="BUY", strike_offset_pct=0.0)
+        assert leg.option_type == "CE"
+        assert leg.action == "BUY"
+        assert leg.strike_offset_pct == 0.0
+
+    def test_lots_multiplier_default_is_one(self):
+        leg = TemplateLeg(option_type="PE", action="SELL", strike_offset_pct=-0.03)
+        assert leg.lots_multiplier == 1
+
+    def test_lots_multiplier_explicit(self):
+        leg = TemplateLeg(option_type="CE", action="BUY", strike_offset_pct=0.03, lots_multiplier=2)
+        assert leg.lots_multiplier == 2
+
+    def test_stock_leg(self):
+        leg = TemplateLeg(option_type="STOCK", action="BUY", strike_offset_pct=0.0)
+        assert leg.option_type == "STOCK"
+
+
+# ── StrategyTemplate dataclass ────────────────────────────────
+
+
+class TestStrategyTemplate:
+    def _make_template(self, **overrides) -> StrategyTemplate:
+        defaults = dict(
+            id="test_strat",
+            name="Test Strategy",
+            category="bullish",
+            views=["BULLISH"],
+            legs=[TemplateLeg("CE", "BUY", 0.0)],
+            max_profit="Unlimited",
+            max_loss="Premium paid",
+            ideal_iv="low",
+            ideal_dte=(15, 45),
+            explanation="Buy a call option.",
+            when_to_use="When strongly bullish.",
+            when_not_to_use="When IV is high.",
+            risks=["Premium fully lost if stock doesn't move"],
+            tags=["directional", "debit"],
+            capital_type="debit",
+            complexity="beginner",
+        )
+        defaults.update(overrides)
+        return StrategyTemplate(**defaults)
+
+    def test_construction(self):
+        t = self._make_template()
+        assert t.id == "test_strat"
+        assert t.category == "bullish"
+        assert t.views == ["BULLISH"]
+
+    def test_capital_type_default(self):
+        t = self._make_template()
+        assert t.capital_type == "debit"
+
+    def test_complexity_default(self):
+        t = self._make_template()
+        assert t.complexity == "beginner"
+
+    def test_ideal_dte_tuple(self):
+        t = self._make_template(ideal_dte=(20, 60))
+        assert t.ideal_dte == (20, 60)
+
+
+# ── TEMPLATES dict — coverage ─────────────────────────────────
+
+
+class TestTemplatesDict:
+    def test_count_is_26(self):
+        assert len(TEMPLATES) == 26
+
+    def test_all_categories_present(self):
+        found = {t.category for t in TEMPLATES.values()}
+        assert found == set(CATEGORIES)
+
+    @pytest.mark.parametrize(
+        "strat_id",
+        [
+            "long_call",
+            "bull_call_spread",
+            "bull_put_spread",
+            "synthetic_long",
+            "call_ratio_backspread",
+            "long_put",
+            "bear_put_spread",
+            "bear_call_spread",
+            "synthetic_short",
+            "put_ratio_backspread",
+            "iron_condor",
+            "iron_butterfly",
+            "short_straddle",
+            "short_strangle",
+            "covered_call",
+            "cash_secured_put",
+            "jade_lizard",
+            "long_straddle",
+            "long_strangle",
+            "long_calendar_spread",
+            "diagonal_spread",
+            "protective_put",
+            "collar",
+            "married_put",
+            "long_fence",
+            "seagull",
+        ],
+    )
+    def test_required_strategy_ids_present(self, strat_id):
+        assert strat_id in TEMPLATES
+
+    def test_all_templates_have_required_fields(self):
+        for sid, t in TEMPLATES.items():
+            assert t.id == sid, f"{sid}: id mismatch"
+            assert t.name, f"{sid}: empty name"
+            assert t.category in CATEGORIES, f"{sid}: invalid category"
+            assert t.views, f"{sid}: empty views"
+            assert t.legs, f"{sid}: no legs"
+            assert t.explanation, f"{sid}: no explanation"
+            assert t.when_to_use, f"{sid}: no when_to_use"
+            assert t.when_not_to_use, f"{sid}: no when_not_to_use"
+            assert t.risks, f"{sid}: no risks"
+            assert t.tags, f"{sid}: no tags"
+            assert len(t.ideal_dte) == 2, f"{sid}: ideal_dte must be (min, max)"
+            assert t.ideal_dte[0] < t.ideal_dte[1], f"{sid}: ideal_dte min >= max"
+
+    def test_bullish_category_count(self):
+        bullish = [t for t in TEMPLATES.values() if t.category == "bullish"]
+        assert len(bullish) == 5
+
+    def test_bearish_category_count(self):
+        bearish = [t for t in TEMPLATES.values() if t.category == "bearish"]
+        assert len(bearish) == 5
+
+    def test_income_category_count(self):
+        income = [t for t in TEMPLATES.values() if t.category == "income"]
+        assert len(income) == 7
+
+    def test_volatility_category_count(self):
+        vol = [t for t in TEMPLATES.values() if t.category == "volatility"]
+        assert len(vol) == 4
+
+    def test_hedging_category_count(self):
+        hedging = [t for t in TEMPLATES.values() if t.category == "hedging"]
+        assert len(hedging) == 5
+
+
+# ── StrategyLibrary ───────────────────────────────────────────
+
+
+class TestStrategyLibrary:
+    def test_list_all_returns_all_templates(self):
+        results = strategy_library.list_all()
+        assert len(results) == 26
+
+    def test_list_all_sorted_by_category_then_name(self):
+        results = strategy_library.list_all()
+        # Category order follows CATEGORIES tuple (bullish→bearish→income→volatility→hedging)
+        cat_order = {c: i for i, c in enumerate(CATEGORIES)}
+        keys = [(cat_order[r.category], r.name) for r in results]
+        assert keys == sorted(keys)
+
+    def test_list_by_category_bullish(self):
+        results = strategy_library.list_by_category("bullish")
+        assert len(results) == 5
+        assert all(r.category == "bullish" for r in results)
+
+    def test_list_by_category_case_insensitive(self):
+        results = strategy_library.list_by_category("INCOME")
+        assert all(r.category == "income" for r in results)
+
+    def test_list_by_category_unknown_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown category"):
+            strategy_library.list_by_category("garbage")
+
+    def test_get_known_id(self):
+        t = strategy_library.get("iron_condor")
+        assert t.id == "iron_condor"
+        assert t.category == "income"
+
+    def test_get_unknown_id_raises_key_error(self):
+        with pytest.raises(KeyError):
+            strategy_library.get("does_not_exist")
+
+    def test_search_by_name_substring(self):
+        results = strategy_library.search("condor")
+        assert any(r.id == "iron_condor" for r in results)
+
+    def test_search_by_tag(self):
+        results = strategy_library.search("defined_risk")
+        assert len(results) > 0
+
+    def test_search_case_insensitive(self):
+        results = strategy_library.search("STRADDLE")
+        assert any("straddle" in r.id for r in results)
+
+    def test_search_returns_empty_for_gibberish(self):
+        results = strategy_library.search("xyzqwerty_nomatch")
+        assert results == []
+
+    def test_search_name_match_ranks_higher_than_tag_match(self):
+        # "iron_condor" matches by name; any strategy with "iron" in tags would rank lower
+        results = strategy_library.search("iron condor")
+        assert results[0].id == "iron_condor"
+
+    def test_singleton_is_strategy_library_instance(self):
+        assert isinstance(strategy_library, StrategyLibrary)
+
+
+# ── apply_template() — StrategyResult fields ──────────────────
+
+
+class TestApplyTemplate:
+    def _apply(self, strat_id: str, **overrides) -> StrategyResult:
+        params = {**ATM_PARAMS, **overrides}
+        template = TEMPLATES[strat_id]
+        return apply_template(template, **params)
+
+    def test_returns_strategy_result(self):
+        result = self._apply("long_call")
+        assert isinstance(result, StrategyResult)
+
+    def test_name_matches_template(self):
+        result = self._apply("long_call")
+        assert result.name == TEMPLATES["long_call"].name
+
+    def test_legs_list_not_empty(self):
+        result = self._apply("bull_call_spread")
+        assert len(result.legs) > 0
+
+    def test_legs_have_required_keys(self):
+        result = self._apply("iron_condor")
+        for leg in result.legs:
+            assert "action" in leg
+            assert "type" in leg
+
+    def test_capital_needed_positive(self):
+        result = self._apply("long_call")
+        assert result.capital_needed > 0
+
+    def test_max_loss_negative(self):
+        result = self._apply("long_call")
+        assert result.max_loss < 0
+
+    def test_breakeven_is_list(self):
+        result = self._apply("long_call")
+        assert isinstance(result.breakeven, list)
+        assert len(result.breakeven) >= 1
+
+    def test_rr_ratio_non_negative(self):
+        result = self._apply("bull_call_spread")
+        assert result.rr_ratio >= 0
+
+    def test_best_for_is_string(self):
+        result = self._apply("iron_condor")
+        assert isinstance(result.best_for, str)
+        assert len(result.best_for) > 0
+
+
+# ── apply_template() — debit strategies ──────────────────────
+
+
+class TestApplyTemplateDebit:
+    def _apply(self, strat_id: str, **kw) -> StrategyResult:
+        return apply_template(TEMPLATES[strat_id], **{**ATM_PARAMS, **kw})
+
+    def test_long_call_capital_equals_premium_times_lot(self):
+        result = self._apply("long_call")
+        # Capital = ATM CE prem * lot_size * lots = 150 * 75 * 1
+        assert result.capital_needed == pytest.approx(150.0 * 75, rel=0.01)
+
+    def test_long_call_max_loss_equals_minus_capital(self):
+        result = self._apply("long_call")
+        assert result.max_loss == pytest.approx(-result.capital_needed, rel=0.01)
+
+    def test_long_call_breakeven_above_atm_strike(self):
+        result = self._apply("long_call")
+        # Breakeven = ATM strike + premium = 24000 + 150 = 24150
+        assert result.breakeven[0] == pytest.approx(24150.0, rel=0.01)
+
+    def test_long_put_breakeven_below_atm_strike(self):
+        result = self._apply("long_put")
+        # Breakeven = ATM strike - premium = 24000 - 140 = 23860
+        assert result.breakeven[0] == pytest.approx(23860.0, rel=0.01)
+
+    def test_bull_call_spread_max_loss_is_net_debit(self):
+        result = self._apply("bull_call_spread")
+        # Max loss = net debit = (ATM CE prem - OTM CE prem) * lot_size
+        assert result.max_loss < 0
+
+    def test_bull_call_spread_max_profit_less_than_uncapped(self):
+        naked_call = self._apply("long_call")
+        spread = self._apply("bull_call_spread")
+        # Spread always has a capped max profit; naked call is "uncapped" (represented large)
+        assert spread.max_profit < naked_call.max_profit
+
+    def test_long_straddle_two_breakevenss(self):
+        result = self._apply("long_straddle")
+        assert len(result.breakeven) == 2
+
+    def test_long_straddle_capital_equals_both_premiums(self):
+        result = self._apply("long_straddle")
+        expected = (150.0 + 140.0) * 75
+        assert result.capital_needed == pytest.approx(expected, rel=0.01)
+
+    def test_lots_multiplier_scales_capital(self):
+        one_lot = self._apply("long_call", lots=1)
+        two_lots = self._apply("long_call", lots=2)
+        assert two_lots.capital_needed == pytest.approx(one_lot.capital_needed * 2, rel=0.01)
+
+
+# ── apply_template() — credit strategies ─────────────────────
+
+
+class TestApplyTemplateCredit:
+    def _apply(self, strat_id: str, **kw) -> StrategyResult:
+        return apply_template(TEMPLATES[strat_id], **{**ATM_PARAMS, **kw})
+
+    def test_iron_condor_max_profit_positive(self):
+        result = self._apply("iron_condor")
+        assert result.max_profit > 0
+
+    def test_iron_condor_max_loss_negative(self):
+        result = self._apply("iron_condor")
+        assert result.max_loss < 0
+
+    def test_iron_condor_two_breakevenss(self):
+        result = self._apply("iron_condor")
+        assert len(result.breakeven) == 2
+
+    def test_iron_condor_lower_breakeven_less_than_upper(self):
+        result = self._apply("iron_condor")
+        assert result.breakeven[0] < result.breakeven[1]
+
+    def test_bull_put_spread_max_profit_is_net_credit(self):
+        result = self._apply("bull_put_spread")
+        assert result.max_profit > 0
+
+    def test_bear_call_spread_max_profit_is_net_credit(self):
+        result = self._apply("bear_call_spread")
+        assert result.max_profit > 0
+
+    def test_cash_secured_put_max_profit_positive(self):
+        result = self._apply("cash_secured_put")
+        assert result.max_profit > 0
+
+    def test_jade_lizard_has_three_legs(self):
+        result = self._apply("jade_lizard")
+        assert len(result.legs) == 3
+
+
+# ── apply_template() — stock strategies ──────────────────────
+
+
+class TestApplyTemplateStock:
+    def _apply(self, strat_id: str, **kw) -> StrategyResult:
+        return apply_template(TEMPLATES[strat_id], **{**ATM_PARAMS, **kw})
+
+    def test_covered_call_capital_needed_positive(self):
+        result = self._apply("covered_call")
+        assert result.capital_needed > 0
+
+    def test_covered_call_max_profit_capped(self):
+        # Covered call max profit = (call_strike - spot + call_premium) * lots
+        result = self._apply("covered_call")
+        assert result.max_profit > 0
+
+    def test_protective_put_reduces_max_loss_vs_stock(self):
+        result = self._apply("protective_put")
+        # Max loss is protected at put strike — should not be full stock value
+        assert result.max_loss < 0
+        # But also shouldn't be larger than spot * lot_size in absolute terms
+        assert abs(result.max_loss) < ATM_PARAMS["spot"] * ATM_PARAMS["lot_size"]
+
+    def test_collar_has_three_legs(self):
+        result = self._apply("collar")
+        assert len(result.legs) == 3
+
+
+# ── apply_template() — fit score ─────────────────────────────
+
+
+class TestFitScore:
+    def _apply(self, strat_id: str, **kw) -> StrategyResult:
+        return apply_template(TEMPLATES[strat_id], **{**ATM_PARAMS, **kw})
+
+    def test_dte_in_range_gives_high_fit_score(self):
+        # iron_condor ideal_dte is (20, 45) — dte=30 is in range
+        result = self._apply("iron_condor", dte=30)
+        assert result.fit_score >= 70
+
+    def test_dte_outside_range_gives_lower_fit_score(self):
+        # iron_condor ideal_dte is (20, 45) — dte=5 is way out
+        result_in = self._apply("iron_condor", dte=30)
+        result_out = self._apply("iron_condor", dte=5)
+        assert result_out.fit_score <= result_in.fit_score
+
+    def test_fit_score_between_0_and_100(self):
+        for strat_id in TEMPLATES:
+            result = self._apply(strat_id)
+            assert 0 <= result.fit_score <= 100, f"{strat_id}: fit_score out of range"
+
+
+# ── apply_template() — payoff object ─────────────────────────
+
+
+class TestPayoffObject:
+    def _apply(self, strat_id: str, **kw) -> StrategyResult:
+        return apply_template(TEMPLATES[strat_id], **{**ATM_PARAMS, **kw})
+
+    def test_options_strategies_have_payoff(self):
+        # Pure options strategies should have a payoff object
+        result = self._apply("long_call")
+        # payoff may be None if analysis.options is not available — just check type
+        if result.payoff is not None:
+            from analysis.options import StrategyPayoff
+
+            assert isinstance(result.payoff, StrategyPayoff)
+
+    def test_calendar_spread_has_result(self):
+        result = self._apply("long_calendar_spread")
+        assert isinstance(result, StrategyResult)
+
+    def test_diagonal_spread_has_result(self):
+        result = self._apply("diagonal_spread")
+        assert isinstance(result, StrategyResult)
+
+
+# ── apply_template() — ratio backspreads ─────────────────────
+
+
+class TestRatioBackspreads:
+    def _apply(self, strat_id: str, **kw) -> StrategyResult:
+        return apply_template(TEMPLATES[strat_id], **{**ATM_PARAMS, **kw})
+
+    def test_call_ratio_backspread_has_three_leg_positions(self):
+        # 1 short ATM CE + 2 long OTM CE = 3 leg positions total
+        result = self._apply("call_ratio_backspread")
+        # The legs list should have at least 2 entries (could be 2 if multiplied inline)
+        assert len(result.legs) >= 2
+
+    def test_put_ratio_backspread_has_three_leg_positions(self):
+        result = self._apply("put_ratio_backspread")
+        assert len(result.legs) >= 2
+
+    def test_call_ratio_backspread_capital_non_negative(self):
+        result = self._apply("call_ratio_backspread")
+        assert result.capital_needed >= 0


### PR DESCRIPTION
## Summary

Implements issue #52 — a read-only curated library of 26 well-known options strategies for Indian markets, built for both beginners and experienced traders.

- **`engine/strategy_library.py`** (new) — `TemplateLeg`, `StrategyTemplate`, `StrategyLibrary`, `apply_template()`, and all 26 strategy definitions across 5 categories (bullish, bearish, income, volatility, hedging)
- **`app/commands/strategy.py`** — three new subcommands: `library`, `learn`, `use`
- **`engine/strategy.py`** — minor: `_get_atm_data` renamed to `get_atm_data` (public)
- **`tests/test_strategy_library.py`** (new) — 94 tests covering all templates, P&L math for every capital_type branch, and library search/filter

### New commands

| Command | What it does |
|---|---|
| `strategy library [category]` | Browse all 26 templates in a table, optionally filtered by category |
| `strategy learn <id>` | Full explanation panel with plain-English intro, leg-by-leg breakdown, example scenarios, risks |
| `strategy use <id> SYMBOL [--lots N] [--dte N]` | Fetch live ATM data and show real P&L figures for the strategy on a specific symbol |

### `strategy learn` panel structure

Each strategy shows:
1. **IN PLAIN ENGLISH** — 1-2 sentences with zero jargon
2. **LEGS** — for each leg: strike location in plain words + role description + concrete example at ₹24,000 spot with ✓/✗ outcome scenarios
3. **HOW IT WORKS** — technical explanation
4. **WHEN TO USE / WHEN NOT TO USE / MAX PROFIT / MAX LOSS / RISKS / TAGS**

### Strategies included (26 total)

| Category | Strategies |
|---|---|
| Bullish (5) | Long Call, Bull Call Spread, Bull Put Spread, Synthetic Long, Call Ratio Backspread |
| Bearish (5) | Long Put, Bear Put Spread, Bear Call Spread, Synthetic Short, Put Ratio Backspread |
| Income (7) | Iron Condor, Iron Butterfly, Short Straddle, Short Strangle, Covered Call, Cash-Secured Put, Jade Lizard |
| Volatility (4) | Long Straddle, Long Strangle, Long Calendar Spread, Diagonal Spread |
| Hedging (5) | Protective Put, Collar, Married Put, Long Fence, Seagull Spread |

## Test plan

- [ ] `strategy library` — all 26 show, grouped by category
- [ ] `strategy library income` — filters to 7 income strategies
- [ ] `strategy library straddle` — search fallback shows matching strategies
- [ ] `strategy learn iron_condor` — full panel with leg examples at ₹24,000
- [ ] `strategy learn xyz` — suggests closest match
- [ ] `strategy use long_call RELIANCE` — fetches live data, shows P&L table
- [ ] `strategy use iron_condor NIFTY --lots 2 --dte 21`
- [ ] `strategy list` / `strategy new` — existing commands unaffected
- [ ] All 506 tests pass, lint clean

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)