### PR TITLE
feat(#99): technical strategy library — 32 templates, 8 backtest strategies, cached learn panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # India Trade CLI
 
-Open-source terminal for trading Indian stocks and derivatives (NSE / BSE / NFO). Runs AI analyst agents, backtests quant strategies, pushes Telegram alerts, and exposes everything as OpenClaw HTTP skills.
+Open-source terminal for trading Indian stocks and derivatives (NSE / BSE / NFO). Runs AI analyst agents, backtests quant strategies, pushes Telegram alerts, and exposes everything as HTTP skills.
 
 > Every trade must be justified. Analyze first, debate second, execute third.
 
@@ -10,629 +10,186 @@ Open-source terminal for trading Indian stocks and derivatives (NSE / BSE / NFO)
 
 ---
 
-## What is India Trade CLI?
-
-India Trade CLI is a free, open-source trading CLI for India's equity and derivatives markets. It runs seven AI analyst agents on any NSE or BSE listed stock (Technical, Fundamental, Options, News & Macro, Sentiment, Sector Rotation, and Risk Manager), forces them into a structured bull-vs-bear debate, and outputs a fund-manager-style synthesis with trade plans across three risk profiles.
-
-It also includes:
-
-- A strategy builder that takes plain-English descriptions (RSI mean reversion, EMA crossover, MACD, pairs spread), interviews you about parameters, generates Python code, and backtests it on NSE history.
-- A Telegram trading bot with 14 commands: live quotes, full AI analysis, FII/DII flows, earnings calendar, price alerts sent to your phone.
-- A paper trading engine to run the AI's trade plans without real money.
-- OpenClaw HTTP skills so any OpenClaw agent can call Indian market data or trigger analysis over a standard REST API.
-
-AI providers: Gemini (free), Claude (subscription or API), OpenAI, Ollama (local), OpenRouter, Groq, and anything OpenAI-compatible.
-Brokers: Fyers (fully supported, free real-time API), Demo/Mock mode, Zerodha / Angel One / Upstox / Groww (work in progress).
-
----
-
 ## How it works
 
 ```
 analyze RELIANCE
-        |
-  [7 Analyst Agents]  ← pure Python, parallel
-  Technical | Fundamental | Options | News(LLM) | Sentiment | Sector Rotation | Risk Manager
-        |
-  [Analyst Scorecard]  ← weighted composite score + conflict detection
-        |
-  [Multi-Round Debate]  ← 5 LLM calls
-  Bull R1 → Bear R1 → Bull Rebuttal → Bear Rebuttal → Facilitator
-        |
-  [Fund Manager Synthesis]  ← 1 LLM call
-  Verdict: BUY/SELL/HOLD + confidence + rationale
-        |
-  [Risk Management]  ← pure Python
-  Aggressive | Neutral | Conservative trade plans
-        |
-  [Trade Plan]
-  Entry orders, stop-loss, targets, position sizing, scaling logic
+        │
+  7 Analyst Agents  (parallel, pure Python)
+  Technical · Fundamental · Options · News · Sentiment · Sector · Risk
+        │
+  Weighted Scorecard + Conflict Detection
+        │
+  Multi-Round Debate  (5 LLM calls)
+  Bull → Bear → Rebuttal → Rebuttal → Facilitator
+        │
+  Fund Manager Synthesis  (1 LLM call)
+  Verdict: BUY / SELL / HOLD + confidence + rationale
+        │
+  3 Risk-Profiled Trade Plans
+  Aggressive · Neutral · Conservative — entry, stop, targets, sizing
 ```
 
-Standard mode: 8 LLM calls. Deep mode (`deep-analyze`): 11 calls with every analyst fully AI-powered.
+Standard `analyze`: 8 LLM calls. `deep-analyze`: 11 calls, every analyst fully AI-powered.
 
 ---
 
 ## Quick start
 
-### Prerequisites
-
-- Python 3.11+ (3.11, 3.12, and 3.13 tested in CI)
-
-### Step 1: Install
-
 ```bash
 git clone https://github.com/hopit-ai/india-trade-cli.git
 cd india-trade-cli
-python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
+python -m venv .venv && source .venv/bin/activate
 pip install -e .
+trade --no-broker   # yfinance data, no broker account needed
 ```
 
-### Step 2: Set up an AI provider
-
-Pick one:
-
-Gemini (free): get a key at [aistudio.google.com](https://aistudio.google.com) → Get API Key.
-
-Claude (Pro/Max subscription): install the CLI with `npm install -g @anthropic-ai/claude-code`, run `claude login`, and that's it. No API key needed.
-
-### Step 3: Get free market data (Fyers)
-
-1. Create a free account at [fyers.in](https://fyers.in) (any Fyers trading/demat account works)
-2. Go to the API dashboard at [myapi.fyers.in](https://myapi.fyers.in) and log in with your Fyers credentials
-3. Click **Create App** and fill in:
-   - **App Name:** anything you like (e.g. `TradeCLI`)
-   - **Redirect URL:** `http://127.0.0.1:8765/fyers/callback` (must be exact)
-   - **App Type:** Personal
-   - **Description:** optional
-4. After creating the app, you'll see your **App ID** (format: `XXXX-100`) and **Secret Key** — copy both
-5. Run `trade`, choose **[5] Fyers**, and paste the App ID and Secret Key when prompted
-6. A browser window opens for Fyers OAuth login. After you log in, the terminal completes automatically — no copy-pasting needed.
-
-### Step 4: Get news headlines (optional)
-
-1. Sign up at [newsapi.org](https://newsapi.org) (free for development)
-2. Copy your API key
-
-### Step 5: Run it
-
-```bash
-trade
-```
-
-First run asks for a broker, AI provider, and NewsAPI key. After that you're in the REPL:
-
+Inside the REPL:
 ```
 > analyze RELIANCE
+> morning-brief
+> strategy library
 ```
 
-That runs 7 analyst agents, a bull-vs-bear debate, and outputs trade plans across 3 risk profiles.
+### AI provider
 
-```
-> deep-analyze INFY        # full LLM mode (11 AI calls)
-> morning-brief            # daily market overview
-> deals                    # today's bulk/block deals
-> quote TCS                # live quote
-```
-
-### No-broker mode (quick start without Fyers)
-
-```bash
-trade --no-broker
-```
-
-Uses yfinance for real NSE/BSE data (~15 min delayed). Technical, fundamental, sentiment, and sector analysis work fine. Options chain data needs a broker connection (Fyers is the free option).
-
----
-
-## Supported AI Providers
-
-| Provider | Cost | Setup |
-|----------|------|-------|
-| **Gemini** | Free tier available | Get key at [aistudio.google.com](https://aistudio.google.com) |
-| **Claude (subscription)** | Free with Pro/Max plan | Install CLI: `npm i -g @anthropic-ai/claude-code` then `claude login` |
+| Provider | Cost | How |
+|----------|------|-----|
+| **Gemini** | Free tier | Key from [aistudio.google.com](https://aistudio.google.com) |
+| **Claude** (Pro/Max sub) | Free with subscription | `npm i -g @anthropic-ai/claude-code` → `claude login` |
 | **Claude API** | Pay per token | Key from [console.anthropic.com](https://console.anthropic.com) |
-| **OpenAI API** | Pay per token | Key from [platform.openai.com](https://platform.openai.com) |
-| **Any OpenAI-compatible** | Varies | OpenRouter, Groq, Together, LM Studio, vLLM |
-| **Ollama (local)** | Free | Run models locally: `ollama pull llama3.1` |
+| **OpenAI** | Pay per token | Key from [platform.openai.com](https://platform.openai.com) |
+| **Ollama** | Free, local | `ollama pull llama3.1` |
+| **OpenRouter / Groq / etc.** | Varies | Set `OPENAI_BASE_URL` in `.env` |
 
-Switch anytime with `provider gemini` or `provider claude_subscription`.
+Switch anytime: `provider gemini` or `provider claude_subscription`.
 
-### Custom OpenAI-compatible endpoint
+### Real-time market data (Fyers — free)
 
-For providers like OpenRouter, Groq, etc.:
+1. Create a free account at [fyers.in](https://fyers.in)
+2. Go to [myapi.fyers.in](https://myapi.fyers.in) → **Create App** — redirect URL must be `http://127.0.0.1:8765/fyers/callback`
+3. Copy the **App ID** (`XXXX-100`) and **Secret Key**
+4. `trade` → choose `[5] Fyers` → paste credentials → browser OAuth completes automatically
 
-```bash
-# In .env
-AI_PROVIDER=openai
-OPENAI_BASE_URL=https://openrouter.ai/api/v1
-OPENAI_API_KEY=sk-or-v1-...
-OPENAI_MODEL=anthropic/claude-sonnet-4
-```
-
-Or interactively: `credentials setup` → AI Provider → Custom (OpenAI-compatible).
-
-API keys go into your OS keychain (macOS Keychain, Linux Secret Service, or Windows Credential Locker) via the `keyring` library. Broker session tokens are cached under `~/.trading_platform/` and deleted on logout.
+Without Fyers, `--no-broker` uses yfinance (~15 min delayed). Options chain needs a broker.
 
 ---
 
-## Supported Brokers
+## What you can do
 
-| Broker | Status | Notes |
-|--------|--------|-------|
-| **Fyers** | **Fully supported** | Free API, real-time WebSocket, options chain |
-| **Mock/Demo** | **Fully supported** | Synthetic data, no login needed |
-| Zerodha | WIP | Requires Kite Connect subscription ([#80](https://github.com/hopit-ai/india-trade-cli/issues/80)) |
-| Angel One | WIP | Free SmartAPI, TOTP login ([#80](https://github.com/hopit-ai/india-trade-cli/issues/80)) |
-| Upstox | WIP | Free API, OAuth ([#80](https://github.com/hopit-ai/india-trade-cli/issues/80)) |
-| Groww | WIP | No historical data API ([#80](https://github.com/hopit-ai/india-trade-cli/issues/80)) |
+**[Full command reference →](docs/commands.md)**
 
-> Broker integrations beyond Fyers are work in progress. See [#80](https://github.com/hopit-ai/india-trade-cli/issues/80) for status.
+The highlights:
 
-### Fyers setup (recommended, free real-time NSE/BSE data)
-
-1. Sign up at [fyers.in](https://fyers.in) if you don't have one (any Fyers trading/demat account works)
-2. Go to [myapi.fyers.in](https://myapi.fyers.in), log in, and click **Create App**:
-   - **Redirect URL:** must be exactly `http://127.0.0.1:8765/fyers/callback`
-   - **App Type:** Personal
-3. Note the **App ID** (format: `XXXX-100`) and **Secret Key**
-4. Run `trade` → choose `[5] Fyers` → paste App ID and Secret Key when prompted
-5. A browser opens for Fyers OAuth login. After you log in, the terminal completes automatically — no copy-pasting needed.
-6. Token saved for 12 hours. WebSocket connects for real-time quotes. Next login just runs `trade` and picks up saved credentials.
-
-### NewsAPI (optional)
-
-A free [NewsAPI](https://newsapi.org) key noticeably improves `morning-brief` and news-driven analysis. Free tier: 100 requests/day.
-
-```bash
-NEWSAPI_KEY=your_key_here
-NEWSAPI_ENABLED=1
-```
-
----
-
-## Telegram trading bot for Indian markets
-
-Run `telegram setup` from the REPL. A short wizard creates the bot via @BotFather and connects your chat. After that, you can query quotes, run full AI analysis, check FII/DII flows, and get price alerts pushed to your phone.
-
-```
-trade
-> telegram setup
-```
-
-14 commands: `/quote`, `/analyze`, `/deepanalyze`, `/brief`, `/flows`, `/earnings`, `/events`, `/macro`, `/alert`, `/alerts`, `/memory`, `/pnl`, `/help`
-
-Alerts fire to Telegram automatically when triggered. The REPL shows a status badge while bot commands are running.
-
----
-
-## OpenClaw integration
-
-Every capability is available as a discoverable HTTP skill endpoint. An OpenClaw agent fetches the manifest, reads the input schemas, and calls whichever skills it needs. No CLI installation required on the agent side.
-
-```
-OpenClaw Agent
-    │  GET /.well-known/openclaw.json   ← discover available skills
-    │  POST /skills/analyze             ← call a skill
-    ▼
-india-trade-cli Skill Server (FastAPI)
-    │
-    ▼ (existing Python modules, unchanged)
-agent/ market/ engine/ analysis/
-```
-
-### Start the skill server
-
-```bash
-uvicorn web.api:app --host 127.0.0.1 --port 8765
-```
-
-Or from the REPL: `web`
-
-> **Security:** The server has no authentication. Keep it on `127.0.0.1`. If you need network access, put it behind a reverse proxy that handles auth.
-
-### Skill discovery
-
-```bash
-curl http://localhost:8765/.well-known/openclaw.json
-```
-
-Returns a manifest with all 17 skills, their input schemas, and descriptions.
-
-### Available skills
-
-| Skill | Input | Speed |
-|-------|-------|-------|
-| `quote` | `{ "symbol": "RELIANCE" }` | Instant |
-| `options_chain` | `{ "symbol": "NIFTY" }` | Instant |
-| `flows` | `{}` | Instant |
-| `earnings` | `{ "symbols": ["TCS"] }` | Instant |
-| `macro` | `{}` | Instant |
-| `deals` | `{ "symbol": "INFY" }` | Instant |
-| `morning_brief` | `{}` | ~2s |
-| `backtest` | `{ "symbol": "INFY", "strategy": "rsi" }` | ~5s |
-| `pairs` | `{ "stock_a": "HDFCBANK", "stock_b": "ICICIBANK" }` | ~5s |
-| `chat` | `{ "message": "Analyse RELIANCE", "session_id": "abc" }` | ~5s |
-| `chat/reset` | `{ "session_id": "abc" }` | Instant |
-| `analyze` | `{ "symbol": "RELIANCE" }` | 30–90s (8 LLM calls) |
-| `deep_analyze` | `{ "symbol": "RELIANCE" }` | 3–8 min (11 LLM calls) |
-| `alerts/add` | `{ "symbol": "RELIANCE", "condition": "ABOVE", "threshold": 2800 }` | Instant |
-| `alerts/list` | `{}` | Instant |
-| `alerts/remove` | `{ "alert_id": "abc12345" }` | Instant |
-| `alerts/check` | `{}` | ~2s |
-
-All endpoints return `{ "status": "ok", "data": { ... } }` on success.
-
-### Example calls
-
-```bash
-# Live NSE quote
-curl -X POST http://localhost:8765/skills/quote \
-  -H "Content-Type: application/json" \
-  -d '{"symbol": "RELIANCE"}'
-
-# Full multi-agent analysis
-curl -X POST http://localhost:8765/skills/analyze \
-  -H "Content-Type: application/json" \
-  -d '{"symbol": "RELIANCE"}'
-
-# Multi-turn chat with the trading agent
-curl -X POST http://localhost:8765/skills/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "What is the RSI on NIFTY?", "session_id": "my-agent"}'
-```
-
-### Webhook alerts
-
-Register a callback URL. The server POSTs to it the moment an alert fires:
-
-```bash
-curl -X POST http://localhost:8765/skills/alerts/add \
-  -H "Content-Type: application/json" \
-  -d '{
-    "symbol": "RELIANCE",
-    "condition": "ABOVE",
-    "threshold": 2800,
-    "webhook_url": "https://my-agent.example.com/on-alert"
-  }'
-```
-
-Payload on trigger:
-```json
-{
-  "event": "alert_triggered",
-  "alert_id": "abc12345",
-  "symbol": "RELIANCE",
-  "description": "RELIANCE price ABOVE ₹2,800.00",
-  "triggered_at": "2026-04-03T11:00:00",
-  "ltp": 2815.5
-}
-```
-
-See [#83](https://github.com/hopit-ai/india-trade-cli/issues/83) for the full integration roadmap (manifest registration, API key auth, Docker image).
-
----
-
-## All CLI Commands
-
-### Analysis (AI-powered)
-| Command | Description |
-|---------|-------------|
-| `analyze RELIANCE` | Multi-agent analysis — 7 analysts + debate + 3 trade plans |
-| `deep-analyze RELIANCE` | Full LLM mode (11 calls, every analyst uses AI) |
-| `ai <message>` | Chat with the trading agent — follow-ups keep context, `clear` to reset |
-| `morning-brief` | Daily NSE/BSE market context + AI narrative |
-| `mtf RELIANCE` | Multi-timeframe analysis (weekly / daily / hourly confluence) |
-
-### Quantitative Strategy Builder
-
-> **Warning:** The strategy builder executes AI-generated Python code on your machine. Only run strategies from sources you trust. Never copy-paste strategy code from untrusted sources into `~/.trading_platform/strategies/`.
-
-| Command | Description |
-|---------|-------------|
-| `strategy new` | Describe a strategy in plain English — AI interviews you, generates code, backtests |
-| `strategy new --simple` | Same but explained without jargon |
-| `strategy list` | List all saved strategies with backtest stats |
-| `strategy backtest <name> --period 2y` | Re-backtest a saved strategy |
-| `strategy run <name> RELIANCE --paper` | Generate latest signal, paper trade if BUY |
-| `strategy show <name>` | View generated Python code |
-| `strategy delete <name>` | Remove a saved strategy |
-
-Supports single-symbol strategies (RSI, MACD, EMA crossover, Bollinger Bands) and multi-symbol pairs strategies (z-score spread trading with both legs tracked). The AI gives data-backed recommendations for each parameter.
-
-### Market Data
-| Command | Description |
-|---------|-------------|
-| `earnings` | Quarterly results calendar (NIFTY 50) |
-| `earnings RELIANCE TCS` | Earnings for specific stocks |
-| `flows` | FII/DII flow intelligence with buy/sell signals |
-| `events` | Event-driven strategy recommendations |
-| `patterns` | Active India-specific market patterns |
-| `macro` | USD/INR, crude oil, gold, US 10Y snapshot |
-| `macro RELIANCE` | Macro impact analysis for a specific stock |
-
-### Backtesting & Simulation
-| Command | Description |
-|---------|-------------|
-| `backtest RELIANCE rsi` | RSI overbought/oversold strategy |
-| `backtest RELIANCE ma 20 50` | EMA crossover |
-| `backtest RELIANCE macd` | MACD signal crossover |
-| `backtest RELIANCE bb` | Bollinger Bands mean reversion |
-| `walkforward RELIANCE rsi` | Walk-forward test (rolling windows) |
-| `whatif nifty -3` | What if NIFTY drops 3%? (uses real stock beta) |
-
-### Risk & Portfolio
-| Command | Description |
-|---------|-------------|
-| `risk-report` | VaR / CVaR portfolio risk analysis |
-| `greeks` | Portfolio Greeks — net Delta, Theta, Vega |
-| `pairs` | Scan for pair trading opportunities |
-| `pairs HDFCBANK ICICIBANK` | Analyze a specific stock pair |
-
-### Trade Execution
-| Command | Description |
-|---------|-------------|
-| `execute` | Execute last trade plan (neutral risk) — LIVE or PAPER, auto-detected |
-| `execute aggressive` | Execute aggressive plan |
-| `execute conservative` | Execute conservative plan |
-
-### Trade Memory & Learning
-| Command | Description |
-|---------|-------------|
-| `memory` | Recent trade analyses |
-| `memory stats` | Win rate, P&L, and performance statistics |
-| `memory RELIANCE` | Past analyses for a specific symbol |
-| `memory outcome ID WIN 1250` | Record trade outcome |
-| `profile` | Your personal trading style profile |
-| `drift` | Model drift detection — is the AI losing edge? |
-| `audit <ID>` | Post-mortem analysis of a specific trade |
-
-### Alerts
-| Command | Description |
-|---------|-------------|
-| `alert RELIANCE above 2800` | Simple price alert |
-| `alert NIFTY RSI above 70` | Technical indicator alert |
-| `alert RELIANCE above 2800 AND RSI above 70` | Conditional alert |
-| `alerts` | List all active alerts |
-| `alert remove <ID>` | Remove an alert |
-
-### Portfolio & Broker
-| Command | Description |
-|---------|-------------|
-| `funds` | Available cash and margin |
-| `holdings` | Long-term delivery holdings |
-| `positions` | Open intraday / F&O positions |
-| `orders` | Today's orders and status |
-| `portfolio` | Unified view across all connected brokers |
-
-### Output & Export
-| Command | Description |
-|---------|-------------|
-| `save-pdf` | Save previous output as PDF |
-| `explain` | Explain previous output in plain English |
-| `--pdf` | Flag: append to any command |
-| `--explain` | Flag: append to any command |
-| `--explain-save` | Explain + PDF in one shot |
-
-### Account & Config
-| Command | Description |
-|---------|-------------|
-| `login` | Connect to a broker |
-| `connect` | Add a second broker (multi-broker mode) |
-| `logout` | Disconnect all brokers |
-| `provider` | Show / switch AI provider |
-| `telegram` / `telegram setup` | Start bot / run guided setup |
-| `credentials` | Manage API keys |
+- **`analyze RELIANCE`** — 7 AI analysts, a bull-bear debate, and three trade plans in one command
+- **`strategy library`** — browse 58 curated strategies (26 options + 32 technical) with plain-English explanations and cached backtest results
+- **`strategy learn supertrend`** — deep-dive on any strategy: what it is, when to use it, real ₹ examples, and last backtest stats
+- **`strategy use iron_condor NIFTY`** — apply an options template with live ATM data, get P&L summary instantly
+- **`strategy new`** — describe a strategy in plain English, the AI generates + backtests the Python code
+- **`backtest RELIANCE rsi`** — quick strategy backtests on NSE history
+- **`morning-brief`** — daily AI market brief
+- **`flows`** — FII/DII intelligence with directional signals
+- **`telegram setup`** — connect a bot; get quotes, analysis, and price alerts on your phone
 
 ---
 
 ## Configuration
 
-### Environment Variables
-
 ```bash
-# AI Provider (choose one)
-AI_PROVIDER=gemini              # or: anthropic, openai, claude_subscription
+# .env  (see .env.example for all options)
+AI_PROVIDER=gemini              # gemini | anthropic | openai | claude_subscription
 GEMINI_API_KEY=AIza...
-ANTHROPIC_API_KEY=sk-ant-...
-OPENAI_API_KEY=sk-...
 
-# Trading Capital & Risk
-TOTAL_CAPITAL=200000            # your trading capital in INR
+TOTAL_CAPITAL=200000            # INR — used for position sizing
 DEFAULT_RISK_PCT=2              # max risk per trade (%)
 TRADING_MODE=PAPER              # PAPER or LIVE
 
-# News (optional)
-NEWSAPI_KEY=...
-NEWSAPI_ENABLED=1
-
-# Telegram (optional)
-TELEGRAM_BOT_TOKEN=...          # from @BotFather
+NEWSAPI_KEY=...                 # optional — improves morning-brief quality
+TELEGRAM_BOT_TOKEN=...          # optional
 ```
 
-### Position Sizing
+Position sizing auto-adjusts for VIX: 100% normal → 85% at VIX 15–20 → 65% at 20–25 → 50% above 25.
 
-```
-Max Risk = Capital × Risk% × VIX Adjustment
-Shares   = Max Risk / Stop-Loss Distance (per share)
-```
-
-VIX-based auto-adjustment:
-
-| VIX Level | Position Size |
-|-----------|--------------|
-| < 15 | 100% (normal) |
-| 15–20 | 85% |
-| 20–25 | 65% |
-| > 25 | 50% (halved) |
-
-### Data Flow Priority
-
-| Source | Latency | When used |
-|--------|---------|-----------|
-| Fyers WebSocket | Real-time | Primary (when broker connected) |
-| Broker REST API | 1–3s | Fallback |
-| yfinance | ~15 min delayed | No broker login |
-| Mock data | Synthetic | Demo mode |
+API keys are stored in the OS keychain (macOS Keychain / Linux SecretService / Windows Credential Locker).
 
 ---
 
-## Project Structure
+## Brokers
 
-```
-india-trade-cli/
-|-- agent/                    # AI layer
-|   |-- core.py               # TradingAgent + 6 LLM providers
-|   |-- multi_agent.py        # 7 analysts, scorecard, debate, synthesis
-|   |-- deep_agent.py         # Full LLM mode (11 calls)
-|   |-- tools.py              # 45+ tool definitions for LLM function calling
-|   +-- prompts.py            # System prompt + command templates
-|-- brokers/                  # Broker integrations
-|   |-- base.py               # Unified BrokerAPI abstract interface
-|   |-- fyers.py              # Fyers API v3 (official SDK)
-|   |-- zerodha.py            # Zerodha Kite Connect
-|   |-- upstox.py             # Upstox API v2
-|   |-- angelone.py           # Angel One SmartAPI
-|   |-- groww.py              # Groww Partner API
-|   |-- mock.py               # Mock broker (paper trading)
-|   +-- session.py            # Multi-broker session manager
-|-- market/                   # Market data
-|   |-- quotes.py             # Quotes: WebSocket → broker REST → yfinance
-|   |-- websocket.py          # Fyers WebSocket for real-time ticks
-|   |-- history.py            # Historical OHLCV
-|   |-- options.py            # NSE options chain
-|   |-- indices.py            # NIFTY 50, BANKNIFTY, India VIX, sectors
-|   |-- news.py               # NewsAPI + RSS feeds
-|   |-- events.py             # Earnings calendar, RBI policy, expiry dates
-|   |-- sentiment.py          # FII/DII data + market breadth
-|   |-- earnings.py           # Earnings agent + surprise prediction
-|   |-- flow_intel.py         # FII/DII flow intelligence + signals
-|   |-- macro.py              # Currency / commodity linkage analysis
-|   +-- yfinance_provider.py  # Free NSE/BSE data via Yahoo Finance
-|-- analysis/                 # Analysis engines
-|   |-- technical.py          # RSI, MACD, EMAs, Bollinger, ATR, pivots
-|   |-- fundamental.py        # PE, ROE, ROCE from Screener.in
-|   |-- options.py            # Greeks, payoff, iron condor, butterfly
-|   +-- multi_timeframe.py    # Weekly/daily/hourly confluence
-|-- engine/                   # Trading logic
-|   |-- trader.py             # Trader Agent + 3 risk personas
-|   |-- backtest.py           # Backtester + walk-forward testing
-|   |-- simulator.py          # What-if with real stock beta
-|   |-- memory.py             # Trade memory (situation-outcome pairs)
-|   |-- patterns.py           # India-specific market patterns
-|   |-- event_strategies.py   # Event-driven strategy recommendations
-|   |-- risk_metrics.py       # VaR, CVaR, correlation, HHI
-|   |-- drift.py              # Model drift detection
-|   |-- pairs.py              # Pair trading / relative value
-|   |-- audit.py              # Decision audit trail
-|   |-- profile.py            # Personal trading style profile
-|   |-- alerts.py             # Price + technical + conditional alerts
-|   |-- paper.py              # Paper trading engine
-|   |-- trade_executor.py     # Execute trade plans (live or paper, with safety gate)
-|   |-- output.py             # PDF export + simple explainer
-|   |-- portfolio.py          # Portfolio tracker + aggregated Greeks
-|   |-- strategy.py           # Strategy recommendation engine
-|   +-- strategy_builder.py   # Interactive strategy builder (AI-guided)
-|-- bot/                      # Telegram bot
-|   |-- telegram_bot.py       # 14 commands + alert push notifications
-|   +-- status.py             # REPL status badge for bot activity
-|-- app/                      # Application layer
-|   |-- main.py               # Entry point
-|   |-- repl.py               # Command REPL (35+ commands, tab-complete)
-|   +-- commands/             # Command handlers
-|-- config/
-|   +-- credentials.py        # OS keychain credential management
-|-- web/                      # Web API (FastAPI)
-|   |-- api.py                # Broker OAuth login + OpenClaw skill server
-|   |-- skills.py             # 17 OpenClaw skill endpoints (POST /skills/*)
-|   +-- openclaw.py           # OpenClaw discovery manifest
-|-- pyproject.toml
-+-- .env.example
-```
+| Broker | Status |
+|--------|--------|
+| **Fyers** | Fully supported — free real-time API, options chain, WebSocket |
+| **Mock / Demo** | Fully supported — no login needed (`trade --no-broker`) |
+| Zerodha / Angel One / Upstox / Groww | WIP — [#80](https://github.com/hopit-ai/india-trade-cli/issues/80) |
 
 ---
 
-## Contributing
+## OpenClaw HTTP skills
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, tests, and code style.
+```bash
+uvicorn web.api:app --host 127.0.0.1 --port 8765
+# or from REPL: web
+```
 
-Short version:
-1. Fork & clone, then `pip install -e .`
-2. Run `pytest` — no API keys needed, network tests are skipped by default
-3. Smoke test with `trade --no-broker` (uses yfinance, no broker account)
-4. Open a PR against `main`
+Exposes 17 skills as `POST /skills/<name>`. Discovery: `GET /.well-known/openclaw.json`.
 
-Python 3.11+ required.
+Includes: `quote`, `analyze`, `deep_analyze`, `backtest`, `flows`, `morning_brief`, `chat` (session-aware), `options_chain`, `deals`, `earnings`, `macro`, `alerts/*`.
 
-### Where help is needed
+> No auth — keep on `127.0.0.1` or put behind a proxy.
 
-See [open issues](https://github.com/hopit-ai/india-trade-cli/issues). The most useful areas right now:
+---
 
-- Broker integrations ([#80](https://github.com/hopit-ai/india-trade-cli/issues/80)) — Zerodha / Angel One / Upstox depth, plus Dhan, ICICI Direct, 5paisa
-- Integration tests ([#79](https://github.com/hopit-ai/india-trade-cli/issues/79)) — live broker and market-data coverage
-- Web dashboard — FastAPI backend and OAuth exist, frontend is missing
-- Options-specific backtest engine
+## Project structure
+
+```
+agent/      AI layer — LLM providers, analyst agents, debate, synthesis
+brokers/    Broker integrations — Fyers, mock, Zerodha/Upstox/Angel (WIP)
+market/     Market data — quotes, WebSocket, options chain, news, FII/DII
+analysis/   Technical, fundamental, options Greeks, multi-timeframe
+engine/     Backtester, 58-strategy library, risk metrics, alerts, trade executor
+bot/        Telegram bot
+app/        REPL entry point and command handlers
+web/        FastAPI — OAuth + 17 OpenClaw skill endpoints
+```
 
 ---
 
 ## Roadmap
 
-### Shipped
-- 7 AI analyst agents + weighted scorecard + conflict detection
-- Multi-round bull/bear debate with facilitator and fund manager synthesis
-- Trader Agent + 3 risk personas (aggressive / neutral / conservative)
-- Trade memory + India-specific market pattern knowledge base
-- Strategy backtesting + walk-forward testing + what-if simulator
-- Earnings agent + surprise prediction + FII/DII flow intelligence
-- Event-driven strategies (expiry, RBI policy, budget, earnings)
-- Advanced options — iron condor, butterfly, calendar, ratio, diagonal spreads
-- VaR / CVaR portfolio risk + correlation matrix + GEX analysis
-- Model drift detection + decision audit trail
-- Pair trading with mean reversion signals
-- Telegram bot (14 commands + alert push + REPL status badge)
-- Fyers WebSocket for real-time NSE/BSE quotes
-- Multi-timeframe analysis (weekly / daily / hourly)
-- Paper trading execution engine
-- PDF export + plain-English explainer
-- DCF valuation with reverse DCF, FCF quality checks, scenario analysis
-- OpenClaw integration — 17 HTTP skill endpoints + webhook alerts + session-aware chat
+**Shipped:** 7 analyst agents · scorecard · debate · 3 risk personas · trade memory · backtesting · walk-forward · what-if · FII/DII flows · event strategies · options analytics (iron condor, butterfly, straddle) · VaR/CVaR · DCF valuation · model drift · pair trading · Telegram bot · Fyers WebSocket · paper trading · PDF export · OpenClaw skills · 58-strategy template library · backtest cache
 
-### Experimental
-- Interactive strategy builder (plain English → backtest → paper trade → save)
+**Planned:** additional broker integrations · web UI frontend · TradingView webhook support · SEBI compliance layer
 
-### Planned
-- Strategy template library (curated strategies with explanations)
-- TradingView / ChartInk webhook support
-- Web UI dashboard (backend exists, frontend pending)
-- SEBI compliance layer
+See [open issues](https://github.com/hopit-ai/india-trade-cli/issues).
 
-See [all open issues](https://github.com/hopit-ai/india-trade-cli/issues).
+---
+
+## Contributing
+
+```bash
+pip install -e .
+pytest                    # no API keys needed, network tests skipped by default
+trade --no-broker         # smoke test
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md). Most wanted: broker integrations ([#80](https://github.com/hopit-ai/india-trade-cli/issues/80)), web UI frontend, integration tests ([#79](https://github.com/hopit-ai/india-trade-cli/issues/79)).
 
 ---
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| `ModuleNotFoundError: kiteconnect` | Broker SDKs are optional. Install only the one you use: `pip install kiteconnect` for Zerodha, or use Demo mode (`login 0`). |
-| `ModuleNotFoundError: feedparser` | Install with `pip install feedparser`. RSS news feeds are optional — the CLI works without them. |
-| `py_vollib` errors | py_vollib uses numba which may not support all environments. The platform falls back to built-in Black-Scholes calculations. |
-| NSE API returns empty data | NSE rate-limits automated requests. Wait a few minutes and retry. The CLI uses browser-like headers to reduce blocks. |
-| Fyers `invalid app id hash` | App ID and Secret Key mismatch. Clear with `credentials delete FYERS_APP_ID` and `credentials delete FYERS_SECRET_KEY`, then `login`. App ID format: `XXXX-100`. |
-| `No active broker session` | Run `login` or `login 0` (demo mode) before broker-dependent commands. |
-| AI commands return errors | Run `credentials setup` to configure your AI provider. Free tier available with Google AI Studio (Gemini). |
-| `keyring` errors on Linux | Install the SecretService backend: `sudo apt install gnome-keyring` or set credentials via `.env`. |
-| Tests failing locally | Run `pip install pytest pytest-mock && pytest tests/ -v -m "not network"`. |
+| Problem | Fix |
+|---------|-----|
+| `ModuleNotFoundError: kiteconnect` | Broker SDKs are optional. Use Demo mode (`login 0`). |
+| NSE API returns empty | NSE rate-limits scrapers. Wait a minute and retry. |
+| Fyers `invalid app id hash` | App ID / Secret mismatch. `credentials delete FYERS_APP_ID` then re-login. App ID format: `XXXX-100`. |
+| `No active broker session` | Run `login` or `login 0` (demo) first. |
+| AI commands error | Run `credentials setup` to configure your AI provider. |
+| `keyring` errors on Linux | `sudo apt install gnome-keyring` or set credentials via `.env`. |
+| Tests failing locally | `pip install pytest pytest-mock && pytest -m "not network"` |
 
 ---
 
-## Disclaimer
-
-This software is for **educational and informational purposes only**. It is not financial advice. Trading in stocks and derivatives involves substantial risk of loss. Past performance (including backtests) does not guarantee future results. Always do your own research and consult a qualified financial advisor before making investment decisions. The authors are not responsible for any financial losses.
-
----
-
-## License
+**Disclaimer:** For educational purposes only. Not financial advice. Trading involves substantial risk of loss. The authors are not responsible for financial losses.
 
 MIT — see [LICENSE](LICENSE).

--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -935,11 +935,41 @@ def _learn_technical(t) -> None:
         )
     params_str = "\n".join(param_lines) if param_lines else "  [dim]None[/dim]"
 
-    backtest_str = (
-        f"[green]✓ Run via:[/green] [bold]strategy use {t.id} SYMBOL[/bold]"
-        if t.backtest_key
-        else "[dim]Not yet available (requires intraday/multi-asset data)[/dim]"
-    )
+    # Load cached backtest result if available
+    cached: dict | None = None
+    if t.backtest_key:
+        try:
+            from engine.backtest_cache import load_result as _cache_load
+
+            cached = _cache_load(t.backtest_key)
+        except Exception:
+            pass
+
+    if t.backtest_key:
+        if cached:
+            ret = cached["total_return"]
+            ret_color = "green" if ret >= 0 else "red"
+            sharpe = cached["sharpe"]
+            sharpe_color = "green" if sharpe >= 1 else "yellow" if sharpe >= 0 else "red"
+            dd = abs(cached["max_drawdown"])
+            backtest_str = (
+                f"[dim]Last run: {cached['symbol']} · {cached['period']} "
+                f"· {cached['run_date']}[/dim]\n"
+                f"  Return      [{ret_color}]{ret:+.1f}%[/{ret_color}]   "
+                f"Sharpe [{sharpe_color}]{sharpe:.2f}[/{sharpe_color}]   "
+                f"Max DD [red]-{dd:.1f}%[/red]\n"
+                f"  Win Rate    {cached['win_rate']:.0f}%   "
+                f"Trades {cached['total_trades']}   "
+                f"Avg Hold {cached['avg_hold']:.0f}d\n"
+                f"  [dim]Re-run: [bold]strategy use {t.id} SYMBOL[/bold][/dim]"
+            )
+        else:
+            backtest_str = (
+                f"[green]✓ Supported.[/green]  "
+                f"[dim]Run [bold]strategy use {t.id} SYMBOL[/bold] to see results.[/dim]"
+            )
+    else:
+        backtest_str = "[dim]Not yet available (requires intraday/multi-asset data)[/dim]"
 
     tf_str = ", ".join(t.timeframes)
     inst_str = ", ".join(t.instruments)
@@ -956,7 +986,7 @@ def _learn_technical(t) -> None:
         f"[bold]PARAMETERS[/bold]\n{params_str}\n\n"
         f"[bold]RISKS[/bold]\n"
         + "\n".join(f"  • {r}" for r in t.risks)
-        + f"\n\n[bold]BACKTEST[/bold]  {backtest_str}"
+        + f"\n\n[bold]BACKTEST[/bold]\n  {backtest_str}"
         + f"\n\n[dim]Tags: {' '.join(t.tags)}[/dim]"
     )
 
@@ -1155,11 +1185,19 @@ def _use_technical(template, symbol: str, raw_args: list[str]) -> None:
     try:
         from engine.backtest import Backtester, STRATEGIES
 
+        from engine.backtest_cache import save_result as _cache_save
+
         strategy_cls = STRATEGIES[template.backtest_key]
         strategy = strategy_cls([])
         bt = Backtester(symbol=symbol, period=period)
         result = bt.run(strategy)
         result.print_summary()
+
+        # Persist so 'strategy learn' can show it without re-running
+        try:
+            _cache_save(template.backtest_key, result, symbol, period)
+        except Exception:
+            pass
 
         # Show last 10 signals in a mini timeline
         try:

--- a/app/commands/strategy.py
+++ b/app/commands/strategy.py
@@ -4,15 +4,15 @@ app/commands/strategy.py
 Interactive strategy builder command.
 
 Subcommands:
-  strategy new [description] [--simple]             — AI-guided strategy creation
-  strategy list                                     — show saved strategies
-  strategy backtest <name> [--period 2y]            — re-backtest a saved strategy
-  strategy run <name> [symbol] [--paper]            — generate signal + paper trade
-  strategy show <name>                              — view code + metadata
-  strategy delete <name>                            — remove a saved strategy
-  strategy library [category]                       — browse the strategy template library
-  strategy learn <name>                             — detailed explanation of a template
-  strategy use <name> SYMBOL [--lots N] [--dte N]  — apply a template with live market data
+  strategy new [description] [--simple]                       — AI-guided strategy creation
+  strategy list                                               — show saved strategies
+  strategy backtest <name> [--period 2y]                      — re-backtest a saved strategy
+  strategy run <name> [symbol] [--paper]                      — generate signal + paper trade
+  strategy show <name>                                        — view code + metadata
+  strategy delete <name>                                      — remove a saved strategy
+  strategy library [category] [--type options|technical|all]  — browse strategy template library
+  strategy learn <name>                                       — detailed explanation of a template
+  strategy use <name> SYMBOL [--lots N] [--dte N]             — apply a template with live data
 """
 
 from __future__ import annotations
@@ -50,15 +50,15 @@ def run(args: list[str]) -> None:
     else:
         console.print(
             "[dim]Usage:\n"
-            "  strategy new [description] [--simple]             Create a new strategy\n"
-            "  strategy list                                     List saved strategies\n"
-            "  strategy backtest <name> [--period 2y]            Re-backtest\n"
-            "  strategy run <name> [symbol] [--paper]            Generate signal\n"
-            "  strategy show <name>                              View code\n"
-            "  strategy delete <name>                            Delete\n"
-            "  strategy library [category]                       Browse strategy templates\n"
-            "  strategy learn <name>                             Explain a template\n"
-            "  strategy use <name> SYMBOL [--lots N] [--dte N]  Apply template with live data[/dim]"
+            "  strategy new [description] [--simple]                       Create a new strategy\n"
+            "  strategy list                                                List saved strategies\n"
+            "  strategy backtest <name> [--period 2y]                       Re-backtest\n"
+            "  strategy run <name> [symbol] [--paper]                       Generate signal\n"
+            "  strategy show <name>                                         View code\n"
+            "  strategy delete <name>                                       Delete\n"
+            "  strategy library [category] [--type options|technical|all]  Browse templates\n"
+            "  strategy learn <name>                                        Explain a template\n"
+            "  strategy use <name> SYMBOL [--lots N] [--dte N]              Apply template[/dim]"
         )
 
 
@@ -500,36 +500,144 @@ def _cmd_delete(args: list[str]) -> None:
 
 
 def _cmd_library(args: list[str]) -> None:
-    """Browse the curated options strategy template library."""
+    """Browse the curated strategy template library (options and/or technical)."""
     from engine.strategy_library import strategy_library, CATEGORIES
+    from engine.technical_library import tech_library, TECH_CATEGORIES
 
-    category = args[0].lower() if args else ""
-
-    if category and category not in CATEGORIES:
-        # Try it as a search query
-        matches = strategy_library.search(category)
-        if matches:
-            console.print(
-                f"[yellow]Unknown category '{category}'. Showing search results instead:[/yellow]\n"
-            )
-            _print_library_table(matches)
+    # Parse --type flag
+    lib_type = "all"
+    clean: list[str] = []
+    i = 0
+    while i < len(args):
+        if args[i] == "--type" and i + 1 < len(args):
+            lib_type = args[i + 1].lower()
+            i += 2
         else:
-            console.print(
-                f"[red]Unknown category '{category}'.[/red] Valid: {', '.join(CATEGORIES)}"
-            )
+            clean.append(args[i])
+            i += 1
+
+    if lib_type not in ("options", "technical", "all"):
+        console.print(f"[red]Unknown --type '{lib_type}'. Use: options, technical, or all[/red]")
         return
 
-    templates = (
-        strategy_library.list_by_category(category) if category else strategy_library.list_all()
-    )
+    category = clean[0].lower() if clean else ""
 
-    title = f"Strategy Library — {category.title()}" if category else "Strategy Library"
-    console.print(f"\n[bold cyan]{title}[/bold cyan] [dim]({len(templates)} strategies)[/dim]\n")
-    _print_library_table(templates)
+    all_cats = tuple(CATEGORIES) + tuple(TECH_CATEGORIES)
+    options_cats = tuple(CATEGORIES)
+    technical_cats = tuple(TECH_CATEGORIES)
+
+    if category:
+        # Route to correct library by category membership
+        if category in options_cats and lib_type != "technical":
+            templates = strategy_library.list_by_category(category)
+            console.print(
+                f"\n[bold cyan]Options Library — {category.title()}[/bold cyan] "
+                f"[dim]({len(templates)} strategies)[/dim]\n"
+            )
+            _print_library_table(templates)
+        elif category in technical_cats and lib_type != "options":
+            templates = tech_library.list_by_category(category)
+            console.print(
+                f"\n[bold cyan]Technical Library — {category.title()}[/bold cyan] "
+                f"[dim]({len(templates)} strategies)[/dim]\n"
+            )
+            _print_technical_table(templates)
+        elif category not in all_cats:
+            # Try search across both libraries
+            opt_matches = strategy_library.search(category)
+            tech_matches = tech_library.search(category)
+            if opt_matches or tech_matches:
+                console.print(
+                    f"[yellow]Unknown category '{category}'. Showing search results:[/yellow]\n"
+                )
+                if opt_matches:
+                    console.print("[bold]Options strategies:[/bold]")
+                    _print_library_table(opt_matches)
+                if tech_matches:
+                    console.print("\n[bold]Technical strategies:[/bold]")
+                    _print_technical_table(tech_matches)
+            else:
+                console.print(
+                    f"[red]Unknown category '{category}'.[/red] "
+                    f"Options: {', '.join(options_cats)} | "
+                    f"Technical: {', '.join(technical_cats)}"
+                )
+        return
+
+    # No category filter — show based on --type
+    if lib_type == "options":
+        templates = strategy_library.list_all()
+        console.print(
+            f"\n[bold cyan]Options Strategy Library[/bold cyan] "
+            f"[dim]({len(templates)} strategies)[/dim]\n"
+        )
+        _print_library_table(templates)
+
+    elif lib_type == "technical":
+        templates = tech_library.list_all()
+        console.print(
+            f"\n[bold cyan]Technical Strategy Library[/bold cyan] "
+            f"[dim]({len(templates)} strategies)[/dim]\n"
+        )
+        _print_technical_table(templates)
+
+    else:  # all
+        opt_templates = strategy_library.list_all()
+        tech_templates = tech_library.list_all()
+        console.print(
+            f"\n[bold cyan]Options Strategy Library[/bold cyan] "
+            f"[dim]({len(opt_templates)} strategies)[/dim]\n"
+        )
+        _print_library_table(opt_templates)
+        console.print(
+            f"\n[bold cyan]Technical Strategy Library[/bold cyan] "
+            f"[dim]({len(tech_templates)} strategies)[/dim]\n"
+        )
+        _print_technical_table(tech_templates)
+
     console.print("\n[dim]Run: [bold]strategy learn <id>[/bold]  to see full explanation[/dim]")
     console.print(
         "[dim]Run: [bold]strategy use <id> SYMBOL[/bold]  to apply with live data[/dim]\n"
     )
+
+
+def _print_technical_table(templates) -> None:
+    """Render a Rich table of technical strategy templates."""
+    from rich.table import Table
+
+    current_cat = None
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("ID", style="cyan", width=28)
+    table.add_column("Name", width=26)
+    table.add_column("Category", width=14)
+    table.add_column("Timeframes", width=16)
+    table.add_column("Complexity", width=14)
+    table.add_column("Backtestable", width=12)
+
+    for t in templates:
+        if t.category != current_cat:
+            if current_cat is not None:
+                table.add_section()
+            current_cat = t.category
+
+        complexity_color = {
+            "beginner": "green",
+            "intermediate": "yellow",
+            "advanced": "red",
+        }.get(t.complexity, "white")
+        backtest_str = "[green]✓[/green]" if t.backtest_key else "[dim]—[/dim]"
+        tf_str = ", ".join(t.timeframes[:3])
+
+        table.add_row(
+            t.id,
+            t.name,
+            t.category,
+            tf_str,
+            f"[{complexity_color}]{t.complexity}[/{complexity_color}]",
+            backtest_str,
+        )
+
+    console.print(table)
 
 
 def _print_library_table(templates) -> None:
@@ -716,9 +824,9 @@ def _format_legs(legs) -> str:
 
 
 def _cmd_learn(args: list[str]) -> None:
-    """Show a detailed explanation panel for a strategy template."""
+    """Show a detailed explanation panel for a strategy template (options or technical)."""
     from engine.strategy_library import strategy_library
-    from rich.panel import Panel
+    from engine.technical_library import tech_library
 
     if not args:
         console.print("[red]Usage: strategy learn <strategy_id>[/red]")
@@ -726,13 +834,27 @@ def _cmd_learn(args: list[str]) -> None:
         return
 
     name = args[0].lower()
+
+    # Try options library first, then technical library
+    t = None
+    is_technical = False
     try:
         t = strategy_library.get(name)
     except KeyError:
-        matches = strategy_library.search(name)
-        if matches:
+        try:
+            t = tech_library.get(name)
+            is_technical = True
+        except KeyError:
+            pass
+
+    if t is None:
+        # Search both libraries for suggestions
+        opt_matches = strategy_library.search(name)
+        tech_matches = tech_library.search(name)
+        all_matches = opt_matches + tech_matches
+        if all_matches:
             console.print(f"[yellow]Strategy '{name}' not found. Did you mean:[/yellow]")
-            for m in matches[:3]:
+            for m in all_matches[:4]:
                 console.print(f"  [cyan]{m.id}[/cyan] — {m.name}")
         else:
             console.print(
@@ -740,6 +862,16 @@ def _cmd_learn(args: list[str]) -> None:
                 "Run [bold]strategy library[/bold] to see all."
             )
         return
+
+    if is_technical:
+        _learn_technical(t)
+    else:
+        _learn_options(t)
+
+
+def _learn_options(t) -> None:
+    """Render the learn panel for an options strategy template."""
+    from rich.panel import Panel
 
     complexity_colors = {"beginner": "green", "intermediate": "yellow", "advanced": "red"}
     comp_color = complexity_colors.get(t.complexity, "white")
@@ -772,12 +904,86 @@ def _cmd_learn(args: list[str]) -> None:
     console.print(f"\n[dim]Apply with live data: [bold]strategy use {t.id} SYMBOL[/bold][/dim]\n")
 
 
+def _learn_technical(t) -> None:
+    """Render the learn panel for a technical strategy template."""
+    from rich.panel import Panel
+
+    complexity_colors = {"beginner": "green", "intermediate": "yellow", "advanced": "red"}
+    comp_color = complexity_colors.get(t.complexity, "white")
+
+    # Format signal rules
+    signal_lines = []
+    for rule in t.signal_rules:
+        sig = rule.get("signal", "")
+        cond = rule.get("condition", "")
+        example = rule.get("example", "")
+        sig_color = "green" if sig == "BUY" else "red" if sig == "SELL" else "yellow"
+        signal_lines.append(
+            f"  [{sig_color}]{sig:<5}[/{sig_color}] [dim]{cond}[/dim]\n"
+            f"         [dim]e.g. {example}[/dim]"
+        )
+    signals_str = "\n\n".join(signal_lines)
+
+    # Format parameters
+    param_lines = []
+    for pname, pdef in t.parameters.items():
+        ptype = pdef.get("type", "")
+        default = pdef.get("default", "")
+        desc = pdef.get("description", "")
+        param_lines.append(
+            f"  [cyan]{pname}[/cyan] ({ptype}, default={default})  [dim]{desc}[/dim]"
+        )
+    params_str = "\n".join(param_lines) if param_lines else "  [dim]None[/dim]"
+
+    backtest_str = (
+        f"[green]✓ Run via:[/green] [bold]strategy use {t.id} SYMBOL[/bold]"
+        if t.backtest_key
+        else "[dim]Not yet available (requires intraday/multi-asset data)[/dim]"
+    )
+
+    tf_str = ", ".join(t.timeframes)
+    inst_str = ", ".join(t.instruments)
+
+    content = (
+        f"[dim]{t.category.upper()} · [{comp_color}]{t.complexity}[/{comp_color}] · "
+        f"Timeframes: {tf_str} · Instruments: {inst_str}[/dim]\n\n"
+        f"[bold yellow]IN PLAIN ENGLISH[/bold yellow]\n{t.layman_explanation}\n\n"
+        f"[bold]SIGNALS[/bold]  [dim](when this strategy says BUY or SELL)[/dim]\n"
+        + signals_str
+        + f"\n\n[bold]HOW IT WORKS[/bold]\n{t.explanation}\n\n"
+        f"[bold]WHEN TO USE[/bold]\n{t.when_to_use}\n\n"
+        f"[bold]WHEN NOT TO USE[/bold]\n{t.when_not_to_use}\n\n"
+        f"[bold]PARAMETERS[/bold]\n{params_str}\n\n"
+        f"[bold]RISKS[/bold]\n"
+        + "\n".join(f"  • {r}" for r in t.risks)
+        + f"\n\n[bold]BACKTEST[/bold]  {backtest_str}"
+        + f"\n\n[dim]Tags: {' '.join(t.tags)}[/dim]"
+    )
+
+    console.print(
+        Panel(
+            content,
+            title=f"[bold]{t.name}[/bold]",
+            border_style="green",
+            padding=(1, 2),
+        )
+    )
+    if t.backtest_key:
+        console.print(f"\n[dim]Run backtest: [bold]strategy use {t.id} SYMBOL[/bold][/dim]\n")
+    else:
+        console.print(
+            "\n[dim]This strategy is documented for learning. "
+            "Backtest support coming in a future release.[/dim]\n"
+        )
+
+
 # ── strategy use ──────────────────────────────────────────────
 
 
 def _cmd_use(args: list[str]) -> None:
-    """Apply a strategy template to a real symbol using live ATM data."""
+    """Apply a strategy template to a real symbol (options: live ATM data; technical: backtest)."""
     from engine.strategy_library import strategy_library, apply_template
+    from engine.technical_library import tech_library
     from engine.strategy import get_atm_data
     from rich.panel import Panel
     from rich.table import Table
@@ -793,19 +999,35 @@ def _cmd_use(args: list[str]) -> None:
         console.print("[red]Usage: strategy use <strategy_id> SYMBOL [--lots N] [--dte N][/red]")
         return
 
+    # Look up in options library first, then technical library
+    template = None
+    is_technical = False
     try:
         template = strategy_library.get(strategy_id)
     except KeyError:
-        matches = strategy_library.search(strategy_id)
-        if matches:
+        try:
+            template = tech_library.get(strategy_id)
+            is_technical = True
+        except KeyError:
+            pass
+
+    if template is None:
+        opt_matches = strategy_library.search(strategy_id)
+        tech_matches = tech_library.search(strategy_id)
+        all_matches = opt_matches + tech_matches
+        if all_matches:
             console.print(f"[yellow]Strategy '{strategy_id}' not found. Did you mean:[/yellow]")
-            for m in matches[:3]:
+            for m in all_matches[:3]:
                 console.print(f"  [cyan]{m.id}[/cyan] — {m.name}")
         else:
             console.print(
                 f"[red]Strategy '{strategy_id}' not found.[/red] "
                 "Run [bold]strategy library[/bold] to see all."
             )
+        return
+
+    if is_technical:
+        _use_technical(template, symbol, args)
         return
 
     # Warn if stock-leg strategy applied to index
@@ -900,6 +1122,78 @@ def _cmd_use(args: list[str]) -> None:
     console.print(
         f"\n[dim]For placement: [bold]trade {symbol} {' / '.join(template.views)}[/bold][/dim]\n"
     )
+
+
+def _use_technical(template, symbol: str, raw_args: list[str]) -> None:
+    """Run a technical strategy template: backtest if available, else show info."""
+    from rich.panel import Panel
+
+    if not template.backtest_key:
+        console.print(
+            f"\n[bold cyan]{template.name}[/bold cyan]\n"
+            f"[yellow]This strategy cannot be backtested yet.[/yellow]\n"
+            f"[dim]It requires {', '.join(template.instruments)} data that is not yet wired up "
+            f"(intraday, multi-asset, or specialised feeds).[/dim]\n\n"
+            f"[dim]Run [bold]strategy learn {template.id}[/bold] to explore the strategy.[/dim]\n"
+        )
+        return
+
+    # Parse optional --period flag
+    period = "1y"
+    i = 0
+    while i < len(raw_args):
+        if raw_args[i] == "--period" and i + 1 < len(raw_args):
+            period = raw_args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    console.print(
+        f"\n[dim]Running backtest: [bold]{template.name}[/bold] on {symbol} ({period})...[/dim]"
+    )
+
+    try:
+        from engine.backtest import Backtester, STRATEGIES
+
+        strategy_cls = STRATEGIES[template.backtest_key]
+        strategy = strategy_cls([])
+        bt = Backtester(symbol=symbol, period=period)
+        result = bt.run(strategy)
+        result.print_summary()
+
+        # Show last 10 signals in a mini timeline
+        try:
+            from market.history import get_ohlcv
+
+            df = get_ohlcv(symbol, days=90)
+            if not df.empty:
+                signals = strategy.generate_signals(df)
+                latest = int(signals.iloc[-1]) if len(signals) else 0
+                latest_price = float(df["close"].iloc[-1])
+                latest_date = (
+                    str(df.index[-1].date()) if hasattr(df.index[-1], "date") else str(df.index[-1])
+                )
+                signal_map = {1: "[green]BUY[/green]", -1: "[red]SELL[/red]", 0: "[dim]HOLD[/dim]"}
+                recent = signals.tail(10)
+                sig_str = " ".join(
+                    "[green]+[/green]" if s == 1 else "[red]-[/red]" if s == -1 else "[dim].[/dim]"
+                    for s in recent
+                )
+                console.print(
+                    Panel(
+                        f"  Symbol : [bold]{symbol}[/bold] @ ₹{latest_price:,.2f} ({latest_date})\n"
+                        f"  Signal : {signal_map.get(latest, '[dim]HOLD[/dim]')}\n"
+                        f"  Last 10: {sig_str}",
+                        title="Current Signal",
+                        border_style="green",
+                        padding=(0, 2),
+                    )
+                )
+        except Exception:
+            pass  # signal panel is best-effort
+
+    except Exception as e:
+        console.print(f"[red]Backtest failed: {e}[/red]")
 
 
 def _parse_use_args(args: list[str]) -> tuple[str, str, int, int]:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,159 @@
+# Command Reference
+
+Full list of REPL commands. Run `help` inside the REPL for a live summary.
+
+---
+
+## Analysis
+
+| Command | Description |
+|---------|-------------|
+| `analyze RELIANCE` | 7 analyst agents + bull-bear debate + 3 risk-profiled trade plans (8 LLM calls) |
+| `deep-analyze INFY` | Full LLM mode — every analyst AI-powered (11 calls) |
+| `morning-brief` | Daily market context + AI narrative |
+| `mtf RELIANCE` | Multi-timeframe confluence (weekly / daily / hourly) |
+| `ai <message>` | Chat with the trading agent — context-aware follow-ups |
+
+---
+
+## Strategy Library (curated templates)
+
+| Command | Description |
+|---------|-------------|
+| `strategy library` | Browse all 58 strategies (26 options + 32 technical) |
+| `strategy library --type options` | Options strategies only |
+| `strategy library --type technical` | Technical / systematic strategies only |
+| `strategy library <category>` | Filter by category (e.g. `momentum`, `income`, `breakout`) |
+| `strategy learn <id>` | Full explanation — layman section, signals, parameters, cached backtest stats |
+| `strategy use <id> SYMBOL` | Options: apply with live ATM data. Technical: run backtest + current signal |
+
+---
+
+## Strategy Builder (AI-generated)
+
+> **Warning:** The builder executes AI-generated Python code on your machine. Only run strategies from sources you trust.
+
+| Command | Description |
+|---------|-------------|
+| `strategy new` | Describe in plain English → AI interviews, generates code, backtests |
+| `strategy new --simple` | Same without jargon |
+| `strategy list` | All saved strategies with backtest stats |
+| `strategy backtest <name> [--period 2y]` | Re-backtest a saved strategy |
+| `strategy run <name> SYMBOL [--paper]` | Generate signal, paper trade if BUY |
+| `strategy show <name>` | View the generated Python code |
+| `strategy delete <name>` | Remove a saved strategy |
+
+---
+
+## Market Data
+
+| Command | Description |
+|---------|-------------|
+| `quote TCS` | Live price, OHLC, volume, change |
+| `flows` | FII/DII flow intelligence + buy/sell signals |
+| `earnings` | Quarterly results calendar (NIFTY 50) |
+| `earnings RELIANCE TCS` | Earnings for specific stocks |
+| `deals` | Today's bulk / block deals |
+| `macro` | USD/INR, crude oil, gold, US 10Y snapshot |
+| `macro RELIANCE` | Macro impact on a specific stock |
+| `events` | Event-driven strategy recommendations (expiry, RBI, budget) |
+| `patterns` | Active India-specific market patterns |
+
+---
+
+## Backtesting & Simulation
+
+| Command | Description |
+|---------|-------------|
+| `backtest RELIANCE rsi` | RSI overbought / oversold |
+| `backtest RELIANCE ma 20 50` | EMA crossover |
+| `backtest RELIANCE macd` | MACD signal crossover |
+| `backtest RELIANCE bb` | Bollinger Bands mean reversion |
+| `walkforward RELIANCE rsi` | Walk-forward test (rolling windows) |
+| `whatif nifty -3` | What if NIFTY drops 3%? (uses real stock beta) |
+
+---
+
+## Risk & Portfolio
+
+| Command | Description |
+|---------|-------------|
+| `risk-report` | VaR / CVaR portfolio risk analysis |
+| `greeks` | Net Delta, Theta, Vega across all positions |
+| `pairs` | Scan for pair trading opportunities |
+| `pairs HDFCBANK ICICIBANK` | Analyse a specific stock pair |
+| `portfolio` | Unified view across all connected brokers |
+
+---
+
+## Trade Execution
+
+| Command | Description |
+|---------|-------------|
+| `execute` | Execute last trade plan (neutral risk) — LIVE or PAPER, auto-detected |
+| `execute aggressive` | Execute aggressive plan |
+| `execute conservative` | Execute conservative plan |
+
+---
+
+## Trade Memory & Learning
+
+| Command | Description |
+|---------|-------------|
+| `memory` | Recent trade analyses |
+| `memory stats` | Win rate, P&L, and performance statistics |
+| `memory RELIANCE` | Past analyses for a specific symbol |
+| `memory outcome <ID> WIN 1250` | Record trade outcome |
+| `profile` | Your personal trading style profile |
+| `drift` | Model drift detection — is the AI losing edge? |
+| `audit <ID>` | Post-mortem analysis of a specific trade |
+
+---
+
+## Alerts
+
+| Command | Description |
+|---------|-------------|
+| `alert RELIANCE above 2800` | Simple price alert |
+| `alert NIFTY RSI above 70` | Technical indicator alert |
+| `alert RELIANCE above 2800 AND RSI above 70` | Conditional alert (AND logic) |
+| `alerts` | List all active alerts |
+| `alert remove <ID>` | Remove an alert |
+
+---
+
+## Broker & Account
+
+| Command | Description |
+|---------|-------------|
+| `funds` | Available cash and margin |
+| `holdings` | Long-term delivery holdings |
+| `positions` | Open intraday / F&O positions |
+| `orders` | Today's orders and status |
+| `login` | Connect to a broker |
+| `connect` | Add a second broker (multi-broker mode) |
+| `logout` | Disconnect all brokers |
+
+---
+
+## Output & Config
+
+| Command | Description |
+|---------|-------------|
+| `save-pdf` | Save previous output as PDF |
+| `explain` | Explain previous output in plain English |
+| `--pdf` / `--explain` / `--explain-save` | Flags: append to any command |
+| `provider` | Show / switch AI provider |
+| `telegram setup` | Connect Telegram bot |
+| `credentials` | Manage API keys |
+| `web` | Start OpenClaw HTTP skill server |
+
+---
+
+## Telegram Bot
+
+Run `telegram setup` once. After that, 14 bot commands are available from your phone:
+
+`/quote` `/analyze` `/deepanalyze` `/brief` `/flows` `/earnings` `/events` `/macro` `/alert` `/alerts` `/memory` `/pnl` `/help`
+
+Alerts fire to Telegram automatically when triggered.

--- a/engine/backtest.py
+++ b/engine/backtest.py
@@ -292,7 +292,316 @@ STRATEGIES = {
     "macd": lambda args: MACDStrategy(),
     "bollinger": lambda args: BollingerStrategy(),
     "bb": lambda args: BollingerStrategy(),
+    "supertrend": lambda args: SupertrendStrategy(
+        period=int(args[0]) if args else 10,
+        multiplier=float(args[1]) if len(args) > 1 else 3.0,
+    ),
+    "heikin_ashi": lambda args: HeikinAshiStrategy(
+        ema_period=int(args[0]) if args else 21,
+    ),
+    "donchian": lambda args: DonchianStrategy(
+        period=int(args[0]) if args else 20,
+    ),
+    "psar": lambda args: ParabolicSARStrategy(
+        step=float(args[0]) if args else 0.02,
+        max_step=float(args[1]) if len(args) > 1 else 0.20,
+    ),
+    "zscore": lambda args: ZScoreStrategy(
+        lookback=int(args[0]) if args else 20,
+        entry_z=float(args[1]) if len(args) > 1 else 2.0,
+    ),
+    "keltner": lambda args: KeltnerStrategy(
+        ema_period=int(args[0]) if args else 20,
+        atr_multiplier=float(args[1]) if len(args) > 1 else 2.0,
+    ),
+    "inside_bar": lambda args: InsideBarStrategy(),
+    "dual_momentum": lambda args: DualMomentumStrategy(
+        lookback=int(args[0]) if args else 90,
+    ),
 }
+
+
+# ── Extended Strategy Classes ─────────────────────────────────
+
+
+class SupertrendStrategy(Strategy):
+    """ATR-based trailing stop that flips direction on trend change."""
+
+    def __init__(self, period: int = 10, multiplier: float = 3.0):
+        self.period = period
+        self.multiplier = multiplier
+        self.name = f"Supertrend({period}, {multiplier})"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        high, low, close = df["high"], df["low"], df["close"]
+
+        # ATR
+        tr = pd.concat(
+            [high - low, (high - close.shift()).abs(), (low - close.shift()).abs()], axis=1
+        ).max(axis=1)
+        atr = tr.rolling(self.period).mean()
+
+        hl2 = (high + low) / 2
+        upper_band = hl2 + self.multiplier * atr
+        lower_band = hl2 - self.multiplier * atr
+
+        # Iteratively compute Supertrend direction
+        trend_arr = [1] * len(df)  # 1 = bullish, -1 = bearish
+        fu = upper_band.to_numpy(dtype=float).copy()
+        fl = lower_band.to_numpy(dtype=float).copy()
+        cl = close.to_numpy(dtype=float)
+
+        import math
+
+        for i in range(1, len(df)):
+            curr_lb = lower_band.iloc[i]
+            curr_ub = upper_band.iloc[i]
+
+            if math.isnan(curr_lb):
+                # ATR not ready yet — hold previous values
+                fl[i] = fl[i - 1]
+                fu[i] = fu[i - 1]
+            elif math.isnan(fl[i - 1]):
+                # Bootstrap: first bar with valid ATR
+                fl[i] = curr_lb
+                fu[i] = curr_ub
+            else:
+                # Lower band (support): raise only, never lower below previous
+                fl[i] = curr_lb if curr_lb > fl[i - 1] or cl[i - 1] < fl[i - 1] else fl[i - 1]
+                # Upper band (resistance): lower only, never raise above previous
+                fu[i] = curr_ub if curr_ub < fu[i - 1] or cl[i - 1] > fu[i - 1] else fu[i - 1]
+
+            # Trend direction flip
+            if trend_arr[i - 1] == -1 and cl[i] > fu[i - 1]:
+                trend_arr[i] = 1
+            elif trend_arr[i - 1] == 1 and cl[i] < fl[i - 1]:
+                trend_arr[i] = -1
+            else:
+                trend_arr[i] = trend_arr[i - 1]
+
+        trend = pd.Series(trend_arr, index=df.index)
+
+        # Signal: 1 on flip to bullish, -1 on flip to bearish
+        signals = pd.Series(0, index=df.index)
+        prev_trend = trend.shift(1)
+        signals[(prev_trend == -1) & (trend == 1)] = 1
+        signals[(prev_trend == 1) & (trend == -1)] = -1
+        return signals
+
+
+class HeikinAshiStrategy(Strategy):
+    """Trade on full Heikin Ashi candles (no opposing wicks) with EMA filter."""
+
+    def __init__(self, ema_period: int = 21):
+        self.ema_period = ema_period
+        self.name = f"Heikin Ashi(EMA {ema_period})"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        # Compute Heikin Ashi candles
+        ha_close = (df["open"] + df["high"] + df["low"] + df["close"]) / 4
+        ha_open = ha_close.copy()
+        for i in range(1, len(df)):
+            ha_open.iloc[i] = (ha_open.iloc[i - 1] + ha_close.iloc[i - 1]) / 2
+        ha_high = pd.concat([df["high"], ha_open, ha_close], axis=1).max(axis=1)
+        ha_low = pd.concat([df["low"], ha_open, ha_close], axis=1).min(axis=1)
+
+        # Full bullish HA candle: no lower wick (ha_low == ha_open), green (close > open)
+        bull_no_lower = (ha_low == ha_open) & (ha_close > ha_open)
+        # Full bearish HA candle: no upper wick (ha_high == ha_open), red (close < open)
+        bear_no_upper = (ha_high == ha_open) & (ha_close < ha_open)
+
+        # EMA filter
+        from analysis.technical import ema as calc_ema
+
+        ema_vals = calc_ema(df["close"], self.ema_period)
+
+        signals = pd.Series(0, index=df.index)
+        signals[bull_no_lower & (df["close"] > ema_vals)] = 1
+        signals[bear_no_upper & (df["close"] < ema_vals)] = -1
+        return signals
+
+
+class DonchianStrategy(Strategy):
+    """Turtle Trading: buy 20-day high breakout, sell 20-day low breakdown."""
+
+    def __init__(self, period: int = 20, filter_period: int = 50):
+        self.period = period
+        self.filter_period = filter_period
+        self.name = f"Donchian({period})"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        high_break = df["high"].rolling(self.period).max().shift(1)
+        low_break = df["low"].rolling(self.period).min().shift(1)
+        filter_high = df["high"].rolling(self.filter_period).max().shift(1)
+        filter_low = df["low"].rolling(self.filter_period).min().shift(1)
+
+        signals = pd.Series(0, index=df.index)
+        # Buy on new N-day high only if price is above 50-day Donchian mid
+        mid_filter = (filter_high + filter_low) / 2
+        signals[(df["close"] > high_break) & (df["close"] > mid_filter)] = 1
+        signals[(df["close"] < low_break) & (df["close"] < mid_filter)] = -1
+        return signals
+
+
+class ParabolicSARStrategy(Strategy):
+    """Trailing stop that accelerates with the trend — flip on SAR touch."""
+
+    def __init__(self, step: float = 0.02, max_step: float = 0.20):
+        self.step = step
+        self.max_step = max_step
+        self.name = f"Parabolic SAR({step}, {max_step})"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        high, low = df["high"].values, df["low"].values
+        n = len(df)
+
+        sar = low[0]
+        ep = high[0]
+        af = self.step
+        bull = True  # current trend direction
+
+        sar_vals = [sar]
+        trend = [1]
+
+        for i in range(1, n):
+            prev_sar = sar
+            if bull:
+                sar = prev_sar + af * (ep - prev_sar)
+                sar = min(sar, low[i - 1], low[max(0, i - 2)])
+                if low[i] < sar:
+                    bull = False
+                    sar = ep
+                    ep = low[i]
+                    af = self.step
+                else:
+                    if high[i] > ep:
+                        ep = high[i]
+                        af = min(af + self.step, self.max_step)
+            else:
+                sar = prev_sar + af * (ep - prev_sar)
+                sar = max(sar, high[i - 1], high[max(0, i - 2)])
+                if high[i] > sar:
+                    bull = True
+                    sar = ep
+                    ep = high[i]
+                    af = self.step
+                else:
+                    if low[i] < ep:
+                        ep = low[i]
+                        af = min(af + self.step, self.max_step)
+
+            sar_vals.append(sar)
+            trend.append(1 if bull else -1)
+
+        trend_series = pd.Series(trend, index=df.index)
+        prev_trend = trend_series.shift(1)
+        signals = pd.Series(0, index=df.index)
+        signals[(prev_trend == -1) & (trend_series == 1)] = 1
+        signals[(prev_trend == 1) & (trend_series == -1)] = -1
+        return signals
+
+
+class ZScoreStrategy(Strategy):
+    """Rolling z-score mean reversion: fade extremes, exit at mean."""
+
+    def __init__(self, lookback: int = 20, entry_z: float = 2.0):
+        self.lookback = lookback
+        self.entry_z = entry_z
+        self.name = f"Z-Score({lookback}, ±{entry_z})"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        close = df["close"]
+        roll_mean = close.rolling(self.lookback).mean()
+        roll_std = close.rolling(self.lookback).std()
+        z = (close - roll_mean) / roll_std.replace(0, float("nan"))
+
+        signals = pd.Series(0, index=df.index)
+        signals[z < -self.entry_z] = 1  # oversold → buy
+        signals[z > self.entry_z] = -1  # overbought → sell
+        return signals.fillna(0).astype(int)
+
+
+class KeltnerStrategy(Strategy):
+    """ATR-based Keltner Channel: fade price at extreme bands."""
+
+    def __init__(self, ema_period: int = 20, atr_multiplier: float = 2.0, atr_period: int = 10):
+        self.ema_period = ema_period
+        self.atr_multiplier = atr_multiplier
+        self.atr_period = atr_period
+        self.name = f"Keltner({ema_period}, {atr_multiplier}×ATR)"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        from analysis.technical import ema as calc_ema
+
+        mid = calc_ema(df["close"], self.ema_period)
+        tr = pd.concat(
+            [
+                df["high"] - df["low"],
+                (df["high"] - df["close"].shift()).abs(),
+                (df["low"] - df["close"].shift()).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        atr = tr.rolling(self.atr_period).mean()
+
+        upper = mid + self.atr_multiplier * atr
+        lower = mid - self.atr_multiplier * atr
+
+        signals = pd.Series(0, index=df.index)
+        signals[df["close"] < lower] = 1
+        signals[df["close"] > upper] = -1
+        return signals
+
+
+class InsideBarStrategy(Strategy):
+    """Inside bar (range within prior candle) breakout on daily charts."""
+
+    def __init__(self):
+        self.name = "Inside Bar Breakout"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        prev_high = df["high"].shift(1)
+        prev_low = df["low"].shift(1)
+
+        # Inside bar: current high < prev high AND current low > prev low
+        is_inside = (df["high"] < prev_high) & (df["low"] > prev_low)
+
+        # Signal fires on the candle AFTER the inside bar
+        inside_shifted = is_inside.shift(1)
+        signals = pd.Series(0, index=df.index)
+        # Break above prior high after inside bar = bullish
+        signals[inside_shifted & (df["close"] > prev_high)] = 1
+        # Break below prior low after inside bar = bearish
+        signals[inside_shifted & (df["close"] < prev_low)] = -1
+        return signals
+
+
+class DualMomentumStrategy(Strategy):
+    """
+    Antonacci Dual Momentum: absolute + relative momentum with monthly rebalance.
+
+    Absolute: if N-day return > 0 → stay in equities.
+    Signal on rebalance days only (approx every 21 trading days).
+    """
+
+    def __init__(self, lookback: int = 90):
+        self.lookback = lookback
+        self.name = f"Dual Momentum({lookback}d)"
+
+    def generate_signals(self, df: pd.DataFrame) -> pd.Series:
+        close = df["close"]
+        momentum = close / close.shift(self.lookback) - 1  # N-day return
+
+        signals = pd.Series(0, index=df.index)
+        # Rebalance approximately monthly (every 21 trading days)
+        rebalance_days = range(self.lookback, len(df), 21)
+        for i in rebalance_days:
+            if i < len(df):
+                if momentum.iloc[i] > 0:
+                    signals.iloc[i] = 1  # positive momentum → stay/go long
+                else:
+                    signals.iloc[i] = -1  # negative → exit / go to safety
+        return signals
 
 
 # ── Backtester Engine ────────────────────────────────────────

--- a/engine/backtest_cache.py
+++ b/engine/backtest_cache.py
@@ -1,0 +1,96 @@
+"""
+engine/backtest_cache.py
+────────────────────────
+Lightweight JSON cache for backtest results, keyed by strategy ID.
+
+Stores the most-recent run for each strategy so ``strategy learn`` can
+display historical performance without re-running the backtest.
+
+Cache file: ~/.trading_platform/backtest_cache.json
+
+Schema (one entry per strategy key):
+    {
+        "supertrend": {
+            "symbol":       "NIFTY",
+            "period":       "1y",
+            "run_date":     "2026-04-05",
+            "start_date":   "2025-04-07",
+            "end_date":     "2026-04-02",
+            "total_return": -1.13,
+            "cagr":         -1.15,
+            "sharpe":       -0.06,
+            "max_drawdown": -12.03,
+            "win_rate":     50.0,
+            "total_trades": 2,
+            "profit_factor": 0.85,
+            "avg_hold":     51.0
+        },
+        ...
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+_CACHE_PATH = Path.home() / ".trading_platform" / "backtest_cache.json"
+
+
+def _load() -> dict[str, Any]:
+    """Read the entire cache file; return empty dict on first run or corrupt file."""
+    try:
+        if _CACHE_PATH.exists():
+            return json.loads(_CACHE_PATH.read_text())
+    except Exception:
+        pass
+    return {}
+
+
+def _save(data: dict[str, Any]) -> None:
+    """Persist the cache atomically."""
+    _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CACHE_PATH.write_text(json.dumps(data, indent=2))
+
+
+def save_result(strategy_key: str, result, symbol: str, period: str) -> None:
+    """
+    Persist a BacktestResult for *strategy_key*.
+
+    Parameters
+    ----------
+    strategy_key : str
+        The key used in STRATEGIES registry (e.g. ``"supertrend"``).
+    result :
+        A ``BacktestResult`` instance (duck-typed: reads the public fields).
+    symbol : str
+        The symbol that was backtested (e.g. ``"NIFTY"``).
+    period : str
+        The period string (e.g. ``"1y"``).
+    """
+    cache = _load()
+    cache[strategy_key] = {
+        "symbol": symbol,
+        "period": period,
+        "run_date": str(date.today()),
+        "start_date": getattr(result, "start_date", ""),
+        "end_date": getattr(result, "end_date", ""),
+        "total_return": round(getattr(result, "total_return", 0.0), 2),
+        "cagr": round(getattr(result, "cagr", 0.0), 2),
+        "sharpe": round(getattr(result, "sharpe_ratio", 0.0), 2),
+        "max_drawdown": round(getattr(result, "max_drawdown", 0.0), 2),
+        "win_rate": round(getattr(result, "win_rate", 0.0), 1),
+        "total_trades": getattr(result, "total_trades", 0),
+        "profit_factor": round(getattr(result, "profit_factor", 0.0), 2),
+        "avg_hold": round(getattr(result, "avg_hold_days", 0.0), 1),
+    }
+    _save(cache)
+
+
+def load_result(strategy_key: str) -> dict[str, Any] | None:
+    """
+    Return the cached result dict for *strategy_key*, or ``None`` if not found.
+    """
+    return _load().get(strategy_key)

--- a/engine/technical_library.py
+++ b/engine/technical_library.py
@@ -71,9 +71,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="EMA Crossover",
         category="momentum",
         layman_explanation=(
-            "Two moving averages track the stock's price — one fast, one slow. "
-            "When the fast one crosses above the slow one, the trend is turning up: buy. "
-            "When it crosses below, the trend is turning down: sell."
+            "Think of two runners on a track — one fast (9-day average), one slow (21-day average). "
+            "When the fast runner overtakes the slow runner, the market has picked up speed: buy. "
+            "When the fast runner falls behind, the market is slowing down: sell. "
+            "Example: RELIANCE at ₹1,200 — its 9-day average rises to ₹1,215 and crosses above "
+            "its 21-day average at ₹1,208. That crossing tells you: recent buyers are outrunning "
+            "longer-term sellers. The trend is turning up."
         ),
         explanation=(
             "Uses two exponential moving averages (default 9/21 for intraday, 20/50 for swing). "
@@ -119,8 +122,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="MACD System",
         category="momentum",
         layman_explanation=(
-            "MACD measures the distance between two moving averages and draws a histogram showing whether "
-            "momentum is building or fading. When the histogram flips from red to green, bulls are taking over."
+            "Think of a car's accelerator — MACD doesn't tell you how fast the car is going, "
+            "it tells you whether you're pressing harder or easing off. "
+            "When you start pressing harder (the bar turns green and grows), buy. "
+            "When you lift your foot (bar shrinks or flips red), sell. "
+            "Example: NIFTY's MACD histogram was -18 for five days (sellers accelerating). "
+            "It flips to +4 today — buyers just took over the pedal. "
+            "The absolute value is small, but the direction change is what matters."
         ),
         explanation=(
             "MACD(12,26,9): MACD line = 12 EMA - 26 EMA; signal line = 9 EMA of MACD. "
@@ -167,9 +175,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Supertrend",
         category="momentum",
         layman_explanation=(
-            "Supertrend draws a line above or below price based on recent volatility. "
-            "While price stays above the line, you're in an uptrend. "
-            "The moment price closes below it, the trend has flipped — get out or reverse."
+            "Imagine a safety net beneath a tightrope walker. "
+            "As long as the walker stays above the net, keep watching them climb. "
+            "The moment they fall through — exit immediately. "
+            "The net also rises as the walker climbs, locking in gains. "
+            "Example: NIFTY climbs from ₹22,000 to ₹24,500. The Supertrend net sits at ₹23,800. "
+            "One bad day drops NIFTY to ₹23,750 — below the net. Exit. "
+            "You captured most of the ₹2,500 move and got out before the reversal deepened."
         ),
         explanation=(
             "ATR-based trailing stop: upper band = (High+Low)/2 + multiplier×ATR; "
@@ -215,9 +227,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Heikin Ashi Trend",
         category="momentum",
         layman_explanation=(
-            "Heikin Ashi candles are smoothed versions of normal candles — they filter out market noise. "
-            "A full green candle with no bottom shadow means very strong buying pressure. "
-            "A full red candle with no top shadow means very strong selling. Trade only these 'clean' candles."
+            "Normal price charts are like trying to hear someone in a noisy crowd — chaotic. "
+            "Heikin Ashi is like noise-cancelling headphones: it smooths out the price chaos "
+            "so you can see the real trend clearly. "
+            "A perfectly clean green bar with no downward tail means buyers were completely in charge — "
+            "sellers couldn't push price down even for a moment during that entire candle. "
+            "Example: INFY shows five consecutive clean green Heikin Ashi bars, each closing higher, "
+            "all above its 21-day average. No ambiguity — that's a strong uptrend. Hold long."
         ),
         explanation=(
             "HA Close = (O+H+L+C)/4; HA Open = (prev HA Open + prev HA Close)/2. "
@@ -260,9 +276,11 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="ADX Trend Strength Filter",
         category="momentum",
         layman_explanation=(
-            "ADX measures how strong the current trend is — not which direction, just how strong. "
-            "Above 25 means the market is trending: use momentum strategies. "
-            "Below 20 means the market is ranging: switch to mean-reversion strategies."
+            "Before deciding how to trade, you need to know: is the market actually going somewhere, "
+            "or just wobbling in place? ADX is a thermometer for the market's energy — not direction, just strength. "
+            "Example: NIFTY ADX reads 34 — that's a strong trend. It doesn't matter which way; "
+            "use a trend strategy and ride it. ADX reads 13 — the market is meandering aimlessly. "
+            "Don't try to catch a trend that isn't there. Switch to a range-trading strategy instead."
         ),
         explanation=(
             "ADX > 25 = strong trend → use EMA crossover, MACD, Supertrend. "
@@ -311,9 +329,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Donchian Channel Breakout",
         category="momentum",
         layman_explanation=(
-            "Donchian channels track the highest high and lowest low over the past N days. "
-            "When price breaks above the channel top, something significant is happening — buy the breakout. "
-            "This is the classic 'Turtle Trading' rule used by Richard Dennis in the 1980s."
+            "If a stock has been stuck under a ceiling for 20 days and then bursts through it, "
+            "that's not random — new buyers arrived who are willing to pay more than anyone in the past month. "
+            "That conviction usually keeps going. "
+            "Example: TCS has been ranging ₹3,600–₹3,800 for three weeks. "
+            "Today it closes at ₹3,825 — a new 20-day high. Buy. "
+            "The Turtle Traders of the 1980s turned $1.6 million into $175 million doing exactly this."
         ),
         explanation=(
             "Buy when price closes above the 20-day highest high; sell when below 20-day lowest low. "
@@ -362,10 +383,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Parabolic SAR",
         category="momentum",
         layman_explanation=(
-            "SAR stands for 'Stop and Reverse'. "
-            "A dot appears either above or below the price bar. "
-            "While the dot is below price, you're long. The moment price closes below the dot — "
-            "exit the long and go short. Simple flip-based system."
+            "Imagine a dog on a leash walking behind you. When you walk forward (uptrend), "
+            "the dog follows slightly behind. The moment you turn back, the leash snaps tight. "
+            "The SAR dot is that leash — it trails the stock as it rises. "
+            "Example: BANKNIFTY climbs from ₹46,000 to ₹48,500 over two weeks. "
+            "The dot sits below at ₹47,900. One bad session drops BANKNIFTY to ₹47,850 — "
+            "below the dot. Exit immediately, flip short. One rule, zero ambiguity."
         ),
         explanation=(
             "The SAR accelerates toward price as the trend extends (acceleration factor starts at 0.02, "
@@ -414,10 +437,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Ichimoku Cloud",
         category="momentum",
         layman_explanation=(
-            "Ichimoku draws a 'cloud' of support/resistance around price. "
-            "If price is above the cloud — it's in an uptrend. Below the cloud — downtrend. "
-            "When all five components agree (price, two lines, and the cloud), "
-            "it's one of the strongest trend signals in technical analysis."
+            "The Ichimoku Cloud is like a weather forecast for stocks. "
+            "The coloured cloud is the storm zone: price above it means clear skies (uptrend), "
+            "inside means fog (uncertain), below means stormy (downtrend). "
+            "Example: HDFC Bank at ₹1,820. The cloud spans ₹1,700–₹1,760 — "
+            "price is well above the storm zone, the fast line (₹1,800) is above the slow line (₹1,775), "
+            "and the lagging line confirms. All five components agree: strong buy signal. "
+            "Used by Japanese traders for 70+ years before the West discovered it."
         ),
         explanation=(
             "Five components: Tenkan-sen (9-period midpoint), Kijun-sen (26-period midpoint), "
@@ -460,9 +486,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Bollinger Band Reversion",
         category="mean_reversion",
         layman_explanation=(
-            "Bollinger Bands draw a 'normal range' around price using standard deviation. "
-            "When price touches the bottom band, it has moved unusually far down — it tends to bounce back. "
-            "When it touches the top band, it has moved unusually far up — it tends to pull back."
+            "Picture a rubber band stretched around a ball. When pulled too far out — it snaps back. "
+            "Bollinger Bands work the same way: a stock's 20-day average is the center, "
+            "and the bands mark 'unusually far' above and below it. "
+            "Example: RELIANCE 20-day average = ₹3,000. Lower band = ₹2,840. "
+            "Price drops to ₹2,830 — it has been stretched far below normal. "
+            "Historically, this kind of stretch almost always snaps back to ₹3,000 within a few days. Buy."
         ),
         explanation=(
             "20-period SMA ± 2 standard deviations. "
@@ -509,9 +538,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="RSI Oversold / Overbought",
         category="mean_reversion",
         layman_explanation=(
-            "RSI scores how fast a stock has been rising or falling, from 0 to 100. "
-            "Below 30 means it's fallen too far too fast — likely to bounce (buy). "
-            "Above 70 means it's risen too far too fast — likely to pull back (sell)."
+            "RSI measures how exhausted buyers or sellers are, on a scale of 0 to 100. "
+            "Below 30: sellers are completely out of breath — time to buy. "
+            "Above 70: buyers are gasping — time to sell. "
+            "Example: WIPRO has fallen 12% over eight days. RSI hits 24. "
+            "That's not a company in crisis — that's exhausted sellers who have nothing left to sell. "
+            "The stock almost always bounces from here. Buy the exhaustion, sell the euphoria."
         ),
         explanation=(
             "RSI(14) below 30 = oversold → buy; above 70 = overbought → sell. "
@@ -561,9 +593,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="VWAP Reversion (Intraday)",
         category="mean_reversion",
         layman_explanation=(
-            "VWAP is the average price of every trade done so far today, weighted by volume — "
-            "it's where most money has exchanged hands. "
-            "If price moves more than 2 standard deviations above VWAP, it's too far away and will likely snap back."
+            "VWAP is today's 'fair price' — the average where the most actual money changed hands today. "
+            "Big institutions use it as their benchmark: their mandate says 'buy at or below today's VWAP'. "
+            "So when price drifts well above VWAP, they stop buying — and price drifts back. "
+            "Example: NIFTY's VWAP is ₹24,100 at 10 AM. Price shoots to ₹24,320 (0.9% above). "
+            "Institutions pause. Price drifts back to ₹24,130 by 11 AM. "
+            "Wait for that drift back, then buy the return to fair value."
         ),
         explanation=(
             "Fade price when it is > 2 standard deviations above/below the VWAP band. "
@@ -617,9 +652,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Z-Score Mean Reversion",
         category="mean_reversion",
         layman_explanation=(
-            "Z-score measures how many standard deviations a stock's price is from its recent average. "
-            "If the Z-score is +2, the price is unusually high — it will likely fall back. "
-            "If it's -2, the price is unusually low — it will likely rise back."
+            "Z-score answers: 'Is this price weird, or normal?' "
+            "Example: AXISBANK usually trades around ₹1,000 and swings about ₹20 a day. "
+            "Today it closes at ₹1,080 — ₹80 above normal, which is 4 times its typical daily swing. "
+            "Z-score = +4. That's extreme. Extremes almost always correct back toward normal. "
+            "If it drops to ₹900 (Z-score = -5), that's even more extreme in the other direction — buy hard. "
+            "The math is pure: buy when something is historically cheap, sell when historically expensive."
         ),
         explanation=(
             "Rolling z-score = (close - N-day mean) / N-day std. "
@@ -673,9 +711,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Keltner Channel Reversion",
         category="mean_reversion",
         layman_explanation=(
-            "Keltner Channels are like Bollinger Bands but smoother — they use ATR instead of standard deviation. "
-            "When price stretches too far above the channel, it tends to snap back. "
-            "The smoother channel means fewer false signals than Bollinger Bands."
+            "Keltner Channels are highway guardrails — stocks stay inside them most of the time. "
+            "When a stock strays outside a guardrail, it naturally drifts back to the center lane. "
+            "Example: NIFTY's center is ₹24,000. Upper guardrail at ₹24,350. "
+            "Price closes at ₹24,380 — outside the guardrail. "
+            "Short it, target ₹24,000. "
+            "Works like Bollinger Bands but is smoother, built on actual average daily swings "
+            "rather than pure statistical math."
         ),
         explanation=(
             "Middle = 20 EMA. Upper = 20 EMA + 2×ATR(10). Lower = 20 EMA - 2×ATR(10). "
@@ -725,9 +767,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Opening Range Breakout (ORB)",
         category="scalping",
         layman_explanation=(
-            "In the first 15–30 minutes after market open, price forms a range (a high and a low). "
-            "This range captures the initial tug-of-war between buyers and sellers. "
-            "Once price breaks above that range — bulls won. Break below — bears won. Trade the winner."
+            "The first 15 minutes after 9:15 AM is a knife fight — buyers and sellers "
+            "arguing over where prices should be. That fight creates a range: a high and a low. "
+            "One side will eventually win. When price breaks above that range — buyers won. Ride with them. "
+            "Example: 9:15–9:30, NIFTY ranges ₹24,000–₹24,120. "
+            "At 9:35, price closes at ₹24,145 — above the range. Buy, target ₹24,240 "
+            "(same ₹120 distance as the opening range). Stop-loss below ₹24,000."
         ),
         explanation=(
             "Define the opening range as the high/low of the first 15 or 30 minutes (9:15–9:30 AM IST). "
@@ -782,9 +827,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="RSI Scalping (Ultra-short)",
         category="scalping",
         layman_explanation=(
-            "Use a very fast RSI (period 2 or 5) on a 1-minute chart. "
-            "When RSI drops below 10 — the stock has fallen too fast in seconds — snap back is very likely. "
-            "Take a quick long, exit when RSI crosses back to 50. A very short-hold trade."
+            "Sometimes a big sell order hits the market and a stock drops ₹15 in 3 minutes — "
+            "not because anything is wrong, just because someone was forced to sell in a hurry. "
+            "RSI scalping catches that panic: when the 2-minute RSI falls below 10, "
+            "the selling was so violent that a snap-back is almost certain. "
+            "Example: HDFC Bank drops ₹18 in 4 minutes, 2-minute RSI hits 7. Buy immediately. "
+            "Hold 5-10 minutes, exit at ₹8-12 gain per share. Small profit, very frequent. "
+            "Requires fast execution and strict discipline — not for beginners."
         ),
         explanation=(
             "RSI(2) or RSI(5) on 1m/3m chart. "
@@ -827,9 +876,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="VWAP Scalp",
         category="scalping",
         layman_explanation=(
-            "VWAP is where most of today's trading has happened. "
-            "When price dips to VWAP after being above it all morning, big institutions often step in to buy — "
-            "that support creates a reliable bounce for a scalp trade."
+            "Institutional fund managers are evaluated against VWAP — their mandate says 'execute at VWAP'. "
+            "This means when price dips back to VWAP, they are waiting there with large buy orders. "
+            "You step in just before them. "
+            "Example: NIFTY VWAP = ₹24,100 at 11 AM. Price has been above it all morning at ₹24,180. "
+            "It dips to ₹24,105 — touching VWAP. Buy. Institution shows up, price bounces to ₹24,160. "
+            "Exit. You made ₹55 in 8 minutes by knowing where the buying wall was."
         ),
         explanation=(
             "Long on first touch of VWAP after a sustained move above it (VWAP reclaim). "
@@ -878,9 +930,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Previous Day High / Low Breakout",
         category="scalping",
         layman_explanation=(
-            "Yesterday's high and low are key levels — many traders have stops and orders sitting there. "
-            "When price breaks through yesterday's high on volume, those stops trigger and price accelerates. "
-            "This creates a reliable momentum trade in the direction of the break."
+            "Yesterday's high and low are invisible walls where thousands of stop-loss orders sit. "
+            "When price breaks through yesterday's high, every stop triggers at once — "
+            "a sudden flood of buyers enters and price accelerates. "
+            "Example: Yesterday RELIANCE high = ₹1,280. Today at 10:15 AM, "
+            "price crosses ₹1,283 with heavy volume. Every short-seller's stop triggers. "
+            "Price shoots to ₹1,295 in 20 minutes. "
+            "You entered at ₹1,283, captured ₹12 — an avalanche others set up for you."
         ),
         explanation=(
             "PDH/PDL are strong intraday reference levels. "
@@ -931,9 +987,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Pivot Point Breakout",
         category="breakout",
         layman_explanation=(
-            "Pivot points are price levels calculated from yesterday's data that many traders watch simultaneously. "
-            "R1/R2 are resistance levels above; S1/S2 are support levels below. "
-            "When price breaks through R1 with momentum, it often runs to R2 — and vice versa."
+            "Pivot points are calculated by every trader, every algorithm, every prop desk — "
+            "all using the same formula from yesterday's numbers. "
+            "Because everyone watches the same levels, they become self-fulfilling. "
+            "Example: NIFTY Pivot = ₹24,000, R1 = ₹24,200. Price stalls below ₹24,200 all morning. "
+            "At 1:15 PM it blasts through ₹24,205 on high volume. Next target is R2 = ₹24,380. "
+            "You entered at ₹24,210 and rode ₹170 — just by reading the same map as everyone else."
         ),
         explanation=(
             "Standard pivots: P = (H + L + C) / 3; R1 = 2P - L; R2 = P + (H - L); "
@@ -982,9 +1041,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Inside Bar Breakout",
         category="breakout",
         layman_explanation=(
-            "An inside bar is a candle that fits completely within the previous candle's range — "
-            "the market couldn't make a new high or low. It's a pause, a breath. "
-            "The next candle that breaks outside that range tells you which way the market wants to go."
+            "An inside bar is a day where the market couldn't make a new high or a new low — "
+            "buyers and sellers reached a perfect standoff. Think of it as a coiled spring. "
+            "Example: Monday, HDFC Bank ranged ₹1,750–₹1,820. "
+            "Tuesday closes entirely inside: ₹1,760–₹1,808. "
+            "The spring is coiling. Wednesday morning opens at ₹1,815, breaks above ₹1,820 — "
+            "buyers won the standoff. Buy ₹1,822, stop-loss ₹1,749 (Monday's low). "
+            "The sharper the breakout, the more energy was stored."
         ),
         explanation=(
             "Inside bar: current high < previous high AND current low > previous low. "
@@ -1029,9 +1092,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Flag / Pennant Continuation",
         category="breakout",
         layman_explanation=(
-            "After a strong vertical move (the flagpole), the stock takes a rest and moves sideways in a tight range "
-            "(the flag). When it breaks out of that rest in the same direction as the initial move, "
-            "it tends to travel the same distance as the original flagpole."
+            "A stock jumps 7% in two days — that's the flagpole. Then it drifts sideways for a week "
+            "as traders take profits — that's the flag. Not a reversal, just a rest. "
+            "When price breaks out of that tight sideways range in the same direction, "
+            "the next leg tends to be the same size as the original jump. "
+            "Example: INFY runs from ₹1,500 to ₹1,605 (+7%) in two days. Drifts sideways ₹1,575–₹1,600. "
+            "Breaks above ₹1,602. Buy. Target: ₹1,707 (another +7% from breakout). "
+            "You're buying after the stock has rested and reloaded."
         ),
         explanation=(
             "Flag: a tight rectangular consolidation after a sharp move, sloping slightly against the trend. "
@@ -1082,9 +1149,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Pairs Trading",
         category="pairs",
         layman_explanation=(
-            "Find two stocks that usually move together (e.g. TCS and Infosys). "
-            "When TCS suddenly becomes much more expensive than Infosys relative to their history, "
-            "you buy the cheaper one and sell the expensive one — betting they'll come back together."
+            "TCS and Infosys are siblings — same business, same cycle, almost always move together. "
+            "Normally TCS trades at about 1.4× the price of Infosys. "
+            "One day: TCS jumps to ₹4,200, Infosys stays at ₹2,700. Ratio = 1.56 — TCS is too expensive. "
+            "Buy ₹1 lakh of Infosys, short ₹1 lakh of TCS. "
+            "Over the next few days the ratio drifts back to 1.4. "
+            "Both legs close in profit. The market's direction doesn't matter — only the gap between siblings does."
         ),
         explanation=(
             "Cointegration test to find a stationary pair. "
@@ -1135,9 +1205,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Index Arbitrage",
         category="pairs",
         layman_explanation=(
-            "NIFTY futures should trade at a 'fair price' slightly above the NIFTY index (because you earn interest "
-            "by not buying all 50 stocks). When futures trade above or below this fair value, "
-            "you buy the cheap side and sell the expensive side — pocketing the gap when it closes."
+            "NIFTY futures should cost slightly more than the actual index, because you're agreeing to buy later "
+            "and your cash earns interest in the meantime. That 'fair price' is a formula. "
+            "Example: NIFTY = ₹24,000. Fair value of 30-day futures (at 7% interest) = ₹24,140. "
+            "Futures are trading at ₹24,280 — ₹140 above fair value. "
+            "Sell ₹24,280 futures, buy the equivalent of all 50 NIFTY stocks. Lock in ₹140 per lot. "
+            "By expiry, futures must converge to ₹24,000. The ₹140 profit is yours regardless of market direction."
         ),
         explanation=(
             "Fair value = Spot × e^(r×t) where r = risk-free rate, t = DTE/365. "
@@ -1178,9 +1251,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="ETF Arbitrage",
         category="pairs",
         layman_explanation=(
-            "ETFs like NIFTYBEES should trade at exactly the value of the stocks inside them. "
-            "Sometimes they trade at a small premium or discount. When that gap is large enough "
-            "to cover transaction costs, you buy the cheap side and sell the expensive side."
+            "NIFTYBEES is a basket holding all 50 NIFTY stocks. "
+            "It should be worth exactly what those 50 stocks are worth — but sometimes it isn't. "
+            "Example: The 50 stocks are collectively worth ₹240.10 per NIFTYBEES unit, "
+            "but NIFTYBEES is trading at ₹241.80 on NSE — a ₹1.70 premium. "
+            "Buy the 50 stocks at ₹240.10, sell NIFTYBEES at ₹241.80. "
+            "Collect ₹1.70 per unit as both sides converge. Zero directional risk. Pure gap capture."
         ),
         explanation=(
             "Monitor iNAV (intraday NAV) vs market price of ETF. "
@@ -1225,9 +1301,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Calendar Spread (Futures)",
         category="pairs",
         layman_explanation=(
-            "Near-month and far-month futures on the same stock should differ by the cost of 'waiting' "
-            "(interest you'd earn if you held cash instead). When the spread between them gets unusually wide "
-            "or narrow, you buy one month and sell the other — waiting for the spread to normalise."
+            "January and March NIFTY futures are the same index — the only difference is time. "
+            "The price gap between them should equal roughly 2 months of interest on your capital. "
+            "At 7% annual interest, that's about ₹280 per ₹24,000 lot. "
+            "Example: January futures at ₹24,050, March futures at ₹24,480 — gap of ₹430, not ₹280. "
+            "Sell March at ₹24,480, buy January at ₹24,050. Lock in ₹150 extra. "
+            "By March expiry, the gap must collapse to zero. No prediction needed."
         ),
         explanation=(
             "Fair spread = Spot × r × (T2 - T1)/365. "
@@ -1273,10 +1352,11 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="RBI Policy Trade",
         category="macro",
         layman_explanation=(
-            "When the RBI announces interest rates, markets usually make a big move — "
-            "but nobody knows exactly which way. One approach: buy both a call and a put (straddle) "
-            "before the announcement so you profit regardless of direction. "
-            "Another: wait for the announcement, then trade the momentum."
+            "RBI rate decisions cause big market moves — but nobody knows which way. "
+            "Strategy 1 (straddle): NIFTY at ₹24,000. Buy a ₹24,000 call for ₹120 and a ₹24,000 put for ₹110. "
+            "Total cost: ₹230. If NIFTY moves more than ₹230 in either direction — you profit. "
+            "Strategy 2 (momentum): Wait for the announcement. If markets start rallying hard, "
+            "buy the first pullback. Both strategies work. Neither requires you to predict the RBI."
         ),
         explanation=(
             "Pre-event: buy ATM straddle 2 days before → exit within 30 minutes of announcement. "
@@ -1326,9 +1406,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="FII Flow Following",
         category="macro",
         layman_explanation=(
-            "Foreign Institutional Investors move markets. When they buy heavily for 3 days in a row, "
-            "the market tends to keep rising. When they sell heavily for 3 days, it tends to keep falling. "
-            "Following their footprints is a simple but effective macro signal."
+            "Foreign investors (FIIs) are the single biggest force in Indian markets — "
+            "their buying and selling moves NIFTY by 100-300 points. "
+            "SEBI publishes exactly how much they bought or sold each day. "
+            "Example: FIIs net bought ₹3,200 cr on Monday, ₹4,800 cr on Tuesday, ₹2,600 cr on Wednesday. "
+            "Three consecutive days of heavy buying. On Thursday morning, buy NIFTY futures. "
+            "Don't predict — follow the elephant. When it walks in one direction, get out of the way or join it."
         ),
         explanation=(
             "NSE publishes daily FII/DII buy-sell data. "
@@ -1378,9 +1461,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="VIX Mean Reversion",
         category="macro",
         layman_explanation=(
-            "India VIX measures how scared the market is. "
-            "When VIX spikes above 20, fear is high and options are expensive — sell premium (you'll be overpaid). "
-            "When VIX drops below 11, complacency is extreme and options are cheap — buy them for an upcoming shock."
+            "India VIX is the market's fear-o-meter. "
+            "Example: VIX spikes to 24 during a geopolitical scare. "
+            "A NIFTY straddle that normally costs ₹300 now costs ₹520 — people are overpaying for insurance. "
+            "Sell the straddle at ₹520. Over the next 7 days, fear fades and VIX drops to 14. "
+            "The straddle is now worth ₹180. Buy it back. Pocket ₹340. "
+            "Flip side: VIX at 10 = everyone relaxed, options at ₹150. Buy cheap insurance before the next shock."
         ),
         explanation=(
             "India VIX > 20 → short straddle, iron condor — collect elevated premiums that will deflate as VIX normalises. "
@@ -1429,9 +1515,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Earnings Momentum",
         category="macro",
         layman_explanation=(
-            "Stock options get more expensive before earnings because nobody knows what will happen. "
-            "If you buy options 5 days before results, you benefit from that rising fear. "
-            "Alternatively, buy the stock the day after a strong earnings beat — the momentum often continues."
+            "Before quarterly results, nobody knows if a company will beat or miss. "
+            "That uncertainty alone makes options expensive — fear and greed both peak. "
+            "Strategy 1 (pre-results): Infosys results in 6 days. Buy the ₹1,800 call for ₹22. "
+            "Day before results, the same call costs ₹42 — fear of missing a big move has driven it up. "
+            "Sell at ₹42. ₹20 profit, and you never even took the earnings risk. "
+            "Strategy 2 (post-beat): Infosys beats by 8%. Next morning, buy the stock. "
+            "Analyst upgrades and fund flows typically push it another 5-10% over 2-3 weeks."
         ),
         explanation=(
             "Pre-earnings IV play: buy ATM straddle 5 days before → sell on announcement day (capture IV expansion). "
@@ -1485,9 +1575,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Sector Rotation",
         category="macro",
         layman_explanation=(
-            "Different industries take turns leading the market. "
-            "Each month, look at which two sectors have performed best in the last month — "
-            "put your money there. Next month, rotate to whichever two are leading then."
+            "The economy moves in cycles — banks lead one phase, then IT, then pharma, then FMCG. "
+            "Each phase lasts months, and the winner of last month often keeps winning next month. "
+            "Example: April check — PSU Banks +9%, IT +2%, Pharma -1%, FMCG +3%. "
+            "For May: put your money in the PSU Bank ETF and FMCG ETF. "
+            "Check again at end of May, rotate to whatever is leading then. "
+            "No prediction needed — just follow who is already winning."
         ),
         explanation=(
             "Rank all NIFTY sector indices by trailing 1-month return. "
@@ -1534,9 +1627,13 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Dual Momentum (Antonacci)",
         category="quantitative",
         layman_explanation=(
-            "Every month, answer two questions: (1) Has the stock/index gone up in the last 3 months? "
-            "(absolute momentum — if no, move to cash). (2) Is it doing better than the alternative? "
-            "(relative momentum — if yes, stay). Simple, low-frequency, rules-based."
+            "Once a month, answer two questions. "
+            "Q1: Is NIFTY higher today than it was 3 months ago? "
+            "If no — sell everything, sit in cash or FD. Done. "
+            "If yes — Q2: Did NIFTY do better than Nifty Midcap over those 3 months? "
+            "Hold whichever won. That's the complete system — two questions, once a month. "
+            "Example: April check — NIFTY 3 months ago ₹22,000, today ₹24,100 (+9.5%). Q1: Yes. "
+            "NIFTY +9.5% vs Midcap +6.2%. Q2: Hold NIFTY for May. Check again May 31."
         ),
         explanation=(
             "Absolute momentum: if N-day return of NIFTY > 0 → stay in equities. "
@@ -1581,9 +1678,14 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Factor Strategy — Quality + Momentum",
         category="quantitative",
         layman_explanation=(
-            "Screen all NSE 500 stocks for two things: (1) quality — high profit, low debt. "
-            "(2) momentum — stock price has been rising over the last 6 months. "
-            "Hold the top 20 that pass both tests. Rebalance monthly."
+            "A two-round talent show for 500 NSE stocks. "
+            "Round 1 — Quality: ROE above 20%? Debt-to-equity below 0.5? Profit growing? "
+            "Say 90 stocks pass. "
+            "Round 2 — Momentum: of those 90, which 25 have risen the most in the past 6 months? "
+            "Keep those 25. Rebalance monthly. "
+            "Example: Round 1 leaves Bajaj Finance, Titan, Pidilite, HDFC AMC. "
+            "Round 2 picks the 25 with best 6-month price performance from that shortlist. "
+            "You own great businesses that the market is already rewarding — a potent combination."
         ),
         explanation=(
             "Quality screen: ROE > 15%, Debt/Equity < 1, positive EPS growth. "
@@ -1640,9 +1742,12 @@ TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
         name="Volatility-Adjusted Position Sizing",
         category="quantitative",
         layman_explanation=(
-            "Instead of always trading the same number of shares, "
-            "you trade fewer shares when a stock is moving violently, and more when it's calm. "
-            "This keeps the rupee risk of each trade roughly the same, regardless of which stock you're trading."
+            "If you always buy 100 shares, you're betting 10x more on volatile stocks without realising it. "
+            "100 shares of HDFC Bank (moves ₹20/day) = ₹2,000 daily risk. "
+            "100 shares of BANKNIFTY (moves ₹200/day) = ₹20,000 daily risk — same share count, 10x the risk. "
+            "Volatility sizing fixes this: you decide your risk per trade (say ₹5,000). "
+            "HDFC Bank: buy 250 shares (₹5,000 ÷ ₹20). BANKNIFTY: buy 25 shares (₹5,000 ÷ ₹200). "
+            "Every trade now risks the same rupees. One bad BANKNIFTY day can't wipe out a week of work."
         ),
         explanation=(
             "ATR-based sizing: quantity = (capital × risk_pct) / (ATR × stop_atr_multiplier). "

--- a/engine/technical_library.py
+++ b/engine/technical_library.py
@@ -1,0 +1,1748 @@
+"""
+engine/technical_library.py
+────────────────────────────
+Curated library of 32 technical and systematic trading strategies for Indian markets.
+
+Companion to engine/strategy_library.py (options strategies). Same architecture:
+each strategy is a TechnicalTemplate — educational metadata + parameter definitions
++ a backtest_key that maps to an entry in engine/backtest.STRATEGIES.
+
+Templates without a backtest_key require intraday data, specialised data feeds,
+or multi-asset infrastructure not yet available — they are documented for learning
+only and will gain backtest support in future iterations.
+
+Usage:
+    from engine.technical_library import tech_library
+
+    template = tech_library.get("supertrend")
+    print(template.layman_explanation)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# ── Constants ─────────────────────────────────────────────────
+
+TECH_CATEGORIES = (
+    "momentum",
+    "mean_reversion",
+    "scalping",
+    "breakout",
+    "pairs",
+    "macro",
+    "quantitative",
+)
+
+
+# ── Dataclass ─────────────────────────────────────────────────
+
+
+@dataclass
+class TechnicalTemplate:
+    """Metadata and educational content for a named technical strategy."""
+
+    id: str
+    name: str
+    category: str  # one of TECH_CATEGORIES
+    layman_explanation: str  # plain English, zero jargon
+    explanation: str  # technical description
+    when_to_use: str
+    when_not_to_use: str
+    signal_rules: list[dict]  # [{"signal": "BUY"|"SELL"|"HOLD", "condition": str, "example": str}]
+    parameters: dict  # {param_name: {"default": val, "description": str, "type": str}}
+    timeframes: list[str]  # e.g. ["5m", "15m", "1D"]
+    instruments: list[str]  # e.g. ["stocks", "indices", "futures"]
+    risks: list[str]
+    tags: list[str]
+    complexity: str = "beginner"  # "beginner" | "intermediate" | "advanced"
+    backtest_key: str | None = (
+        None  # key in engine/backtest.STRATEGIES; None = not yet backtestable
+    )
+
+
+# ── Template definitions ──────────────────────────────────────
+
+TECH_TEMPLATES: dict[str, TechnicalTemplate] = {
+    # ── MOMENTUM (8) ──────────────────────────────────────────
+    "ema_crossover": TechnicalTemplate(
+        id="ema_crossover",
+        name="EMA Crossover",
+        category="momentum",
+        layman_explanation=(
+            "Two moving averages track the stock's price — one fast, one slow. "
+            "When the fast one crosses above the slow one, the trend is turning up: buy. "
+            "When it crosses below, the trend is turning down: sell."
+        ),
+        explanation=(
+            "Uses two exponential moving averages (default 9/21 for intraday, 20/50 for swing). "
+            "A bullish signal fires when the fast EMA crosses above the slow EMA; bearish on the reverse. "
+            "Adding an ADX > 20 filter avoids false signals in choppy markets."
+        ),
+        when_to_use="Trending markets with clear directional momentum; works on any timeframe.",
+        when_not_to_use="Sideways/range-bound markets — generates repeated false crossovers.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Fast EMA crosses above Slow EMA",
+                "example": "e.g. RELIANCE: 9 EMA rises to ₹1,255, crosses above 21 EMA at ₹1,248 → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Fast EMA crosses below Slow EMA",
+                "example": "e.g. RELIANCE: 9 EMA falls to ₹1,230, crosses below 21 EMA at ₹1,238 → SELL",
+            },
+            {
+                "signal": "HOLD",
+                "condition": "EMAs are not crossing — trend is intact",
+                "example": "9 EMA is clearly above 21 EMA and both are rising → hold long",
+            },
+        ],
+        parameters={
+            "fast": {"default": 20, "description": "Fast EMA period", "type": "int"},
+            "slow": {"default": 50, "description": "Slow EMA period", "type": "int"},
+        },
+        timeframes=["5m", "15m", "1h", "1D"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "Whipsaws in sideways markets — fast/slow periods cross repeatedly with no follow-through",
+            "Lagging indicator — entry is always after the move has started",
+            "Works poorly during news-driven gaps",
+        ],
+        tags=["momentum", "trend", "ema", "crossover", "beginner"],
+        complexity="beginner",
+        backtest_key="ema",
+    ),
+    "macd_system": TechnicalTemplate(
+        id="macd_system",
+        name="MACD System",
+        category="momentum",
+        layman_explanation=(
+            "MACD measures the distance between two moving averages and draws a histogram showing whether "
+            "momentum is building or fading. When the histogram flips from red to green, bulls are taking over."
+        ),
+        explanation=(
+            "MACD(12,26,9): MACD line = 12 EMA - 26 EMA; signal line = 9 EMA of MACD. "
+            "Three entry triggers: (1) histogram flip — earliest; (2) signal line crossover; "
+            "(3) zero-line cross — highest conviction. Best aligned with 200 EMA direction."
+        ),
+        when_to_use="Swing and positional trades where you want to catch momentum shifts.",
+        when_not_to_use="Scalping or very short timeframes — too much lag for quick trades.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "MACD histogram turns positive (crosses above zero)",
+                "example": "e.g. NIFTY: histogram was -15, now +3 → bulls taking control → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "MACD histogram turns negative (crosses below zero)",
+                "example": "e.g. NIFTY: histogram was +12, now -5 → momentum flipping → SELL",
+            },
+            {
+                "signal": "HOLD",
+                "condition": "Histogram is positive and growing — trend intact",
+                "example": "Histogram at +20 and expanding → stay long",
+            },
+        ],
+        parameters={
+            "fast": {"default": 12, "description": "Fast EMA period", "type": "int"},
+            "slow": {"default": 26, "description": "Slow EMA period", "type": "int"},
+            "signal": {"default": 9, "description": "Signal line period", "type": "int"},
+        },
+        timeframes=["15m", "1h", "1D", "1W"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "Divergence signals can be premature — price may continue before reversing",
+            "Lags the market — you will never catch the exact top or bottom",
+            "Many false signals during low-volatility chop",
+        ],
+        tags=["momentum", "macd", "histogram", "swing", "beginner"],
+        complexity="beginner",
+        backtest_key="macd",
+    ),
+    "supertrend": TechnicalTemplate(
+        id="supertrend",
+        name="Supertrend",
+        category="momentum",
+        layman_explanation=(
+            "Supertrend draws a line above or below price based on recent volatility. "
+            "While price stays above the line, you're in an uptrend. "
+            "The moment price closes below it, the trend has flipped — get out or reverse."
+        ),
+        explanation=(
+            "ATR-based trailing stop: upper band = (High+Low)/2 + multiplier×ATR; "
+            "lower band = (High+Low)/2 - multiplier×ATR. "
+            "Default: ATR period 10, multiplier 3.0. "
+            "When close crosses the band, the trend flips and the SAR level switches sides."
+        ),
+        when_to_use="Strongly trending markets — works well on NIFTY futures and liquid large-caps.",
+        when_not_to_use="Range-bound or low-ATR markets — produces frequent, costly whipsaws.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price closes above the Supertrend line (trend flips bullish)",
+                "example": "e.g. NIFTY at ₹24,100 closes above Supertrend at ₹24,050 → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price closes below the Supertrend line (trend flips bearish)",
+                "example": "e.g. NIFTY at ₹23,900 closes below Supertrend at ₹23,950 → SELL",
+            },
+        ],
+        parameters={
+            "period": {"default": 10, "description": "ATR lookback period", "type": "int"},
+            "multiplier": {
+                "default": 3.0,
+                "description": "ATR multiplier for band width",
+                "type": "float",
+            },
+        },
+        timeframes=["5m", "15m", "1h", "1D"],
+        instruments=["indices", "stocks", "futures"],
+        risks=[
+            "Whipsaws in choppy markets can generate 5-6 consecutive small losses",
+            "ATR widens after volatile sessions — stop moves far from price",
+            "Does not work well near major support/resistance zones",
+        ],
+        tags=["momentum", "trend", "atr", "trailing_stop", "popular", "beginner"],
+        complexity="beginner",
+        backtest_key="supertrend",
+    ),
+    "heikin_ashi": TechnicalTemplate(
+        id="heikin_ashi",
+        name="Heikin Ashi Trend",
+        category="momentum",
+        layman_explanation=(
+            "Heikin Ashi candles are smoothed versions of normal candles — they filter out market noise. "
+            "A full green candle with no bottom shadow means very strong buying pressure. "
+            "A full red candle with no top shadow means very strong selling. Trade only these 'clean' candles."
+        ),
+        explanation=(
+            "HA Close = (O+H+L+C)/4; HA Open = (prev HA Open + prev HA Close)/2. "
+            "Full bullish signal: no lower wick (HA Low = HA Open) + green candle + price above EMA. "
+            "Full bearish: no upper wick (HA High = HA Open) + red candle + price below EMA."
+        ),
+        when_to_use="Strong trending moves; useful for holding positions without getting shaken out by noise.",
+        when_not_to_use="At major turning points — HA candles are lagging and can miss reversals.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Full green HA candle (no lower wick) above the EMA",
+                "example": "e.g. INFY: HA candle is fully green, no lower wick, price above 21 EMA → strong BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Full red HA candle (no upper wick) below the EMA",
+                "example": "e.g. INFY: HA candle is fully red, no upper wick, price below 21 EMA → SELL",
+            },
+        ],
+        parameters={
+            "ema_period": {
+                "default": 21,
+                "description": "EMA period for trend filter",
+                "type": "int",
+            },
+        },
+        timeframes=["15m", "1h", "1D"],
+        instruments=["stocks", "indices"],
+        risks=[
+            "HA prices are not real prices — stop-loss levels need converting back to actual OHLC",
+            "Candles lag real price action — exits can be late in fast reversals",
+        ],
+        tags=["momentum", "trend", "heikin_ashi", "candles", "intermediate"],
+        complexity="intermediate",
+        backtest_key="heikin_ashi",
+    ),
+    "adx_trend": TechnicalTemplate(
+        id="adx_trend",
+        name="ADX Trend Strength Filter",
+        category="momentum",
+        layman_explanation=(
+            "ADX measures how strong the current trend is — not which direction, just how strong. "
+            "Above 25 means the market is trending: use momentum strategies. "
+            "Below 20 means the market is ranging: switch to mean-reversion strategies."
+        ),
+        explanation=(
+            "ADX > 25 = strong trend → use EMA crossover, MACD, Supertrend. "
+            "ADX < 20 = range-bound → use Bollinger, RSI reversion, Keltner. "
+            "Standalone variant: +DI/-DI crossover with ADX confirmation above 20 as a directional signal."
+        ),
+        when_to_use="As a regime filter layered on top of any other strategy to avoid whipsaws.",
+        when_not_to_use="As the sole entry signal — ADX alone gives no direction.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "+DI crosses above -DI with ADX > 20",
+                "example": "e.g. NIFTY: +DI at 28, -DI at 18, ADX at 26 → trending bullishly → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "-DI crosses above +DI with ADX > 20",
+                "example": "e.g. NIFTY: -DI at 30, +DI at 15, ADX at 28 → trending bearishly → SELL",
+            },
+            {
+                "signal": "HOLD",
+                "condition": "ADX < 20 — market is ranging, avoid directional trades",
+                "example": "ADX at 14 → no trend signal; switch to mean-reversion strategy",
+            },
+        ],
+        parameters={
+            "period": {"default": 14, "description": "ADX lookback period", "type": "int"},
+            "trend_threshold": {
+                "default": 25,
+                "description": "ADX level above which market is trending",
+                "type": "int",
+            },
+        },
+        timeframes=["1h", "1D"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "ADX can remain above 25 during a counter-trend correction — direction still matters",
+            "Slow to respond to sudden trend changes",
+        ],
+        tags=["momentum", "adx", "regime_filter", "trend_strength", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,  # regime filter — combine with another strategy
+    ),
+    "donchian_breakout": TechnicalTemplate(
+        id="donchian_breakout",
+        name="Donchian Channel Breakout",
+        category="momentum",
+        layman_explanation=(
+            "Donchian channels track the highest high and lowest low over the past N days. "
+            "When price breaks above the channel top, something significant is happening — buy the breakout. "
+            "This is the classic 'Turtle Trading' rule used by Richard Dennis in the 1980s."
+        ),
+        explanation=(
+            "Buy when price closes above the 20-day highest high; sell when below 20-day lowest low. "
+            "Filter: only trade in the direction of the 50-day Donchian midpoint to avoid counter-trend trades. "
+            "Works best on liquid large-caps and index futures."
+        ),
+        when_to_use="Strong trending markets; after a long consolidation period near a resistance level.",
+        when_not_to_use="Already-extended trends; choppy markets where breakouts frequently fail.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Close > 20-day highest high AND price > 50-day channel midpoint",
+                "example": "e.g. TCS: 20-day high is ₹3,800, today closes at ₹3,820 → BUY breakout",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Close < 20-day lowest low AND price < 50-day channel midpoint",
+                "example": "e.g. TCS: 20-day low is ₹3,600, today closes at ₹3,580 → SELL breakdown",
+            },
+        ],
+        parameters={
+            "period": {
+                "default": 20,
+                "description": "Breakout lookback period (days)",
+                "type": "int",
+            },
+            "filter_period": {
+                "default": 50,
+                "description": "Trend filter channel period",
+                "type": "int",
+            },
+        },
+        timeframes=["1D", "1W"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "High false breakout rate in Indian markets — price often reverses after touching new highs",
+            "Requires wide stop loss (beyond the channel) — large capital at risk per trade",
+            "Not suitable for intraday — needs daily closing prices",
+        ],
+        tags=["momentum", "breakout", "donchian", "turtle", "trend_following", "intermediate"],
+        complexity="intermediate",
+        backtest_key="donchian",
+    ),
+    "parabolic_sar": TechnicalTemplate(
+        id="parabolic_sar",
+        name="Parabolic SAR",
+        category="momentum",
+        layman_explanation=(
+            "SAR stands for 'Stop and Reverse'. "
+            "A dot appears either above or below the price bar. "
+            "While the dot is below price, you're long. The moment price closes below the dot — "
+            "exit the long and go short. Simple flip-based system."
+        ),
+        explanation=(
+            "The SAR accelerates toward price as the trend extends (acceleration factor starts at 0.02, "
+            "increases by 0.02 each new extreme, max 0.20). When price touches the SAR, "
+            "the system flips direction and resets the AF. Generates continuous long/short signals."
+        ),
+        when_to_use="Strongly trending markets with low volatility noise; good for riding established trends.",
+        when_not_to_use="Sideways markets — constant flip-flop causes rapid small losses.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price closes above the SAR (SAR flips below price)",
+                "example": "e.g. BANKNIFTY: SAR was at ₹47,200 above price; price closes at ₹47,300 → SAR flips below → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price closes below the SAR (SAR flips above price)",
+                "example": "e.g. BANKNIFTY: SAR was at ₹46,800 below price; price drops to ₹46,750 → SAR flips above → SELL",
+            },
+        ],
+        parameters={
+            "step": {
+                "default": 0.02,
+                "description": "Acceleration factor step size",
+                "type": "float",
+            },
+            "max_step": {
+                "default": 0.20,
+                "description": "Maximum acceleration factor",
+                "type": "float",
+            },
+        },
+        timeframes=["15m", "1h", "1D"],
+        instruments=["indices", "stocks", "futures"],
+        risks=[
+            "Extremely choppy in range-bound markets — many small consecutive losses",
+            "Stop moves far from price in high-ATR environments",
+            "Fully mechanical — no discretion to skip poor setups",
+        ],
+        tags=["momentum", "trailing_stop", "sar", "trend_following", "beginner"],
+        complexity="beginner",
+        backtest_key="psar",
+    ),
+    "ichimoku": TechnicalTemplate(
+        id="ichimoku",
+        name="Ichimoku Cloud",
+        category="momentum",
+        layman_explanation=(
+            "Ichimoku draws a 'cloud' of support/resistance around price. "
+            "If price is above the cloud — it's in an uptrend. Below the cloud — downtrend. "
+            "When all five components agree (price, two lines, and the cloud), "
+            "it's one of the strongest trend signals in technical analysis."
+        ),
+        explanation=(
+            "Five components: Tenkan-sen (9-period midpoint), Kijun-sen (26-period midpoint), "
+            "Senkou Span A & B (future cloud), Chikou Span (close shifted back 26 periods). "
+            "Strongest entry: price above cloud, Tenkan > Kijun, Chikou above price, cloud bullish (A > B)."
+        ),
+        when_to_use="All three conditions aligned in trending markets; especially on daily/weekly charts.",
+        when_not_to_use="Range-bound or thin-volume stocks — cloud becomes messy and unreliable.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price above cloud + Tenkan > Kijun + Chikou above price 26 periods ago",
+                "example": "e.g. HDFC: price at ₹1,800, cloud between ₹1,720–₹1,750, Tenkan at ₹1,780 > Kijun ₹1,760 → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price below cloud + Tenkan < Kijun + Chikou below price",
+                "example": "e.g. HDFC: price at ₹1,650, cloud at ₹1,700–₹1,720 acting as resistance → SELL",
+            },
+        ],
+        parameters={
+            "tenkan": {"default": 9, "description": "Tenkan-sen period", "type": "int"},
+            "kijun": {"default": 26, "description": "Kijun-sen period", "type": "int"},
+            "senkou_b": {"default": 52, "description": "Senkou Span B period", "type": "int"},
+        },
+        timeframes=["1h", "1D", "1W"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "Complex — five components to interpret simultaneously",
+            "Lagging by design (Senkou spans are plotted ahead and behind)",
+            "Less effective on Indian intraday charts due to market microstructure",
+        ],
+        tags=["momentum", "trend", "ichimoku", "cloud", "advanced"],
+        complexity="advanced",
+        backtest_key=None,  # multi-component — future implementation
+    ),
+    # ── MEAN REVERSION (5) ────────────────────────────────────
+    "bollinger_reversion": TechnicalTemplate(
+        id="bollinger_reversion",
+        name="Bollinger Band Reversion",
+        category="mean_reversion",
+        layman_explanation=(
+            "Bollinger Bands draw a 'normal range' around price using standard deviation. "
+            "When price touches the bottom band, it has moved unusually far down — it tends to bounce back. "
+            "When it touches the top band, it has moved unusually far up — it tends to pull back."
+        ),
+        explanation=(
+            "20-period SMA ± 2 standard deviations. "
+            "Buy when price touches lower band in an uptrend (SMA sloping up); "
+            "sell at upper band in a downtrend. "
+            "Squeeze variant: when bands are very narrow (low volatility), "
+            "a breakout in either direction is imminent."
+        ),
+        when_to_use="Range-bound markets with mean-reverting behaviour; after volatility compression.",
+        when_not_to_use="Strong trending markets — price can 'walk the band' for extended periods.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Close touches or breaks below lower Bollinger Band",
+                "example": "e.g. RELIANCE: lower band at ₹2,800, price closes at ₹2,790 → oversold → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Close touches or breaks above upper Bollinger Band",
+                "example": "e.g. RELIANCE: upper band at ₹3,200, price closes at ₹3,210 → overbought → SELL",
+            },
+        ],
+        parameters={
+            "period": {"default": 20, "description": "SMA lookback period", "type": "int"},
+            "std_dev": {
+                "default": 2.0,
+                "description": "Standard deviation multiplier",
+                "type": "float",
+            },
+        },
+        timeframes=["15m", "1h", "1D"],
+        instruments=["stocks", "indices"],
+        risks=[
+            "In trending markets price walks along the band — losses mount",
+            "Standard deviation expands after a big move — bands widen just as you want to fade",
+            "No built-in exit rule — need to define a take-profit level",
+        ],
+        tags=["mean_reversion", "bollinger", "volatility", "bands", "beginner"],
+        complexity="beginner",
+        backtest_key="bb",
+    ),
+    "rsi_reversion": TechnicalTemplate(
+        id="rsi_reversion",
+        name="RSI Oversold / Overbought",
+        category="mean_reversion",
+        layman_explanation=(
+            "RSI scores how fast a stock has been rising or falling, from 0 to 100. "
+            "Below 30 means it's fallen too far too fast — likely to bounce (buy). "
+            "Above 70 means it's risen too far too fast — likely to pull back (sell)."
+        ),
+        explanation=(
+            "RSI(14) below 30 = oversold → buy; above 70 = overbought → sell. "
+            "Best used when ADX < 20 (ranging market) to avoid buying falling knives in downtrends. "
+            "RSI(2) ultra-short variant for intraday scalping extremes (< 10 = buy, > 90 = sell)."
+        ),
+        when_to_use="Range-bound markets; high-quality stocks in a sideways phase.",
+        when_not_to_use="Strong trends — RSI can stay oversold/overbought for weeks in a trending move.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "RSI(14) crosses below 30 (oversold)",
+                "example": "e.g. WIPRO: RSI drops to 28 after a 10-day selloff → oversold → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "RSI(14) crosses above 70 (overbought)",
+                "example": "e.g. WIPRO: RSI rises to 74 after a strong rally → overbought → SELL",
+            },
+        ],
+        parameters={
+            "period": {"default": 14, "description": "RSI lookback period", "type": "int"},
+            "buy_level": {
+                "default": 30,
+                "description": "Oversold threshold (buy signal)",
+                "type": "int",
+            },
+            "sell_level": {
+                "default": 70,
+                "description": "Overbought threshold (sell signal)",
+                "type": "int",
+            },
+        },
+        timeframes=["15m", "1h", "1D"],
+        instruments=["stocks", "indices"],
+        risks=[
+            "In a downtrend, RSI can stay below 30 for weeks — buying too early",
+            "Works best with an ADX filter to confirm a ranging environment",
+            "RSI divergence (leading) is not captured in this simple version",
+        ],
+        tags=["mean_reversion", "rsi", "oscillator", "beginner"],
+        complexity="beginner",
+        backtest_key="rsi",
+    ),
+    "vwap_reversion": TechnicalTemplate(
+        id="vwap_reversion",
+        name="VWAP Reversion (Intraday)",
+        category="mean_reversion",
+        layman_explanation=(
+            "VWAP is the average price of every trade done so far today, weighted by volume — "
+            "it's where most money has exchanged hands. "
+            "If price moves more than 2 standard deviations above VWAP, it's too far away and will likely snap back."
+        ),
+        explanation=(
+            "Fade price when it is > 2 standard deviations above/below the VWAP band. "
+            "Best window: 10:30 AM–2:00 PM IST (avoid first and last 30 min). "
+            "Exit target: price returns to VWAP. Stop: beyond the extreme band."
+        ),
+        when_to_use="High-volume intraday sessions on NIFTY, BANKNIFTY futures; avoid low-volume stocks.",
+        when_not_to_use="Strong trend days — price can stay extended from VWAP for hours.",
+        signal_rules=[
+            {
+                "signal": "SELL",
+                "condition": "Price > VWAP + 2 standard deviations",
+                "example": "e.g. NIFTY futures at ₹24,400, VWAP at ₹24,000, +2σ band at ₹24,350 → fade the move → SELL",
+            },
+            {
+                "signal": "BUY",
+                "condition": "Price < VWAP - 2 standard deviations",
+                "example": "e.g. NIFTY futures at ₹23,600, VWAP at ₹24,000, -2σ band at ₹23,650 → buy the dip → BUY",
+            },
+        ],
+        parameters={
+            "std_bands": {
+                "default": 2.0,
+                "description": "Standard deviation band multiplier",
+                "type": "float",
+            },
+            "start_time": {
+                "default": "10:30",
+                "description": "Earliest entry time (IST)",
+                "type": "str",
+            },
+            "end_time": {
+                "default": "14:00",
+                "description": "Latest entry time (IST)",
+                "type": "str",
+            },
+        },
+        timeframes=["1m", "3m", "5m"],
+        instruments=["indices", "futures"],
+        risks=[
+            "Intraday data required — does not work on daily bars",
+            "Trend days cause extended VWAP deviations with no reversion",
+            "News-driven moves ignore VWAP entirely",
+        ],
+        tags=["mean_reversion", "vwap", "intraday", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,  # requires intraday tick data
+    ),
+    "zscore_reversion": TechnicalTemplate(
+        id="zscore_reversion",
+        name="Z-Score Mean Reversion",
+        category="mean_reversion",
+        layman_explanation=(
+            "Z-score measures how many standard deviations a stock's price is from its recent average. "
+            "If the Z-score is +2, the price is unusually high — it will likely fall back. "
+            "If it's -2, the price is unusually low — it will likely rise back."
+        ),
+        explanation=(
+            "Rolling z-score = (close - N-day mean) / N-day std. "
+            "Enter long when z < -2, short when z > +2. Exit when z reverts to 0. "
+            "Default lookback: 20 days. Best for stable, low-beta stocks with mean-reverting behaviour."
+        ),
+        when_to_use="Stable, liquid, large-cap stocks in sideways markets; pairs trading spread.",
+        when_not_to_use="High-beta, news-driven stocks or during trending markets.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Rolling z-score drops below -2.0",
+                "example": "e.g. HDFC Bank: 20-day mean ₹1,600, std ₹40. Price at ₹1,520 → z = -2.0 → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Rolling z-score rises above +2.0",
+                "example": "e.g. HDFC Bank: price at ₹1,680 → z = +2.0 → SELL",
+            },
+            {
+                "signal": "EXIT",
+                "condition": "Z-score returns to 0 (price back at rolling mean)",
+                "example": "Price returns to ₹1,600 → z = 0 → take profit",
+            },
+        ],
+        parameters={
+            "lookback": {
+                "default": 20,
+                "description": "Rolling mean/std lookback period",
+                "type": "int",
+            },
+            "entry_z": {
+                "default": 2.0,
+                "description": "Z-score threshold to enter",
+                "type": "float",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["stocks"],
+        risks=[
+            "Mean may shift permanently — stock may not revert after a fundamental change",
+            "Z-score of -2 in a downtrend is just 'cheaper expensive stock'",
+            "Requires the underlying to be genuinely stationary (mean-reverting)",
+        ],
+        tags=["mean_reversion", "zscore", "statistical", "intermediate"],
+        complexity="intermediate",
+        backtest_key="zscore",
+    ),
+    "keltner_reversion": TechnicalTemplate(
+        id="keltner_reversion",
+        name="Keltner Channel Reversion",
+        category="mean_reversion",
+        layman_explanation=(
+            "Keltner Channels are like Bollinger Bands but smoother — they use ATR instead of standard deviation. "
+            "When price stretches too far above the channel, it tends to snap back. "
+            "The smoother channel means fewer false signals than Bollinger Bands."
+        ),
+        explanation=(
+            "Middle = 20 EMA. Upper = 20 EMA + 2×ATR(10). Lower = 20 EMA - 2×ATR(10). "
+            "Fade price at the extremes: buy lower band touch, sell upper band touch. "
+            "Keltner channels are tighter than Bollinger during low-volatility periods — "
+            "when price breaks out of both (BB outside Keltner = 'squeeze'), expect a big move."
+        ),
+        when_to_use="Range-bound markets as a cleaner alternative to Bollinger Bands.",
+        when_not_to_use="Trending markets where price consistently stays above or below the channel.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price closes below the lower Keltner Band",
+                "example": "e.g. ASIANPAINT: lower band ₹2,600, price closes ₹2,580 → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price closes above the upper Keltner Band",
+                "example": "e.g. ASIANPAINT: upper band ₹3,000, price closes ₹3,020 → SELL",
+            },
+        ],
+        parameters={
+            "ema_period": {
+                "default": 20,
+                "description": "EMA period for channel midline",
+                "type": "int",
+            },
+            "atr_multiplier": {
+                "default": 2.0,
+                "description": "ATR multiplier for band width",
+                "type": "float",
+            },
+        },
+        timeframes=["1h", "1D"],
+        instruments=["stocks", "indices"],
+        risks=[
+            "Trending stocks can walk the upper/lower band indefinitely",
+            "ATR expands during volatility — bands widen right when you want to fade",
+        ],
+        tags=["mean_reversion", "keltner", "atr", "bands", "intermediate"],
+        complexity="intermediate",
+        backtest_key="keltner",
+    ),
+    # ── SCALPING (4) ──────────────────────────────────────────
+    "orb": TechnicalTemplate(
+        id="orb",
+        name="Opening Range Breakout (ORB)",
+        category="scalping",
+        layman_explanation=(
+            "In the first 15–30 minutes after market open, price forms a range (a high and a low). "
+            "This range captures the initial tug-of-war between buyers and sellers. "
+            "Once price breaks above that range — bulls won. Break below — bears won. Trade the winner."
+        ),
+        explanation=(
+            "Define the opening range as the high/low of the first 15 or 30 minutes (9:15–9:30 AM IST). "
+            "Entry on breakout of range with a close above/below. "
+            "Exit at 1:1 or 2:1 R:R or at 3:00 PM. "
+            "Skip on gap-open days (> 0.5% gap) as the range is distorted."
+        ),
+        when_to_use="Trending intraday sessions; NIFTY/BANKNIFTY futures and F&O liquid stocks.",
+        when_not_to_use="Gap-open days, event days (RBI, results) where the range is meaningless.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price closes above the opening range high with volume confirmation",
+                "example": "e.g. NIFTY: 9:15–9:30 range is ₹24,000–₹24,120. Price closes at ₹24,135 at 9:35 AM → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price closes below the opening range low",
+                "example": "e.g. NIFTY: price closes at ₹23,990 at 9:35 AM → SELL",
+            },
+        ],
+        parameters={
+            "range_minutes": {
+                "default": 15,
+                "description": "Opening range duration in minutes",
+                "type": "int",
+            },
+            "rr_target": {
+                "default": 2.0,
+                "description": "Reward:risk ratio for exit",
+                "type": "float",
+            },
+            "gap_filter_pct": {
+                "default": 0.5,
+                "description": "Skip if gap open > this %",
+                "type": "float",
+            },
+        },
+        timeframes=["1m", "3m", "5m"],
+        instruments=["indices", "futures"],
+        risks=[
+            "False breakouts common — price breaks range then reverses immediately",
+            "Requires intraday data and discipline to take every signal",
+            "Afternoon sessions often lose the ORB momentum",
+        ],
+        tags=["scalping", "intraday", "breakout", "orb", "beginner"],
+        complexity="beginner",
+        backtest_key=None,  # requires intraday OHLCV
+    ),
+    "rsi_scalping": TechnicalTemplate(
+        id="rsi_scalping",
+        name="RSI Scalping (Ultra-short)",
+        category="scalping",
+        layman_explanation=(
+            "Use a very fast RSI (period 2 or 5) on a 1-minute chart. "
+            "When RSI drops below 10 — the stock has fallen too fast in seconds — snap back is very likely. "
+            "Take a quick long, exit when RSI crosses back to 50. A very short-hold trade."
+        ),
+        explanation=(
+            "RSI(2) or RSI(5) on 1m/3m chart. "
+            "Buy when RSI < 10 (extreme oversold), sell short when RSI > 90. "
+            "Exit when RSI crosses 50 or at a fixed point target (5–8 points on NIFTY). "
+            "Works best on index futures during high-volume sessions."
+        ),
+        when_to_use="High-volume intraday sessions on liquid index futures; 10:00 AM–2:30 PM IST.",
+        when_not_to_use="Low-volume midday sessions; trending days where RSI stays extreme.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "RSI(2) < 10 on a 1-minute or 3-minute chart",
+                "example": "e.g. NIFTY futures: 3-min RSI drops to 7 → extreme short-term oversold → quick BUY scalp",
+            },
+            {
+                "signal": "SELL",
+                "condition": "RSI(2) > 90 on a 1-minute or 3-minute chart",
+                "example": "e.g. NIFTY futures: 3-min RSI spikes to 94 → short scalp → SELL",
+            },
+        ],
+        parameters={
+            "rsi_period": {"default": 2, "description": "Ultra-short RSI period", "type": "int"},
+            "buy_level": {"default": 10, "description": "Oversold entry level", "type": "int"},
+            "sell_level": {"default": 90, "description": "Overbought entry level", "type": "int"},
+        },
+        timeframes=["1m", "3m"],
+        instruments=["indices", "futures"],
+        risks=[
+            "Extremely high trade frequency — commissions and slippage add up quickly",
+            "Requires laser focus — positions held for seconds to minutes",
+            "Needs Level 2 / depth-of-market data for best execution",
+        ],
+        tags=["scalping", "rsi", "intraday", "ultra_short", "advanced"],
+        complexity="advanced",
+        backtest_key=None,  # requires tick/1m data
+    ),
+    "vwap_scalp": TechnicalTemplate(
+        id="vwap_scalp",
+        name="VWAP Scalp",
+        category="scalping",
+        layman_explanation=(
+            "VWAP is where most of today's trading has happened. "
+            "When price dips to VWAP after being above it all morning, big institutions often step in to buy — "
+            "that support creates a reliable bounce for a scalp trade."
+        ),
+        explanation=(
+            "Long on first touch of VWAP after a sustained move above it (VWAP reclaim). "
+            "Short on rejection from VWAP after a sustained move below. "
+            "Tight stop: 5–8 points on NIFTY, just beyond VWAP. Target: prior swing high/low."
+        ),
+        when_to_use="Trending intraday days where VWAP is acting as a dynamic support/resistance.",
+        when_not_to_use="Choppy days with price crossing VWAP every 15 minutes.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price bounces off VWAP after being above it; bullish candle at VWAP",
+                "example": "e.g. BANKNIFTY: trading above VWAP all morning, pulls back to VWAP at ₹47,200, forms doji → BUY scalp",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price rejects VWAP from below; bearish candle at VWAP",
+                "example": "e.g. BANKNIFTY: below VWAP all session, rallies to VWAP at ₹47,500, reversal candle → SELL",
+            },
+        ],
+        parameters={
+            "stop_points": {
+                "default": 8,
+                "description": "Stop loss in index points",
+                "type": "int",
+            },
+            "require_confirmation": {
+                "default": True,
+                "description": "Wait for reversal candle at VWAP",
+                "type": "bool",
+            },
+        },
+        timeframes=["1m", "3m", "5m"],
+        instruments=["indices", "futures"],
+        risks=[
+            "Intraday VWAP only available with tick/intraday data feed",
+            "Multiple VWAP tests in one session reduce reliability",
+            "News events can blow through VWAP with no bounce",
+        ],
+        tags=["scalping", "vwap", "intraday", "support_resistance", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+    "prev_day_hl": TechnicalTemplate(
+        id="prev_day_hl",
+        name="Previous Day High / Low Breakout",
+        category="scalping",
+        layman_explanation=(
+            "Yesterday's high and low are key levels — many traders have stops and orders sitting there. "
+            "When price breaks through yesterday's high on volume, those stops trigger and price accelerates. "
+            "This creates a reliable momentum trade in the direction of the break."
+        ),
+        explanation=(
+            "PDH/PDL are strong intraday reference levels. "
+            "Buy on a 5-minute candle close above PDH with volume > 1.5× average. "
+            "Short on close below PDL. "
+            "Target: PDH + (PDH - PDL) i.e. range extension. Stop: below PDH."
+        ),
+        when_to_use="First 90 minutes of trading (9:15–10:45 AM IST); trending market days.",
+        when_not_to_use="Days that gap above PDH at open — PDH is no longer meaningful.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "5-min candle closes above previous day high with volume surge",
+                "example": "e.g. RELIANCE: PDH ₹2,900. Price breaks ₹2,905 at 9:40 AM with 2× volume → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "5-min candle closes below previous day low",
+                "example": "e.g. RELIANCE: PDL ₹2,820. Price breaks ₹2,815 at 9:50 AM → SELL",
+            },
+        ],
+        parameters={
+            "confirmation_candles": {
+                "default": 1,
+                "description": "Candles needed to confirm break",
+                "type": "int",
+            },
+            "volume_multiplier": {
+                "default": 1.5,
+                "description": "Volume vs average to confirm",
+                "type": "float",
+            },
+        },
+        timeframes=["5m", "15m"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "False breakouts happen often — price pokes above PDH then reverses",
+            "Requires previous day OHLC data and intraday bars",
+            "Stop is tight — noise can stop you out before the move develops",
+        ],
+        tags=["scalping", "breakout", "intraday", "pdh", "pdl", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+    # ── BREAKOUT (3) ──────────────────────────────────────────
+    "pivot_breakout": TechnicalTemplate(
+        id="pivot_breakout",
+        name="Pivot Point Breakout",
+        category="breakout",
+        layman_explanation=(
+            "Pivot points are price levels calculated from yesterday's data that many traders watch simultaneously. "
+            "R1/R2 are resistance levels above; S1/S2 are support levels below. "
+            "When price breaks through R1 with momentum, it often runs to R2 — and vice versa."
+        ),
+        explanation=(
+            "Standard pivots: P = (H + L + C) / 3; R1 = 2P - L; R2 = P + (H - L); "
+            "S1 = 2P - H; S2 = P - (H - L). "
+            "Trade breakouts of R1/R2 (long) or S1/S2 (short) with a close beyond the level on a 5-minute bar."
+        ),
+        when_to_use="Intraday trending days; most effective in the first 2 hours of trading.",
+        when_not_to_use="Days with large overnight gaps that skew the pivot calculations.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Price closes above R1 on a 5-minute bar",
+                "example": "e.g. NIFTY: R1 at ₹24,200. 5-min candle closes at ₹24,215 → BUY, target R2 at ₹24,400",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Price closes below S1 on a 5-minute bar",
+                "example": "e.g. NIFTY: S1 at ₹23,800. Closes at ₹23,785 → SELL, target S2 at ₹23,600",
+            },
+        ],
+        parameters={
+            "pivot_type": {
+                "default": "standard",
+                "description": "Pivot type: standard/camarilla/fibonacci/woodie",
+                "type": "str",
+            },
+            "level": {
+                "default": "R1",
+                "description": "Which level to trade: R1, R2, S1, S2",
+                "type": "str",
+            },
+        },
+        timeframes=["5m", "15m"],
+        instruments=["indices", "futures"],
+        risks=[
+            "Calculated from previous day's OHLC — gaps or limit moves distort them",
+            "R1 is often hit and reversed before reaching R2",
+            "Multiple overlapping pivot levels create conflicting signals",
+        ],
+        tags=["breakout", "pivot", "intraday", "support_resistance", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+    "inside_bar": TechnicalTemplate(
+        id="inside_bar",
+        name="Inside Bar Breakout",
+        category="breakout",
+        layman_explanation=(
+            "An inside bar is a candle that fits completely within the previous candle's range — "
+            "the market couldn't make a new high or low. It's a pause, a breath. "
+            "The next candle that breaks outside that range tells you which way the market wants to go."
+        ),
+        explanation=(
+            "Inside bar: current high < previous high AND current low > previous low. "
+            "Signal fires on the next candle: close above prior high = bullish break; "
+            "close below prior low = bearish break. "
+            "Best on daily and weekly charts for swing trades. "
+            "ATR-based stop: beyond the prior candle's extreme."
+        ),
+        when_to_use="After a strong directional move; consolidation at key support/resistance on daily chart.",
+        when_not_to_use="Choppy markets where inside bars occur every other day with no follow-through.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Candle after the inside bar closes above the prior candle's high",
+                "example": "e.g. TCS: inside bar on Tuesday (H: ₹3,850, L: ₹3,790). Wednesday closes ₹3,870 → BUY",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Candle after the inside bar closes below the prior candle's low",
+                "example": "e.g. TCS: Wednesday closes ₹3,770 → SELL",
+            },
+        ],
+        parameters={
+            "atr_stop_multiplier": {
+                "default": 1.0,
+                "description": "ATR multiplier for stop beyond the pattern",
+                "type": "float",
+            },
+        },
+        timeframes=["1D", "1W"],
+        instruments=["stocks", "indices"],
+        risks=[
+            "False breakouts common — especially if inside bar is very small",
+            "Requires patience — inside bars on daily charts may only occur a few times per month",
+        ],
+        tags=["breakout", "price_action", "inside_bar", "swing", "beginner"],
+        complexity="beginner",
+        backtest_key="inside_bar",
+    ),
+    "flag_pennant": TechnicalTemplate(
+        id="flag_pennant",
+        name="Flag / Pennant Continuation",
+        category="breakout",
+        layman_explanation=(
+            "After a strong vertical move (the flagpole), the stock takes a rest and moves sideways in a tight range "
+            "(the flag). When it breaks out of that rest in the same direction as the initial move, "
+            "it tends to travel the same distance as the original flagpole."
+        ),
+        explanation=(
+            "Flag: a tight rectangular consolidation after a sharp move, sloping slightly against the trend. "
+            "Pennant: converging trendlines (triangle) after an impulse move. "
+            "Entry on breakout of the flag/pennant boundary with volume expansion. "
+            "Target: entry + flagpole length. Stop: below the flag low."
+        ),
+        when_to_use="Strong trending stocks after a clear impulse move and consolidation.",
+        when_not_to_use="When the 'flagpole' is less than 5% — pattern is too weak to trade.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Break above the flag's upper boundary after a bullish impulse move",
+                "example": "e.g. INFY: sharp 8% move up, 5-day sideways flag. Break of flag top → BUY, target = +8% from breakout",
+            },
+            {
+                "signal": "SELL",
+                "condition": "Break below flag bottom after a bearish impulse move",
+                "example": "e.g. INFY: sharp -7% move, flag forms. Break below flag base → SELL",
+            },
+        ],
+        parameters={
+            "min_impulse_pct": {
+                "default": 5.0,
+                "description": "Minimum flagpole move % to qualify",
+                "type": "float",
+            },
+            "max_consolidation_days": {
+                "default": 15,
+                "description": "Max days of flag/pennant",
+                "type": "int",
+            },
+        },
+        timeframes=["1h", "1D"],
+        instruments=["stocks", "indices"],
+        risks=[
+            "Pattern recognition is subjective — two traders may see different flags",
+            "Breakouts after weak impulse moves often fail",
+            "Cannot be easily automated without pattern detection algorithms",
+        ],
+        tags=["breakout", "price_action", "flag", "pennant", "continuation", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,  # requires pattern recognition
+    ),
+    # ── PAIRS (4) ─────────────────────────────────────────────
+    "pairs_trading": TechnicalTemplate(
+        id="pairs_trading",
+        name="Pairs Trading",
+        category="pairs",
+        layman_explanation=(
+            "Find two stocks that usually move together (e.g. TCS and Infosys). "
+            "When TCS suddenly becomes much more expensive than Infosys relative to their history, "
+            "you buy the cheaper one and sell the expensive one — betting they'll come back together."
+        ),
+        explanation=(
+            "Cointegration test to find a stationary pair. "
+            "Spread = log(Stock A) - hedge_ratio × log(Stock B). "
+            "Trade when z-score of spread > 2 (short the spread) or < -2 (long the spread). "
+            "Exit when z-score returns to 0. Stop at z = 3."
+        ),
+        when_to_use="Sector pairs with stable long-term relationships; market-neutral view.",
+        when_not_to_use="When the pair's fundamental relationship has broken (e.g. one company has a large acquisition).",
+        signal_rules=[
+            {
+                "signal": "BUY SPREAD",
+                "condition": "Z-score of spread < -2.0 (Stock A unusually cheap vs B)",
+                "example": "e.g. TCS/INFY spread z-score = -2.3 → buy TCS, sell INFY (equal INR value)",
+            },
+            {
+                "signal": "SELL SPREAD",
+                "condition": "Z-score of spread > +2.0 (Stock A unusually expensive vs B)",
+                "example": "e.g. TCS/INFY spread z-score = +2.1 → sell TCS, buy INFY",
+            },
+        ],
+        parameters={
+            "lookback": {
+                "default": 60,
+                "description": "Rolling window for z-score (days)",
+                "type": "int",
+            },
+            "entry_z": {
+                "default": 2.0,
+                "description": "Z-score to enter position",
+                "type": "float",
+            },
+            "stop_z": {"default": 3.0, "description": "Z-score to stop out", "type": "float"},
+        },
+        timeframes=["1D"],
+        instruments=["stocks"],
+        risks=[
+            "Cointegration can break permanently — mean may never revert",
+            "Requires simultaneous execution of two orders — slippage on both legs",
+            "Market impact if position size is large relative to stock volume",
+        ],
+        tags=["pairs", "statistical_arbitrage", "market_neutral", "cointegration", "advanced"],
+        complexity="advanced",
+        backtest_key=None,  # uses MultiBacktester; future integration
+    ),
+    "index_arb": TechnicalTemplate(
+        id="index_arb",
+        name="Index Arbitrage",
+        category="pairs",
+        layman_explanation=(
+            "NIFTY futures should trade at a 'fair price' slightly above the NIFTY index (because you earn interest "
+            "by not buying all 50 stocks). When futures trade above or below this fair value, "
+            "you buy the cheap side and sell the expensive side — pocketing the gap when it closes."
+        ),
+        explanation=(
+            "Fair value = Spot × e^(r×t) where r = risk-free rate, t = DTE/365. "
+            "If futures premium > fair value → sell futures + buy basket. "
+            "If futures at discount → buy futures + sell basket. "
+            "Requires simultaneous execution of futures and all 50 NIFTY constituents."
+        ),
+        when_to_use="When futures premium/discount significantly exceeds fair value; requires high capital.",
+        when_not_to_use="Near expiry when convergence is guaranteed — window too short for entry/exit cost.",
+        signal_rules=[
+            {
+                "signal": "BUY FUTURES / SELL BASKET",
+                "condition": "Futures at discount to fair value",
+                "example": "e.g. NIFTY spot ₹24,000, fair value ₹24,080, futures at ₹24,050 → buy futures",
+            },
+            {
+                "signal": "SELL FUTURES / BUY BASKET",
+                "condition": "Futures at premium to fair value",
+                "example": "e.g. NIFTY futures at ₹24,150 vs fair value ₹24,080 → sell futures",
+            },
+        ],
+        parameters={
+            "risk_free_rate": {"default": 0.065, "description": "RBI repo rate", "type": "float"},
+        },
+        timeframes=["1m"],
+        instruments=["indices", "futures"],
+        risks=[
+            "Extremely capital intensive — need to buy/sell all 50 NIFTY components",
+            "Execution risk — spread can widen before both legs are filled",
+            "Institutional strategy — retail participation not practical",
+        ],
+        tags=["pairs", "arbitrage", "index", "advanced"],
+        complexity="advanced",
+        backtest_key=None,
+    ),
+    "etf_arb": TechnicalTemplate(
+        id="etf_arb",
+        name="ETF Arbitrage",
+        category="pairs",
+        layman_explanation=(
+            "ETFs like NIFTYBEES should trade at exactly the value of the stocks inside them. "
+            "Sometimes they trade at a small premium or discount. When that gap is large enough "
+            "to cover transaction costs, you buy the cheap side and sell the expensive side."
+        ),
+        explanation=(
+            "Monitor iNAV (intraday NAV) vs market price of ETF. "
+            "If ETF market price > iNAV by > 0.1% → sell ETF, buy underlying (creation). "
+            "If ETF price < iNAV by > 0.1% → buy ETF, redeem for underlying. "
+            "Authorised participants do this continuously — retail window is very small."
+        ),
+        when_to_use="When ETF premium/discount exceeds round-trip transaction costs.",
+        when_not_to_use="For retail investors — gap is usually too small after costs; institutional play.",
+        signal_rules=[
+            {
+                "signal": "BUY ETF",
+                "condition": "ETF market price < iNAV - transaction cost threshold",
+                "example": "e.g. NIFTYBEES iNAV ₹230.50, market price ₹229.80 → discount of 0.30% → BUY",
+            },
+            {
+                "signal": "SELL ETF",
+                "condition": "ETF market price > iNAV + transaction cost threshold",
+                "example": "e.g. NIFTYBEES iNAV ₹230.50, market price ₹231.50 → premium → SELL",
+            },
+        ],
+        parameters={
+            "min_gap_pct": {
+                "default": 0.1,
+                "description": "Minimum premium/discount % to trade",
+                "type": "float",
+            },
+        },
+        timeframes=["1m", "5m"],
+        instruments=["etfs"],
+        risks=[
+            "iNAV data requires a real-time data feed",
+            "Creation/redemption is only available to authorised participants",
+            "Gap closes quickly — execution must be near-instant",
+        ],
+        tags=["pairs", "arbitrage", "etf", "advanced"],
+        complexity="advanced",
+        backtest_key=None,
+    ),
+    "calendar_spread_futures": TechnicalTemplate(
+        id="calendar_spread_futures",
+        name="Calendar Spread (Futures)",
+        category="pairs",
+        layman_explanation=(
+            "Near-month and far-month futures on the same stock should differ by the cost of 'waiting' "
+            "(interest you'd earn if you held cash instead). When the spread between them gets unusually wide "
+            "or narrow, you buy one month and sell the other — waiting for the spread to normalise."
+        ),
+        explanation=(
+            "Fair spread = Spot × r × (T2 - T1)/365. "
+            "If actual spread > fair spread → sell near, buy far (spread will narrow). "
+            "If spread < fair → buy near, sell far. "
+            "Instruments: NIFTY, BANKNIFTY, single stock futures."
+        ),
+        when_to_use="When the term structure of futures is significantly mis-priced relative to cost-of-carry.",
+        when_not_to_use="Near expiry of the near-month contract — liquidity drops sharply.",
+        signal_rules=[
+            {
+                "signal": "SELL SPREAD (sell near, buy far)",
+                "condition": "Near–far spread > cost-of-carry fair value",
+                "example": "e.g. NIFTY near ₹24,300, far ₹24,500, fair spread ₹120. Actual spread ₹200 → sell near, buy far",
+            },
+            {
+                "signal": "BUY SPREAD (buy near, sell far)",
+                "condition": "Near–far spread < cost-of-carry fair value",
+                "example": "e.g. Actual spread ₹40 vs fair ₹120 → buy near, sell far",
+            },
+        ],
+        parameters={
+            "risk_free_rate": {
+                "default": 0.065,
+                "description": "RBI repo rate (decimal)",
+                "type": "float",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["futures"],
+        risks=[
+            "Low liquidity on far-month contracts — wide bid-ask spreads",
+            "Requires simultaneous execution of two futures contracts",
+            "Rollover costs reduce profitability if held too long",
+        ],
+        tags=["pairs", "futures", "calendar", "cost_of_carry", "advanced"],
+        complexity="advanced",
+        backtest_key=None,
+    ),
+    # ── MACRO (5) ─────────────────────────────────────────────
+    "rbi_policy": TechnicalTemplate(
+        id="rbi_policy",
+        name="RBI Policy Trade",
+        category="macro",
+        layman_explanation=(
+            "When the RBI announces interest rates, markets usually make a big move — "
+            "but nobody knows exactly which way. One approach: buy both a call and a put (straddle) "
+            "before the announcement so you profit regardless of direction. "
+            "Another: wait for the announcement, then trade the momentum."
+        ),
+        explanation=(
+            "Pre-event: buy ATM straddle 2 days before → exit within 30 minutes of announcement. "
+            "Post-event: if rate cut → buy BANKNIFTY, sell NIFTY (bank-heavy). "
+            "If rate hold/surprise hike → buy interest-rate sensitive shorts. "
+            "RBI meets 6 times a year."
+        ),
+        when_to_use="Before scheduled RBI Monetary Policy Committee meetings.",
+        when_not_to_use="When market has already priced in the expected move — IV is already very high.",
+        signal_rules=[
+            {
+                "signal": "BUY STRADDLE (pre-event)",
+                "condition": "2 days before RBI announcement and IV is not elevated",
+                "example": "e.g. NIFTY at ₹24,000, buy 24000 CE + 24000 PE. If market moves 1%+ either way, straddle profits.",
+            },
+            {
+                "signal": "BUY (post-event, rate cut)",
+                "condition": "RBI cuts rates → financials and rate-sensitive stocks rally",
+                "example": "RBI cuts 25bps → buy BANKNIFTY futures → target 2% move in next 30 minutes",
+            },
+        ],
+        parameters={
+            "days_before": {
+                "default": 2,
+                "description": "Days before announcement to enter straddle",
+                "type": "int",
+            },
+            "exit_minutes": {
+                "default": 30,
+                "description": "Minutes after announcement to exit",
+                "type": "int",
+            },
+        },
+        timeframes=["1D", "5m"],
+        instruments=["indices", "futures", "options"],
+        risks=[
+            "IV crush after announcement can wipe out gains even if the market moves",
+            "Post-announcement direction trade can reverse within minutes",
+            "RBI surprises (hawkish hold, emergency cut) are unpredictable",
+        ],
+        tags=["macro", "event_driven", "rbi", "straddle", "advanced"],
+        complexity="advanced",
+        backtest_key=None,
+    ),
+    "fii_flow": TechnicalTemplate(
+        id="fii_flow",
+        name="FII Flow Following",
+        category="macro",
+        layman_explanation=(
+            "Foreign Institutional Investors move markets. When they buy heavily for 3 days in a row, "
+            "the market tends to keep rising. When they sell heavily for 3 days, it tends to keep falling. "
+            "Following their footprints is a simple but effective macro signal."
+        ),
+        explanation=(
+            "NSE publishes daily FII/DII buy-sell data. "
+            "Signal: FII net buy > ₹2,000 Cr for 3 consecutive days → long NIFTY. "
+            "FII net sell > ₹2,000 Cr for 3 days → reduce longs / go short. "
+            "Hold position until signal reverses or 10 trading days pass."
+        ),
+        when_to_use="As a medium-term (weekly) market direction filter; combine with technical entry.",
+        when_not_to_use="During global risk-off events where FII flows are driven by factors outside India.",
+        signal_rules=[
+            {
+                "signal": "BUY NIFTY",
+                "condition": "FII net buy > ₹2,000 Cr for 3 consecutive sessions",
+                "example": "e.g. FII buy: Day1 ₹2,500 Cr, Day2 ₹3,100 Cr, Day3 ₹2,200 Cr → BUY NIFTY",
+            },
+            {
+                "signal": "REDUCE / SHORT",
+                "condition": "FII net sell > ₹2,000 Cr for 3 consecutive sessions",
+                "example": "e.g. FII sell: 3 days of ₹2,000+ Cr outflows → reduce equity exposure",
+            },
+        ],
+        parameters={
+            "threshold_cr": {
+                "default": 2000,
+                "description": "FII net buy/sell threshold in ₹ Cr",
+                "type": "int",
+            },
+            "consecutive_days": {
+                "default": 3,
+                "description": "Days of consistent flow to trigger signal",
+                "type": "int",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["indices", "futures"],
+        risks=[
+            "Lagging indicator — FII data published end-of-day, after the move is underway",
+            "FII can reverse rapidly — 3-day trend can break on day 4",
+            "During global crises, FII flows are not actionable — exit speed matters",
+        ],
+        tags=["macro", "fii", "flow", "sentiment", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+    "vix_reversion": TechnicalTemplate(
+        id="vix_reversion",
+        name="VIX Mean Reversion",
+        category="macro",
+        layman_explanation=(
+            "India VIX measures how scared the market is. "
+            "When VIX spikes above 20, fear is high and options are expensive — sell premium (you'll be overpaid). "
+            "When VIX drops below 11, complacency is extreme and options are cheap — buy them for an upcoming shock."
+        ),
+        explanation=(
+            "India VIX > 20 → short straddle, iron condor — collect elevated premiums that will deflate as VIX normalises. "
+            "India VIX < 11 → buy straddles, long options — cheap insurance before next volatility spike. "
+            "VIX typically mean-reverts within 5–15 trading days of an extreme."
+        ),
+        when_to_use="After a volatility spike (VIX > 20) — sell premium. Before expected events when VIX < 11.",
+        when_not_to_use="During structural changes to the market — VIX can sustain elevated levels for months.",
+        signal_rules=[
+            {
+                "signal": "SELL PREMIUM",
+                "condition": "India VIX > 20 (fear elevated → options overpriced)",
+                "example": "e.g. India VIX at 23 post-election concern → sell NIFTY iron condor, collect inflated premium",
+            },
+            {
+                "signal": "BUY OPTIONS",
+                "condition": "India VIX < 11 (complacency → options cheap)",
+                "example": "e.g. VIX at 10.5 in a calm market → buy cheap NIFTY straddle before next catalyst",
+            },
+        ],
+        parameters={
+            "high_vix": {
+                "default": 20,
+                "description": "VIX level above which premium selling is favoured",
+                "type": "int",
+            },
+            "low_vix": {
+                "default": 11,
+                "description": "VIX level below which buying options is favoured",
+                "type": "int",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["indices", "options"],
+        risks=[
+            "VIX can spike further after you sell premium — unlimited loss on naked positions",
+            "Low VIX can persist for months without a spike materialising",
+            "India VIX data requires a separate data source (not standard OHLCV feed)",
+        ],
+        tags=["macro", "vix", "volatility", "regime", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+    "earnings_momentum": TechnicalTemplate(
+        id="earnings_momentum",
+        name="Earnings Momentum",
+        category="macro",
+        layman_explanation=(
+            "Stock options get more expensive before earnings because nobody knows what will happen. "
+            "If you buy options 5 days before results, you benefit from that rising fear. "
+            "Alternatively, buy the stock the day after a strong earnings beat — the momentum often continues."
+        ),
+        explanation=(
+            "Pre-earnings IV play: buy ATM straddle 5 days before → sell on announcement day (capture IV expansion). "
+            "Post-earnings momentum: buy breakout on next day if results beat estimates by > 10% and stock gaps up > 2%. "
+            "Hold for 3–5 days to capture the follow-through momentum."
+        ),
+        when_to_use="Around quarterly earnings season (April, July, October, January for most NSE companies).",
+        when_not_to_use="When IV is already inflated before earnings (market expects a big move — too expensive).",
+        signal_rules=[
+            {
+                "signal": "BUY STRADDLE (pre-earnings)",
+                "condition": "5 days before earnings date and IV is not already elevated",
+                "example": "e.g. WIPRO results in 5 days. Current IV normal. Buy 400CE + 400PE → sell morning of results.",
+            },
+            {
+                "signal": "BUY (post-earnings momentum)",
+                "condition": "Results beat estimates > 10% + stock gaps up > 2% on results day",
+                "example": "e.g. HDFC reports 15% profit beat. Stock gaps up 3%. Buy at open, hold 3 days.",
+            },
+        ],
+        parameters={
+            "pre_days": {
+                "default": 5,
+                "description": "Days before earnings to enter IV play",
+                "type": "int",
+            },
+            "beat_threshold_pct": {
+                "default": 10,
+                "description": "Earnings beat % to trigger momentum buy",
+                "type": "float",
+            },
+            "gap_threshold_pct": {
+                "default": 2.0,
+                "description": "Gap up % required on results day",
+                "type": "float",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["stocks", "options"],
+        risks=[
+            "IV crush on announcement day can wipe out straddle gains even on a big move",
+            "Earnings calendar requires an external data source",
+            "Post-earnings momentum can reverse sharply if sector/market conditions worsen",
+        ],
+        tags=["macro", "earnings", "event_driven", "momentum", "advanced"],
+        complexity="advanced",
+        backtest_key=None,
+    ),
+    "sector_rotation": TechnicalTemplate(
+        id="sector_rotation",
+        name="Sector Rotation",
+        category="macro",
+        layman_explanation=(
+            "Different industries take turns leading the market. "
+            "Each month, look at which two sectors have performed best in the last month — "
+            "put your money there. Next month, rotate to whichever two are leading then."
+        ),
+        explanation=(
+            "Rank all NIFTY sector indices by trailing 1-month return. "
+            "Allocate equally to the top 2 sectors via sector ETFs (BANKBEES, ITBEES, PHARMABEES, etc.). "
+            "Rebalance on the last Thursday of each month to align with F&O expiry. "
+            "Filter: only hold a sector if its 1-month return is positive (absolute momentum filter)."
+        ),
+        when_to_use="Monthly rebalancing strategy; best in trending, rotation-heavy market regimes.",
+        when_not_to_use="During sharp market-wide corrections — all sectors fall together.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Sector ranks in top 2 by 1-month return AND return is positive",
+                "example": "e.g. April: PSU Banks up 8%, Pharma up 6%, IT up 1%. Allocate to PSU Banks + Pharma ETFs.",
+            },
+            {
+                "signal": "EXIT / ROTATE",
+                "condition": "Sector drops out of top 2 on monthly rebalance day",
+                "example": "e.g. May rebalance: IT surges to top 2, Pharma drops → sell Pharma ETF, buy IT ETF",
+            },
+        ],
+        parameters={
+            "top_n": {"default": 2, "description": "Number of top sectors to hold", "type": "int"},
+            "lookback_days": {
+                "default": 21,
+                "description": "Return lookback in trading days",
+                "type": "int",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["etfs"],
+        risks=[
+            "Momentum crash risk — top sectors of last month can be worst next month",
+            "ETF liquidity (ITBEES, PHARMABEES) is lower than direct stocks",
+            "Sector ETF data not always available via standard data feeds",
+        ],
+        tags=["macro", "rotation", "etf", "momentum", "monthly", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+    # ── QUANTITATIVE (3) ──────────────────────────────────────
+    "dual_momentum": TechnicalTemplate(
+        id="dual_momentum",
+        name="Dual Momentum (Antonacci)",
+        category="quantitative",
+        layman_explanation=(
+            "Every month, answer two questions: (1) Has the stock/index gone up in the last 3 months? "
+            "(absolute momentum — if no, move to cash). (2) Is it doing better than the alternative? "
+            "(relative momentum — if yes, stay). Simple, low-frequency, rules-based."
+        ),
+        explanation=(
+            "Absolute momentum: if N-day return of NIFTY > 0 → stay in equities. "
+            "Relative momentum (multi-asset): hold the stronger of two assets (e.g. NIFTY vs Gold) "
+            "based on trailing 3-month return. Rebalance monthly. "
+            "Simplest implementation: single asset, stay long if 90-day return > 0, else cash (0)."
+        ),
+        when_to_use="Long-term (months to years) systematic investing; eliminates most bear market drawdowns.",
+        when_not_to_use="Short-term trading — monthly rebalance is too slow for tactical adjustments.",
+        signal_rules=[
+            {
+                "signal": "BUY (stay long)",
+                "condition": "90-day return > 0 on monthly rebalance day",
+                "example": "e.g. NIFTY was at ₹22,000 three months ago, now ₹24,000. Return +9% → stay long",
+            },
+            {
+                "signal": "EXIT (go to cash)",
+                "condition": "90-day return ≤ 0 on monthly rebalance day",
+                "example": "e.g. NIFTY three months ago ₹25,000, now ₹23,500. Return -6% → exit to cash",
+            },
+        ],
+        parameters={
+            "lookback": {
+                "default": 90,
+                "description": "Return lookback in trading days (~3 months)",
+                "type": "int",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["indices", "etfs"],
+        risks=[
+            "Monthly rebalance misses intra-month crashes — drawdown before signal fires",
+            "Whipsaw risk in choppy markets — alternates long/cash frequently",
+            "Simple version ignores relative momentum — combine with sector rotation for full system",
+        ],
+        tags=["quantitative", "momentum", "systematic", "monthly", "long_term", "beginner"],
+        complexity="beginner",
+        backtest_key="dual_momentum",
+    ),
+    "factor_quality_momentum": TechnicalTemplate(
+        id="factor_quality_momentum",
+        name="Factor Strategy — Quality + Momentum",
+        category="quantitative",
+        layman_explanation=(
+            "Screen all NSE 500 stocks for two things: (1) quality — high profit, low debt. "
+            "(2) momentum — stock price has been rising over the last 6 months. "
+            "Hold the top 20 that pass both tests. Rebalance monthly."
+        ),
+        explanation=(
+            "Quality screen: ROE > 15%, Debt/Equity < 1, positive EPS growth. "
+            "Momentum screen: top quartile 6-month price return among quality stocks. "
+            "Portfolio: equal-weight top 20 stocks passing both filters. "
+            "Rebalance monthly on last Thursday. "
+            "Historical outperformance: Quality + Momentum factor portfolios have beaten NIFTY by 4-8% annually on NSE."
+        ),
+        when_to_use="Core long-term equity portfolio; works best over 3+ year horizons.",
+        when_not_to_use="During factor rotation periods where value outperforms momentum strongly.",
+        signal_rules=[
+            {
+                "signal": "BUY",
+                "condition": "Stock passes quality screen AND ranks top quartile in 6-month momentum",
+                "example": "e.g. DIXON Tech: ROE 28%, D/E 0.3, 6-month return +35% → qualifies → BUY",
+            },
+            {
+                "signal": "EXIT",
+                "condition": "Stock drops below quality or momentum thresholds on monthly rebalance",
+                "example": "e.g. Stock's 6-month return drops below top quartile → rotate out",
+            },
+        ],
+        parameters={
+            "min_roe": {"default": 15, "description": "Minimum Return on Equity %", "type": "int"},
+            "max_debt_equity": {
+                "default": 1.0,
+                "description": "Maximum Debt/Equity ratio",
+                "type": "float",
+            },
+            "momentum_months": {
+                "default": 6,
+                "description": "Momentum lookback in months",
+                "type": "int",
+            },
+            "portfolio_size": {
+                "default": 20,
+                "description": "Number of stocks to hold",
+                "type": "int",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["stocks"],
+        risks=[
+            "Requires fundamental data (ROE, debt) — not available in standard price feeds",
+            "Factor crowding — if many funds use same screen, stocks get bid up",
+            "Monthly rebalance incurs significant turnover and transaction costs",
+        ],
+        tags=["quantitative", "factor", "quality", "momentum", "fundamental", "advanced"],
+        complexity="advanced",
+        backtest_key=None,
+    ),
+    "volatility_sizing": TechnicalTemplate(
+        id="volatility_sizing",
+        name="Volatility-Adjusted Position Sizing",
+        category="quantitative",
+        layman_explanation=(
+            "Instead of always trading the same number of shares, "
+            "you trade fewer shares when a stock is moving violently, and more when it's calm. "
+            "This keeps the rupee risk of each trade roughly the same, regardless of which stock you're trading."
+        ),
+        explanation=(
+            "ATR-based sizing: quantity = (capital × risk_pct) / (ATR × stop_atr_multiplier). "
+            "Kelly criterion variant: size = edge / odds (requires win rate and avg win/loss estimates). "
+            "Portfolio volatility target: adjust all positions so total portfolio volatility = target% per day. "
+            "Not a standalone signal generator — a sizing layer applied on top of any entry signal."
+        ),
+        when_to_use="On every trade as a risk management overlay; especially useful in a diversified portfolio.",
+        when_not_to_use="As a standalone signal — this generates no entry/exit signals by itself.",
+        signal_rules=[
+            {
+                "signal": "SIZE UP",
+                "condition": "ATR is low relative to historical average → stock is calm → more shares",
+                "example": "e.g. HDFC: ATR ₹15 (below 20-day avg ₹25). Capital ₹2L, risk 1% → trade 133 shares (₹2L × 1% / ₹15)",
+            },
+            {
+                "signal": "SIZE DOWN",
+                "condition": "ATR is high → stock is volatile → fewer shares",
+                "example": "e.g. HDFC: ATR spikes to ₹50 (post-results). Same ₹2L capital → trade only 40 shares",
+            },
+        ],
+        parameters={
+            "risk_pct": {
+                "default": 1.0,
+                "description": "Risk per trade as % of capital",
+                "type": "float",
+            },
+            "atr_period": {"default": 14, "description": "ATR lookback period", "type": "int"},
+            "stop_atr": {
+                "default": 2.0,
+                "description": "Stop loss in ATR multiples",
+                "type": "float",
+            },
+        },
+        timeframes=["1D"],
+        instruments=["stocks", "indices", "futures"],
+        risks=[
+            "Low ATR (calm market) can lead to oversized positions right before a volatility spike",
+            "Requires accurate ATR calculation — different data feeds give slightly different values",
+            "Kelly criterion can recommend very large sizes — use fractional Kelly (0.25–0.5×) for safety",
+        ],
+        tags=["quantitative", "risk_management", "position_sizing", "atr", "kelly", "intermediate"],
+        complexity="intermediate",
+        backtest_key=None,
+    ),
+}
+
+
+# ── TechnicalLibrary class ────────────────────────────────────
+
+
+class TechnicalLibrary:
+    """Registry and search interface for the technical strategy template library."""
+
+    def __init__(self, templates: dict[str, TechnicalTemplate]) -> None:
+        self._templates = templates
+
+    def list_all(self) -> list[TechnicalTemplate]:
+        """Return all templates sorted by TECH_CATEGORIES order then name."""
+        cat_order = {c: i for i, c in enumerate(TECH_CATEGORIES)}
+        return sorted(
+            self._templates.values(),
+            key=lambda t: (cat_order.get(t.category, 99), t.name),
+        )
+
+    def list_by_category(self, category: str) -> list[TechnicalTemplate]:
+        """Filter by category (case-insensitive). Raises ValueError for unknown categories."""
+        cat = category.lower()
+        if cat not in TECH_CATEGORIES:
+            raise ValueError(f"Unknown category '{category}'. Valid: {', '.join(TECH_CATEGORIES)}")
+        return [t for t in self.list_all() if t.category == cat]
+
+    def get(self, id: str) -> TechnicalTemplate:
+        """Exact-match lookup by id. Raises KeyError if not found."""
+        if id not in self._templates:
+            raise KeyError(
+                f"Strategy '{id}' not found. Run 'strategy library --type technical' to see all."
+            )
+        return self._templates[id]
+
+    def search(self, query: str) -> list[TechnicalTemplate]:
+        """Case-insensitive search across id, name, tags, and explanation."""
+        q = query.lower()
+        results: list[tuple[int, TechnicalTemplate]] = []
+        for t in self._templates.values():
+            score = 0
+            if q in t.id:
+                score += 3
+            if q in t.name.lower():
+                score += 3
+            if any(q in tag for tag in t.tags):
+                score += 2
+            if q in t.explanation.lower():
+                score += 1
+            if score > 0:
+                results.append((score, t))
+        results.sort(key=lambda x: x[0], reverse=True)
+        return [t for _, t in results]
+
+
+# ── Module-level singleton ────────────────────────────────────
+
+tech_library = TechnicalLibrary(TECH_TEMPLATES)

--- a/tests/test_technical_library.py
+++ b/tests/test_technical_library.py
@@ -1,0 +1,365 @@
+"""
+tests/test_technical_library.py
+────────────────────────────────
+Tests for engine/technical_library.py and the 8 new Strategy classes
+added to engine/backtest.py.
+
+Covers:
+  - TechnicalTemplate dataclass fields
+  - TechnicalLibrary list/get/search/list_by_category
+  - All 32 templates present with required fields
+  - Category counts correct
+  - New Strategy classes: signal shape, no crash on minimal data
+  - backtest_key maps to a real STRATEGIES entry or is None
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from engine.technical_library import (
+    TECH_CATEGORIES,
+    TECH_TEMPLATES,
+    TechnicalLibrary,
+    TechnicalTemplate,
+    tech_library,
+)
+
+
+# ── Shared fixture ────────────────────────────────────────────
+
+
+def _make_ohlcv(n: int = 120, start_price: float = 1000.0) -> pd.DataFrame:
+    """Minimal OHLCV DataFrame for strategy signal tests."""
+    rng = np.random.default_rng(42)
+    closes = start_price + np.cumsum(rng.normal(0, 10, n))
+    highs = closes + rng.uniform(5, 20, n)
+    lows = closes - rng.uniform(5, 20, n)
+    opens = closes + rng.normal(0, 5, n)
+    volumes = rng.integers(100_000, 1_000_000, n).astype(float)
+    idx = pd.date_range("2024-01-01", periods=n, freq="B")
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes, "volume": volumes},
+        index=idx,
+    )
+
+
+# ── TechnicalTemplate dataclass ───────────────────────────────
+
+
+class TestTechnicalTemplate:
+    def _make(self, **overrides) -> TechnicalTemplate:
+        defaults = dict(
+            id="test_tech",
+            name="Test Technical",
+            category="momentum",
+            layman_explanation="Simple test strategy.",
+            explanation="Uses a moving average crossover.",
+            when_to_use="Trending markets.",
+            when_not_to_use="Choppy markets.",
+            signal_rules=[
+                {
+                    "signal": "BUY",
+                    "condition": "Fast EMA > Slow EMA",
+                    "example": "e.g. 9 EMA crosses above 21 EMA",
+                },
+                {
+                    "signal": "SELL",
+                    "condition": "Fast EMA < Slow EMA",
+                    "example": "e.g. 9 EMA crosses below 21 EMA",
+                },
+            ],
+            parameters={"fast": {"default": 9, "description": "Fast EMA period", "type": "int"}},
+            timeframes=["1D"],
+            instruments=["stocks", "indices"],
+            risks=["Whipsaws in ranging markets"],
+            tags=["momentum", "trend"],
+            complexity="beginner",
+            backtest_key="ema",
+        )
+        defaults.update(overrides)
+        return TechnicalTemplate(**defaults)
+
+    def test_basic_construction(self):
+        t = self._make()
+        assert t.id == "test_tech"
+        assert t.category == "momentum"
+
+    def test_backtest_key_optional(self):
+        t = self._make(backtest_key=None)
+        assert t.backtest_key is None
+
+    def test_parameters_is_dict(self):
+        t = self._make()
+        assert isinstance(t.parameters, dict)
+
+    def test_signal_rules_is_list(self):
+        t = self._make()
+        assert isinstance(t.signal_rules, list)
+        assert len(t.signal_rules) >= 1
+
+
+# ── TECH_TEMPLATES dict ───────────────────────────────────────
+
+
+class TestTechTemplatesDict:
+    def test_count_is_32(self):
+        assert len(TECH_TEMPLATES) == 32
+
+    def test_all_categories_present(self):
+        found = {t.category for t in TECH_TEMPLATES.values()}
+        assert found == set(TECH_CATEGORIES)
+
+    @pytest.mark.parametrize(
+        "strat_id",
+        [
+            # Momentum
+            "ema_crossover",
+            "macd_system",
+            "supertrend",
+            "heikin_ashi",
+            "adx_trend",
+            "donchian_breakout",
+            "parabolic_sar",
+            "ichimoku",
+            # Mean reversion
+            "bollinger_reversion",
+            "rsi_reversion",
+            "vwap_reversion",
+            "zscore_reversion",
+            "keltner_reversion",
+            # Scalping
+            "orb",
+            "rsi_scalping",
+            "vwap_scalp",
+            "prev_day_hl",
+            # Breakout
+            "pivot_breakout",
+            "inside_bar",
+            "flag_pennant",
+            # Pairs
+            "pairs_trading",
+            "index_arb",
+            "etf_arb",
+            "calendar_spread_futures",
+            # Macro
+            "rbi_policy",
+            "fii_flow",
+            "vix_reversion",
+            "earnings_momentum",
+            "sector_rotation",
+            # Quantitative
+            "dual_momentum",
+            "factor_quality_momentum",
+            "volatility_sizing",
+        ],
+    )
+    def test_all_strategy_ids_present(self, strat_id):
+        assert strat_id in TECH_TEMPLATES, f"Missing: {strat_id}"
+
+    def test_all_templates_have_required_fields(self):
+        for sid, t in TECH_TEMPLATES.items():
+            assert t.id == sid, f"{sid}: id mismatch"
+            assert t.name, f"{sid}: empty name"
+            assert t.category in TECH_CATEGORIES, f"{sid}: invalid category '{t.category}'"
+            assert t.layman_explanation, f"{sid}: no layman_explanation"
+            assert t.explanation, f"{sid}: no explanation"
+            assert t.when_to_use, f"{sid}: no when_to_use"
+            assert t.when_not_to_use, f"{sid}: no when_not_to_use"
+            assert t.signal_rules, f"{sid}: no signal_rules"
+            assert t.risks, f"{sid}: no risks"
+            assert t.tags, f"{sid}: no tags"
+            assert t.timeframes, f"{sid}: no timeframes"
+            assert t.instruments, f"{sid}: no instruments"
+
+    def test_momentum_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "momentum"]) == 8
+
+    def test_mean_reversion_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "mean_reversion"]) == 5
+
+    def test_scalping_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "scalping"]) == 4
+
+    def test_breakout_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "breakout"]) == 3
+
+    def test_pairs_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "pairs"]) == 4
+
+    def test_macro_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "macro"]) == 5
+
+    def test_quantitative_count(self):
+        assert len([t for t in TECH_TEMPLATES.values() if t.category == "quantitative"]) == 3
+
+    def test_backtest_key_when_set_is_string(self):
+        for sid, t in TECH_TEMPLATES.items():
+            if t.backtest_key is not None:
+                assert isinstance(t.backtest_key, str), f"{sid}: backtest_key must be str or None"
+
+    def test_backtestable_templates_map_to_known_keys(self):
+        from engine.backtest import STRATEGIES
+
+        for sid, t in TECH_TEMPLATES.items():
+            if t.backtest_key is not None:
+                assert t.backtest_key in STRATEGIES, (
+                    f"{sid}: backtest_key '{t.backtest_key}' not in STRATEGIES registry"
+                )
+
+
+# ── TechnicalLibrary ──────────────────────────────────────────
+
+
+class TestTechnicalLibrary:
+    def test_list_all_returns_32(self):
+        assert len(tech_library.list_all()) == 32
+
+    def test_list_all_sorted_by_category_then_name(self):
+        results = tech_library.list_all()
+        cat_order = {c: i for i, c in enumerate(TECH_CATEGORIES)}
+        keys = [(cat_order[r.category], r.name) for r in results]
+        assert keys == sorted(keys)
+
+    def test_list_by_category_momentum(self):
+        results = tech_library.list_by_category("momentum")
+        assert len(results) == 8
+        assert all(r.category == "momentum" for r in results)
+
+    def test_list_by_category_case_insensitive(self):
+        results = tech_library.list_by_category("MACRO")
+        assert all(r.category == "macro" for r in results)
+
+    def test_list_by_category_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown category"):
+            tech_library.list_by_category("garbage")
+
+    def test_get_known_id(self):
+        t = tech_library.get("supertrend")
+        assert t.id == "supertrend"
+        assert t.category == "momentum"
+
+    def test_get_unknown_raises_key_error(self):
+        with pytest.raises(KeyError):
+            tech_library.get("does_not_exist")
+
+    def test_search_by_name(self):
+        results = tech_library.search("macd")
+        assert any(r.id == "macd_system" for r in results)
+
+    def test_search_by_tag(self):
+        results = tech_library.search("trend")
+        assert len(results) > 0
+
+    def test_search_case_insensitive(self):
+        results = tech_library.search("RSI")
+        assert any("rsi" in r.id for r in results)
+
+    def test_search_no_match_returns_empty(self):
+        assert tech_library.search("xyzqwerty_nomatch") == []
+
+    def test_singleton_is_technical_library(self):
+        assert isinstance(tech_library, TechnicalLibrary)
+
+
+# ── New Strategy classes in engine/backtest.py ────────────────
+
+
+class TestNewStrategyClasses:
+    """Verify each new Strategy class runs without crashing and returns correct signal shape."""
+
+    def _signals(self, strategy_key: str, df: pd.DataFrame) -> pd.Series:
+        from engine.backtest import STRATEGIES
+
+        strategy = STRATEGIES[strategy_key]([])
+        return strategy.generate_signals(df)
+
+    def _assert_valid_signals(self, signals: pd.Series, df: pd.DataFrame):
+        assert isinstance(signals, pd.Series)
+        assert len(signals) == len(df)
+        assert set(signals.unique()).issubset({-1, 0, 1})
+
+    def test_supertrend_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("supertrend", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_heikin_ashi_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("heikin_ashi", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_donchian_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("donchian", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_parabolic_sar_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("psar", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_zscore_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("zscore", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_keltner_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("keltner", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_inside_bar_signals(self):
+        df = _make_ohlcv(120)
+        sigs = self._signals("inside_bar", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_dual_momentum_signals(self):
+        df = _make_ohlcv(250)  # needs more history for monthly rebalance
+        sigs = self._signals("dual_momentum", df)
+        self._assert_valid_signals(sigs, df)
+
+    def test_existing_strategies_still_work(self):
+        df = _make_ohlcv(120)
+        for key in ("rsi", "ema", "macd", "bb"):
+            sigs = self._signals(key, df)
+            self._assert_valid_signals(sigs, df)
+
+    def test_supertrend_not_all_zero(self):
+        # Build a clear up-then-down price series to guarantee a Supertrend flip.
+        import pandas as pd
+        import numpy as np
+
+        n = 200
+        idx = pd.date_range("2024-01-01", periods=n, freq="B")
+        closes = np.concatenate(
+            [
+                np.linspace(1000, 1500, 100),  # strong uptrend  (+50%)
+                np.linspace(1500, 900, 100),  # strong downtrend (−40%)
+            ]
+        )
+        highs = closes + 10
+        lows = closes - 10
+        opens = closes + np.random.default_rng(7).normal(0, 3, n)
+        volumes = np.ones(n) * 500_000
+        df = pd.DataFrame(
+            {"open": opens, "high": highs, "low": lows, "close": closes, "volume": volumes},
+            index=idx,
+        )
+        sigs = self._signals("supertrend", df)
+        self._assert_valid_signals(sigs, df)
+        assert (sigs != 0).any(), "Supertrend should generate at least one signal"
+
+    def test_donchian_not_all_zero(self):
+        df = _make_ohlcv(200)
+        sigs = self._signals("donchian", df)
+        assert (sigs != 0).any()
+
+    def test_zscore_signals_symmetric(self):
+        # Z-score mean reversion should produce both buy and sell signals
+        df = _make_ohlcv(200)
+        sigs = self._signals("zscore", df)
+        # With random walk data both +/- signals should appear eventually
+        assert 1 in sigs.values or -1 in sigs.values


### PR DESCRIPTION
## What this PR does

Closes #99. Adds a curated library of 32 technical/systematic trading strategies for Indian markets — the technical equivalent of the options strategy library from #100.

## New files

**`engine/technical_library.py`**
- 32 `TechnicalTemplate` dataclass instances across 7 categories: `momentum` (8), `mean_reversion` (5), `scalping` (4), `breakout` (3), `pairs` (4), `macro` (5), `quantitative` (3)
- Each template has: plain-English explanation with concrete ₹ examples and analogies, signal rules (BUY/SELL/HOLD with realistic Indian market examples), parameters, timeframes, instruments, risks, tags, complexity
- `backtest_key` field maps to the `STRATEGIES` registry for the 12 backtestable strategies; `None` for strategies requiring intraday/multi-asset data not yet available
- `TechnicalLibrary` class with `list_all()`, `list_by_category()`, `get()`, `search()` — same interface as `StrategyLibrary`

**`engine/backtest_cache.py`**
- Lightweight JSON cache at `~/.trading_platform/backtest_cache.json`
- `save_result(strategy_key, result, symbol, period)` — called after every `strategy use` backtest run
- `load_result(strategy_key)` — called by `strategy learn` to show cached stats without re-running

## Modified files

**`engine/backtest.py`**
- 8 new `Strategy` classes: `SupertrendStrategy`, `HeikinAshiStrategy`, `DonchianStrategy`, `ParabolicSARStrategy`, `ZScoreStrategy`, `KeltnerStrategy`, `InsideBarStrategy`, `DualMomentumStrategy`
- All registered in the `STRATEGIES` dict
- Fixes a NaN-bootstrap bug in `SupertrendStrategy` where iterative band computation stayed `NaN` forever due to `NaN > NaN = False` in pandas comparisons

**`app/commands/strategy.py`**
- `strategy library [--type options|technical|all]` — browse either or both libraries; auto-routes by category name
- `strategy learn <id>` — checks options library first, then technical; technical strategies show SIGNALS + PARAMETERS panel with green border
- `strategy learn` now shows a **BACKTEST** section: if cache exists, displays last run stats (return, Sharpe, drawdown, win rate, trades, avg hold, symbol, date) inline — no re-run needed; if no cache yet, shows "run `strategy use` to see results"
- `strategy use <id> SYMBOL` — routes to `_use_technical()` for technical templates; runs backtest + shows current signal; saves result to cache automatically
- `strategy use <id> SYMBOL` for non-backtestable strategies (ORB, VWAP scalp, etc.) shows a clear message explaining why backtest isn't available

**`tests/test_technical_library.py`**
- 72 tests covering all 32 template IDs, per-category counts, required fields, `TechnicalLibrary` interface (list/search/get/sort order), and signal-shape assertions for all 8 new `Strategy` classes

## Test plan

- [x] `pytest tests/test_technical_library.py` — 72 passed
- [x] `pytest` (full suite) — 639 passed, 5 deselected
- [x] `ruff check` + `ruff format --check` — clean on all 5 changed files
- [x] `strategy library --type technical` — 32 strategies, ✓ for backtestable ones
- [x] `strategy learn supertrend` — plain-English panel with tightrope-walker analogy + concrete ₹ example + BACKTEST section (populated after first `use`)
- [x] `strategy learn orb` — shows "Not yet available" for backtest; explains why
- [x] `strategy use supertrend RELIANCE` — runs backtest, shows current signal, writes cache
- [x] `strategy learn supertrend` (after `use`) — shows cached stats inline, no re-run needed