### PR TITLE
feat: self-contained macOS app — Python bootstrap, onboarding wizard, DMG packaging

### DIFF
--- a/config/credentials.py
+++ b/config/credentials.py
@@ -70,12 +70,11 @@ KNOWN_CREDENTIALS: list[tuple[str, str, bool]] = [
     ("NEWSAPI_KEY", "NewsAPI.org Key", True),
     # ── Notifications ─────────────────────────────────────────
     ("TELEGRAM_BOT_TOKEN", "Telegram Bot Token", True),
-    # ── Trading Settings ──────────────────────────────────────
-    ("TOTAL_CAPITAL", "Trading Capital (INR)", False),
-    ("DEFAULT_RISK_PCT", "Default Risk Per Trade (%)", False),
-    ("TRADING_MODE", "Trading Mode (PAPER/LIVE)", False),
-    ("ONBOARDING_COMPLETE", "Onboarding Complete Flag", False),
 ]
+
+# Settings saved to keychain by onboarding but NOT auto-loaded into env
+# (they're read explicitly by the onboarding status endpoint)
+SETTING_KEYS = {"TOTAL_CAPITAL", "DEFAULT_RISK_PCT", "TRADING_MODE", "ONBOARDING_COMPLETE"}
 
 _KNOWN_KEYS = {k for k, _, _ in KNOWN_CREDENTIALS}
 

--- a/config/credentials.py
+++ b/config/credentials.py
@@ -70,6 +70,11 @@ KNOWN_CREDENTIALS: list[tuple[str, str, bool]] = [
     ("NEWSAPI_KEY", "NewsAPI.org Key", True),
     # ── Notifications ─────────────────────────────────────────
     ("TELEGRAM_BOT_TOKEN", "Telegram Bot Token", True),
+    # ── Trading Settings ──────────────────────────────────────
+    ("TOTAL_CAPITAL", "Trading Capital (INR)", False),
+    ("DEFAULT_RISK_PCT", "Default Risk Per Trade (%)", False),
+    ("TRADING_MODE", "Trading Mode (PAPER/LIVE)", False),
+    ("ONBOARDING_COMPLETE", "Onboarding Complete Flag", False),
 ]
 
 _KNOWN_KEYS = {k for k, _, _ in KNOWN_CREDENTIALS}

--- a/docs/specs/134-python-bootstrap.md
+++ b/docs/specs/134-python-bootstrap.md
@@ -1,0 +1,62 @@
+# Spec: macOS App Python Bootstrap (#134)
+
+## Problem
+The macOS Electron app requires a pre-existing `.venv` at the repo root. Packaged DMG has no Python — app fails on first launch for anyone without the repo cloned.
+
+## Solution
+Auto-detect Python 3.11+ on the system, create a venv at `~/.trading_platform/venv/`, install dependencies from a bundled wheel, and start the sidecar.
+
+## Requirements
+
+### Python Detection
+- Check candidates in order: `python3` on PATH, `/opt/homebrew/bin/python3`, `/usr/local/bin/python3`, `/usr/bin/python3`, versioned variants (3.12, 3.13)
+- Parse version string from `python3 --version`
+- Accept >= 3.11 only
+- Return first valid candidate
+
+### Venv Management
+- Venv path: `~/.trading_platform/venv/`
+- Check: `venv/bin/python` exists AND executes successfully
+- Version stamp: `venv/.app-version` contains app version from package.json
+- If stamp mismatches: reinstall deps (app updated)
+
+### Dependency Installation
+- Packaged mode: `pip install` bundled `.whl` from `extraResources/python-pkg/`
+- Dev mode fallback: `pip install -e .` from project root
+- Timeout: 10 min (scipy is large)
+- Progress: parse pip stdout lines for rough percentage
+
+### Dev Mode Shortcut
+- If `!app.isPackaged` and `.venv/bin/python` exists at repo root (3 dirs up): use it directly
+- Skip all bootstrap steps
+- Preserves existing developer workflow
+
+### Setup Screen UI
+- Progress state: message + progress bar (indeterminate for detect/venv, determinate for pip install)
+- Python missing state: install instructions (python.org link + brew command) + Retry button
+- Error state: error message + expandable details + Retry + Reset Environment button
+
+### IPC Channels
+- `setup-progress`: `{ stage, message, percent? }`
+- `setup-python-missing`: `{ message, installUrl, brewCommand }`
+- `sidecar-ready`: `{ port }`
+- `sidecar-error`: `{ message, details? }`
+- `retry-setup`: trigger re-bootstrap
+- `reset-venv`: delete venv + re-bootstrap
+
+### Startup Flow
+| Scenario | Steps | Time |
+|----------|-------|------|
+| First launch | detect → create venv → pip install → start sidecar | ~2 min |
+| Subsequent | detect → venv exists + version match → start sidecar | ~2 sec |
+| App update | detect → venv exists + version mismatch → pip install → start sidecar | ~1 min |
+| No Python | detect fails → show install instructions | instant |
+
+## Acceptance Criteria
+1. Dev mode (`npm run dev`) works unchanged when `.venv` exists at repo root
+2. With `.venv` removed + `~/.trading_platform/venv/` removed, app shows SetupScreen and bootstraps
+3. After bootstrap, app loads normally with sidecar on port 8765
+4. Subsequent launch skips setup (< 3 sec to sidecar-ready)
+5. Changing version in package.json triggers reinstall on next launch
+6. Reset Environment button deletes venv and re-bootstraps
+7. If Python not found, shows clear install instructions with Retry

--- a/docs/specs/135-onboarding-wizard.md
+++ b/docs/specs/135-onboarding-wizard.md
@@ -1,0 +1,86 @@
+# Spec: First-Launch Onboarding Wizard (#135)
+
+## Problem
+After Python bootstrap, a fresh install goes straight to the chat UI with nothing configured. No AI provider, no broker, no API keys. Users must edit `.env` manually — unacceptable for DMG distribution.
+
+## Solution
+5-step guided onboarding wizard shown on first launch (after sidecar is ready). Credentials stored in OS keychain + backup `.env` at `~/.trading_platform/.env`.
+
+## Requirements
+
+### First-Launch Detection
+- `GET /api/onboarding/status` checks if `AI_PROVIDER` is set in keychain or env
+- Returns: `{ onboarding_complete, ai_provider, newsapi_key_set, broker_connected, capital, risk_pct, trading_mode }`
+- If `onboarding_complete` is false AND no `ai_provider`: show wizard
+
+### Step 1: Welcome
+- App logo, title, tagline
+- "Get Started" button → next step
+
+### Step 2: AI Provider (mandatory)
+- 5 provider cards: Gemini (free), Claude API, Claude Pro/Max (free*), OpenAI, Ollama (free)
+- Providers with `needsKey=true`: show API key input + "Test Key" button
+- Providers without key (Ollama, Claude subscription): show SetupRunner
+  - Ollama: auto-detect → brew install → start server → pull llama3.1
+  - Claude sub: auto-detect → npm install CLI → prompt `claude login`
+- `POST /api/onboarding/test-provider` validates key via lightweight API call
+- `POST /api/onboarding/credential` saves key to keychain + env
+- `POST /api/onboarding/setup-provider` runs shell commands for Ollama/Claude
+- Cannot proceed without a valid provider configured
+
+### Step 3: Market Data (NewsAPI mandatory, broker skippable)
+- **NewsAPI** (mandatory):
+  - Key input + "Get free key" link (opens newsapi.org)
+  - `POST /api/onboarding/test-newsapi` validates key
+  - Saves via `/api/onboarding/credential`
+  - Cannot proceed without valid NewsAPI key
+- **Broker** (skippable):
+  - Info banner: "Connect a broker for live data. Without one, 15-min delayed."
+  - Fyers card: opens `/fyers/login` via `electronAPI.openExternal`
+  - Zerodha card: opens `/zerodha/login` via `electronAPI.openExternal`
+  - Polls `/api/status` every 2s to detect auth completion
+  - "Skip for now" button
+
+### Step 4: Trading Settings
+- Capital (INR): number input, default 200000
+- Risk per trade (%): number input, default 2, range 0.5-10
+- Trading mode: Paper (default) / Live toggle
+  - Live shows warning: "Real trades through your broker"
+
+### Step 5: Completion
+- Summary of all configured settings with check/skip icons
+- "Start Trading" button
+- `POST /api/onboarding/complete` saves settings + writes `~/.trading_platform/.env`
+
+### Credential Storage
+- Primary: OS keychain via `keyring` (set_credential in config/credentials.py)
+- Backup: `~/.trading_platform/.env` for packaged mode
+- Sidecar loads: `load_dotenv(~/.trading_platform/.env, override=False)` as fallback
+- No restart needed: `set_credential` writes to `os.environ` immediately
+
+### Backend Endpoints
+| Endpoint | Method | Purpose | Auth |
+|----------|--------|---------|------|
+| `/api/onboarding/status` | GET | Check configuration state | None |
+| `/api/onboarding/credential` | POST | Save key/value to keychain + env | None |
+| `/api/onboarding/test-provider` | POST | Test AI provider key | None |
+| `/api/onboarding/test-newsapi` | POST | Test NewsAPI key | None |
+| `/api/onboarding/setup-provider` | POST | Run Ollama/Claude setup commands | None |
+| `/api/onboarding/complete` | POST | Save settings, mark done | None |
+
+### Setup Provider Steps
+**Ollama:** check → install (brew) → start (ollama serve) → pull_model (llama3.1)
+**Claude subscription:** check → install (npm) → prompt login
+
+## Acceptance Criteria
+1. Fresh app (no AI_PROVIDER in keychain/env) shows onboarding wizard after sidecar ready
+2. Cannot proceed past Step 2 without a valid AI provider
+3. Cannot proceed past Step 3 without a valid NewsAPI key
+4. Broker connection is skippable
+5. "Test Key" validates against the actual API (Gemini, Anthropic, OpenAI, Ollama)
+6. Ollama setup runs brew install + ollama pull from within the app
+7. Claude subscription setup runs npm install from within the app
+8. After completion, main chat UI loads immediately (no restart)
+9. Subsequent launches skip wizard (onboarding_complete = true)
+10. Credentials persist across app restarts (stored in keychain)
+11. `~/.trading_platform/.env` is written as backup for packaged mode

--- a/macos-app/package.json
+++ b/macos-app/package.json
@@ -42,8 +42,9 @@
     ],
     "extraResources": [
       {
-        "from": "dist/india_trade_cli-*.whl",
-        "to": "python-pkg/"
+        "from": "dist/",
+        "to": "python-pkg/",
+        "filter": ["*.whl"]
       }
     ],
     "mac": {

--- a/macos-app/package.json
+++ b/macos-app/package.json
@@ -7,6 +7,7 @@
   "main": "out/main/index.js",
   "scripts": {
     "dev": "electron-vite dev",
+    "prebuild": "cd .. && python3 -m build --wheel -o macos-app/dist",
     "build": "electron-vite build && electron-builder --mac",
     "preview": "electron-vite preview",
     "test": "vitest run",
@@ -39,6 +40,12 @@
       "out/**/*",
       "build/icon.icns"
     ],
+    "extraResources": [
+      {
+        "from": "dist/india_trade_cli-*.whl",
+        "to": "python-pkg/"
+      }
+    ],
     "mac": {
       "category": "public.app-category.finance",
       "icon": "build/icon.icns",
@@ -46,7 +53,8 @@
         {
           "target": "dmg",
           "arch": [
-            "arm64"
+            "arm64",
+            "x64"
           ]
         }
       ]

--- a/macos-app/src/main/index.js
+++ b/macos-app/src/main/index.js
@@ -1,34 +1,11 @@
 import { app, BrowserWindow, shell, ipcMain, Tray, nativeImage, globalShortcut } from 'electron'
 import { join, resolve } from 'path'
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs'
-import { homedir } from 'os'
+import { existsSync } from 'fs'
 import { spawn } from 'child_process'
+import { ensurePythonEnv, VENV_PATH } from './pythonBootstrap.js'
+import { rmSync } from 'fs'
 
-// ---------------------------------------------------------------------------
-// Project root resolution
-// ---------------------------------------------------------------------------
-const CONFIG_DIR  = join(homedir(), '.trading_platform')
-const CONFIG_FILE = join(CONFIG_DIR, 'electron-project-path')
-
-function saveProjectRoot(root) {
-  try { mkdirSync(CONFIG_DIR, { recursive: true }); writeFileSync(CONFIG_FILE, root, 'utf8') } catch (_) {}
-}
-
-function findProjectRoot() {
-  // Dev mode: src/main/ → ../../.. = project root
-  const dev = resolve(__dirname, '../../..')
-  if (existsSync(join(dev, '.venv', 'bin', 'python'))) { saveProjectRoot(dev); return dev }
-  // Packaged: read saved path
-  try {
-    const saved = readFileSync(CONFIG_FILE, 'utf8').trim()
-    if (saved && existsSync(join(saved, '.venv', 'bin', 'python'))) return saved
-  } catch (_) {}
-  return null
-}
-
-const projectRoot = findProjectRoot()
-const venvBin     = projectRoot ? join(projectRoot, '.venv', 'bin') : null
-const PORT        = 8765
+const PORT = 8765
 
 // ---------------------------------------------------------------------------
 // Uvicorn sidecar
@@ -44,27 +21,56 @@ async function waitForReady(port, ms = 15000) {
   return false
 }
 
-async function startSidecar(onReady, onError) {
-  if (!projectRoot || !venvBin) return onError('Project root not found.')
-
+async function startSidecar(venvBin, sourceRoot) {
   const uvicorn = join(venvBin, 'uvicorn')
-  if (!existsSync(uvicorn)) return onError(`uvicorn not found at ${uvicorn}`)
+  if (!existsSync(uvicorn)) throw new Error(`uvicorn not found at ${uvicorn}`)
 
   uvicornProcess = spawn(uvicorn, ['web.api:app', '--host', '127.0.0.1', '--port', String(PORT), '--log-level', 'warning'], {
-    cwd: projectRoot,
-    env: { ...process.env, PYTHONPATH: projectRoot, PATH: `${venvBin}:${process.env.PATH}` },
+    cwd: sourceRoot,
+    env: { ...process.env, PYTHONPATH: sourceRoot, PATH: `${venvBin}:${process.env.PATH}` },
   })
 
   uvicornProcess.stderr.on('data', d => process.stdout.write(`[uvicorn] ${d}`))
-  uvicornProcess.on('error', e => onError(e.message))
+  uvicornProcess.on('error', e => { throw new Error(e.message) })
   uvicornProcess.on('exit', code => { console.log('[uvicorn] exit', code); uvicornProcess = null })
 
-  if (await waitForReady(PORT)) onReady(PORT)
-  else onError(`FastAPI server did not start within 15s on port ${PORT}`)
+  if (!await waitForReady(PORT)) throw new Error(`FastAPI server did not start within 15s on port ${PORT}`)
 }
 
 function stopSidecar() {
   if (uvicornProcess) { try { uvicornProcess.kill('SIGTERM') } catch (_) {}; uvicornProcess = null }
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap: detect Python, create venv, install deps, start sidecar
+// ---------------------------------------------------------------------------
+async function bootstrapAndStart() {
+  const sendProgress = (data) => mainWindow?.webContents.send('setup-progress', data)
+
+  try {
+    const { venvBin, sourceRoot } = await ensurePythonEnv((progress) => {
+      sendProgress(progress)
+    })
+
+    sendProgress({ stage: 'starting', message: 'Starting server...' })
+    await startSidecar(venvBin, sourceRoot)
+
+    _readyPort = PORT
+    mainWindow?.webContents.send('sidecar-ready', { port: PORT })
+  } catch (err) {
+    if (err.isPythonMissing) {
+      mainWindow?.webContents.send('setup-python-missing', {
+        message: err.message,
+        installUrl: 'https://www.python.org/downloads/',
+        brewCommand: 'brew install python@3.12',
+      })
+    } else {
+      mainWindow?.webContents.send('sidecar-error', {
+        message: err.message,
+        details: err.stderr || '',
+      })
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -75,11 +81,11 @@ let tray = null
 function createTray() {
   const iconPath = join(__dirname, '../../build/icon.iconset/icon_16x16.png')
   const icon     = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 })
-  icon.setTemplateImage(true)   // adapts to macOS dark/light menu bar
+  icon.setTemplateImage(true)
 
   tray = new Tray(icon)
   tray.setToolTip('India Trade')
-  tray.setTitle('◆')           // replaced with NIFTY level once market opens
+  tray.setTitle('◆')
 
   tray.on('click', () => {
     if (!mainWindow) return
@@ -98,7 +104,6 @@ function createTray() {
 let mainWindow = null
 
 function createWindow() {
-  // Set dock icon explicitly for dev mode (packaged mode uses icon.icns from bundle)
   const appIcon = nativeImage.createFromPath(join(__dirname, '../../build/icon.iconset/icon_512x512.png'))
   if (process.platform === 'darwin' && appIcon && !appIcon.isEmpty()) {
     app.dock.setIcon(appIcon)
@@ -130,10 +135,7 @@ function createWindow() {
 
   mainWindow.once('ready-to-show', () => {
     mainWindow.show()
-    startSidecar(
-      port => { _readyPort = port; mainWindow?.webContents.send('sidecar-ready', { port }) },
-      err  => mainWindow?.webContents.send('sidecar-error', { message: err }),
-    )
+    bootstrapAndStart()
   })
 
   mainWindow.on('closed', () => { mainWindow = null })
@@ -141,23 +143,35 @@ function createWindow() {
 }
 
 // ---------------------------------------------------------------------------
-// IPC — renderer can request the current port after HMR / reload
+// IPC
 // ---------------------------------------------------------------------------
-let _readyPort = null  // set once uvicorn is up
+let _readyPort = null
 
 ipcMain.handle('get-port', () => _readyPort)
 ipcMain.handle('open-external', (_, url) => shell.openExternal(url))
 
-// Renderer sends live NIFTY/market data to update the tray title
 ipcMain.on('update-tray', (_, { label }) => {
   if (tray) tray.setTitle(label ? ` ${label}` : '◆')
+})
+
+// Setup IPC: retry and reset
+ipcMain.handle('retry-setup', async () => {
+  _readyPort = null
+  stopSidecar()
+  await bootstrapAndStart()
+})
+
+ipcMain.handle('reset-venv', async () => {
+  _readyPort = null
+  stopSidecar()
+  try { rmSync(VENV_PATH, { recursive: true, force: true }) } catch (_) {}
+  await bootstrapAndStart()
 })
 
 // ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
 app.whenReady().then(() => {
-  // Set app name for dev mode (packaged mode reads from Info.plist)
   if (!app.isPackaged) {
     app.setName('India Trade')
   }
@@ -165,7 +179,6 @@ app.whenReady().then(() => {
   createTray()
   createWindow()
 
-  // Global shortcut: Cmd+Shift+Space → show/focus the app from anywhere
   globalShortcut.register('CommandOrControl+Shift+Space', () => {
     if (!mainWindow) return
     if (mainWindow.isVisible() && mainWindow.isFocused()) {
@@ -182,6 +195,5 @@ app.on('before-quit', () => {
   stopSidecar()
 })
 app.on('window-all-closed', () => {
-  // On macOS keep the app alive in the tray even when window is closed
   if (process.platform !== 'darwin') { stopSidecar(); app.quit() }
 })

--- a/macos-app/src/main/pythonBootstrap.js
+++ b/macos-app/src/main/pythonBootstrap.js
@@ -1,0 +1,274 @@
+/**
+ * pythonBootstrap.js
+ * ──────────────────
+ * Detects Python 3.11+, creates a venv at ~/.trading_platform/venv/,
+ * and installs the india-trade-cli wheel into it.
+ *
+ * First launch: detect → create venv → pip install wheel → ~2 min
+ * Subsequent:   detect → venv exists + version matches → ~1 sec
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { spawn, execFileSync } from 'child_process'
+import { app } from 'electron'
+
+// ── Paths ────────────────────────────────────────────────────────
+
+const PLATFORM_DIR = join(homedir(), '.trading_platform')
+const VENV_PATH    = join(PLATFORM_DIR, 'venv')
+const VENV_BIN     = join(VENV_PATH, 'bin')
+const VENV_PYTHON  = join(VENV_BIN, 'python')
+const VENV_PIP     = join(VENV_BIN, 'pip')
+const VENV_UVICORN = join(VENV_BIN, 'uvicorn')
+const VERSION_STAMP = join(VENV_PATH, '.app-version')
+
+// Minimum Python version required
+const MIN_PYTHON_MAJOR = 3
+const MIN_PYTHON_MINOR = 11
+
+// ── Python Detection ─────────────────────────────────────────────
+
+const PYTHON_CANDIDATES = [
+  'python3',
+  '/opt/homebrew/bin/python3',
+  '/usr/local/bin/python3',
+  '/usr/bin/python3',
+  '/opt/homebrew/bin/python3.12',
+  '/opt/homebrew/bin/python3.13',
+  '/usr/local/bin/python3.12',
+  '/usr/local/bin/python3.13',
+]
+
+function parsePythonVersion(versionString) {
+  const match = versionString.match(/Python (\d+)\.(\d+)\.(\d+)/)
+  if (!match) return null
+  return { major: parseInt(match[1]), minor: parseInt(match[2]), patch: parseInt(match[3]) }
+}
+
+function tryPythonCandidate(candidate) {
+  try {
+    const output = execFileSync(candidate, ['--version'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:/usr/bin:${process.env.PATH}` },
+    }).trim()
+    const version = parsePythonVersion(output)
+    if (!version) return null
+    if (version.major < MIN_PYTHON_MAJOR) return null
+    if (version.major === MIN_PYTHON_MAJOR && version.minor < MIN_PYTHON_MINOR) return null
+    return { path: candidate, version }
+  } catch {
+    return null
+  }
+}
+
+export function detectPython() {
+  for (const candidate of PYTHON_CANDIDATES) {
+    const result = tryPythonCandidate(candidate)
+    if (result) return result
+  }
+  return null
+}
+
+// ── Venv Management ──────────────────────────────────────────────
+
+export function checkVenv() {
+  if (!existsSync(VENV_PYTHON)) return false
+  // Verify the Python binary actually works (symlinks might be broken)
+  try {
+    execFileSync(VENV_PYTHON, ['--version'], { encoding: 'utf8', timeout: 5000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function checkDepsVersion() {
+  if (!existsSync(VERSION_STAMP)) return false
+  try {
+    const stamped = readFileSync(VERSION_STAMP, 'utf8').trim()
+    const current = app.getVersion()
+    return stamped === current
+  } catch {
+    return false
+  }
+}
+
+function writeVersionStamp() {
+  writeFileSync(VERSION_STAMP, app.getVersion(), 'utf8')
+}
+
+// ── Subprocess helpers ───────────────────────────────────────────
+
+function runProcess(cmd, args, opts = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(cmd, args, {
+      env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:/usr/bin:${process.env.PATH}` },
+      ...opts,
+    })
+    let stdout = ''
+    let stderr = ''
+
+    proc.stdout?.on('data', (d) => {
+      stdout += d.toString()
+      opts.onStdout?.(d.toString())
+    })
+    proc.stderr?.on('data', (d) => {
+      stderr += d.toString()
+      opts.onStderr?.(d.toString())
+    })
+    proc.on('error', (err) => reject(new Error(`Failed to start ${cmd}: ${err.message}`)))
+    proc.on('exit', (code) => {
+      if (code === 0) resolve({ stdout, stderr })
+      else reject(Object.assign(new Error(`${cmd} exited with code ${code}`), { stderr: stderr.slice(-2000) }))
+    })
+
+    // Timeout
+    const timeout = opts.timeout ?? 300000 // 5 min default
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM')
+      reject(new Error(`${cmd} timed out after ${timeout / 1000}s`))
+    }, timeout)
+    proc.on('exit', () => clearTimeout(timer))
+  })
+}
+
+// ── Core Bootstrap ───────────────────────────────────────────────
+
+async function createVenv(pythonPath, onProgress) {
+  onProgress?.({ stage: 'creating_venv', message: 'Creating Python environment...' })
+  mkdirSync(PLATFORM_DIR, { recursive: true })
+  await runProcess(pythonPath, ['-m', 'venv', VENV_PATH], { timeout: 60000 })
+}
+
+function findWheelPath() {
+  const { readdirSync } = require('fs')
+
+  // Packaged mode: extraResources/python-pkg/
+  if (app.isPackaged) {
+    const resourceDir = join(process.resourcesPath, 'python-pkg')
+    if (existsSync(resourceDir)) {
+      const wheels = readdirSync(resourceDir).filter(f => f.endsWith('.whl'))
+      if (wheels.length > 0) return join(resourceDir, wheels[0])
+    }
+  }
+
+  // Dev mode: macos-app/dist/
+  const devDir = join(__dirname, '../../dist')
+  if (existsSync(devDir)) {
+    const wheels = readdirSync(devDir).filter(f => f.endsWith('.whl'))
+    if (wheels.length > 0) return join(devDir, wheels[0])
+  }
+
+  return null
+}
+
+async function installDeps(onProgress) {
+  onProgress?.({ stage: 'installing_deps', message: 'Installing dependencies (first time only)...', percent: 0 })
+
+  const wheelPath = findWheelPath()
+
+  // Upgrade pip first
+  await runProcess(VENV_PIP, ['install', '--upgrade', 'pip'], { timeout: 60000 })
+
+  if (wheelPath) {
+    // Install from bundled wheel
+    let lineCount = 0
+    await runProcess(VENV_PIP, ['install', wheelPath, '--no-input'], {
+      timeout: 600000, // 10 min for scipy etc.
+      onStdout: (line) => {
+        lineCount++
+        // Rough progress: ~50 packages, each emits 1-3 lines
+        const percent = Math.min(95, Math.round(lineCount / 150 * 100))
+        onProgress?.({ stage: 'installing_deps', message: `Installing packages...`, percent })
+      },
+    })
+  } else {
+    // Fallback: install from project root (dev mode without wheel)
+    const projectRoot = join(__dirname, '../../..')
+    if (existsSync(join(projectRoot, 'pyproject.toml'))) {
+      let lineCount = 0
+      await runProcess(VENV_PIP, ['install', '-e', projectRoot, '--no-input'], {
+        timeout: 600000,
+        onStdout: (line) => {
+          lineCount++
+          const percent = Math.min(95, Math.round(lineCount / 150 * 100))
+          onProgress?.({ stage: 'installing_deps', message: `Installing packages...`, percent })
+        },
+      })
+    } else {
+      throw new Error('No wheel or pyproject.toml found. Cannot install dependencies.')
+    }
+  }
+
+  writeVersionStamp()
+  onProgress?.({ stage: 'installing_deps', message: 'Dependencies installed.', percent: 100 })
+}
+
+function findSourceRoot() {
+  // After pip install, the source is in site-packages or editable install
+  try {
+    const output = execFileSync(VENV_PYTHON, ['-c', 'import web.api; import os; print(os.path.dirname(os.path.dirname(web.api.__file__)))'], {
+      encoding: 'utf8',
+      timeout: 10000,
+    }).trim()
+    if (output && existsSync(output)) return output
+  } catch { /* fallback below */ }
+
+  // Fallback for editable installs: project root
+  const projectRoot = join(__dirname, '../../..')
+  if (existsSync(join(projectRoot, 'web', 'api.py'))) return projectRoot
+
+  throw new Error('Could not find Python source root after installation.')
+}
+
+// ── Main Entry Point ─────────────────────────────────────────────
+
+export async function ensurePythonEnv(onProgress) {
+  // Dev mode shortcut: use repo .venv if it exists
+  if (!app.isPackaged) {
+    const devRoot = join(__dirname, '../../..')
+    const devVenvPython = join(devRoot, '.venv', 'bin', 'python')
+    if (existsSync(devVenvPython)) {
+      onProgress?.({ stage: 'starting', message: 'Using development environment...' })
+      return {
+        venvBin: join(devRoot, '.venv', 'bin'),
+        sourceRoot: devRoot,
+      }
+    }
+  }
+
+  // Step 1: Detect Python
+  onProgress?.({ stage: 'detecting', message: 'Checking for Python...' })
+  const python = detectPython()
+  if (!python) {
+    const err = new Error('Python 3.11 or later is required but was not found on this system.')
+    err.isPythonMissing = true
+    throw err
+  }
+  onProgress?.({ stage: 'detecting', message: `Found Python ${python.version.major}.${python.version.minor}.${python.version.patch}` })
+
+  // Step 2: Check venv
+  const venvExists = checkVenv()
+  const versionMatch = venvExists && checkDepsVersion()
+
+  if (venvExists && versionMatch) {
+    // Fast path: venv ready, skip setup
+    onProgress?.({ stage: 'starting', message: 'Environment ready.' })
+    return { venvBin: VENV_BIN, sourceRoot: findSourceRoot() }
+  }
+
+  // Step 3: Create venv if needed
+  if (!venvExists) {
+    await createVenv(python.path, onProgress)
+  }
+
+  // Step 4: Install / update dependencies
+  await installDeps(onProgress)
+
+  return { venvBin: VENV_BIN, sourceRoot: findSourceRoot() }
+}
+
+export { VENV_PATH, VENV_BIN }

--- a/macos-app/src/preload/index.js
+++ b/macos-app/src/preload/index.js
@@ -1,9 +1,16 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  onSidecarReady:  (cb)    => ipcRenderer.on('sidecar-ready', (_, data) => cb(data)),
-  onSidecarError:  (cb)    => ipcRenderer.on('sidecar-error', (_, data) => cb(data)),
-  getPort:         ()      => ipcRenderer.invoke('get-port'),
-  openExternal:    (url)   => ipcRenderer.invoke('open-external', url),
-  updateTray:      (data)  => ipcRenderer.send('update-tray', data),
+  // Sidecar lifecycle
+  onSidecarReady:      (cb) => ipcRenderer.on('sidecar-ready', (_, data) => cb(data)),
+  onSidecarError:      (cb) => ipcRenderer.on('sidecar-error', (_, data) => cb(data)),
+  getPort:             ()   => ipcRenderer.invoke('get-port'),
+  openExternal:        (url) => ipcRenderer.invoke('open-external', url),
+  updateTray:          (data) => ipcRenderer.send('update-tray', data),
+
+  // Setup / bootstrap
+  onSetupProgress:     (cb) => ipcRenderer.on('setup-progress', (_, data) => cb(data)),
+  onSetupPythonMissing:(cb) => ipcRenderer.on('setup-python-missing', (_, data) => cb(data)),
+  retrySetup:          ()   => ipcRenderer.invoke('retry-setup'),
+  resetVenv:           ()   => ipcRenderer.invoke('reset-venv'),
 })

--- a/macos-app/src/renderer/src/App.jsx
+++ b/macos-app/src/renderer/src/App.jsx
@@ -5,6 +5,7 @@ import Sidebar from './components/Sidebar'
 import ChatArea from './components/Chat/ChatArea'
 import InputBar from './components/Input/InputBar'
 import SetupScreen from './components/SetupScreen'
+import OnboardingWizard from './components/Onboarding/OnboardingWizard'
 
 export default function App() {
   const { setPort, setSidecarError, setBrokerStatuses } = useChatStore()
@@ -12,7 +13,7 @@ export default function App() {
 
   // Setup phase state machine
   const [setupPhase, setSetupPhase] = useState('initializing')
-  // 'initializing' | 'progress' | 'python_missing' | 'error' | 'ready'
+  // 'initializing' | 'progress' | 'python_missing' | 'error' | 'onboarding' | 'ready'
   const [setupData, setSetupData] = useState(null)
 
   useEffect(() => {
@@ -28,10 +29,20 @@ export default function App() {
       setSetupData(data)
     })
 
-    // Sidecar ready — setup complete
-    window.electronAPI?.onSidecarReady(({ port }) => {
+    // Sidecar ready — check onboarding before showing main UI
+    window.electronAPI?.onSidecarReady(async ({ port }) => {
       setPort(port)
-      setSetupPhase('ready')
+      try {
+        const res = await fetch(`http://127.0.0.1:${port}/api/onboarding/status`)
+        const data = await res.json()
+        if (data.onboarding_complete) {
+          setSetupPhase('ready')
+        } else {
+          setSetupPhase('onboarding')
+        }
+      } catch {
+        setSetupPhase('ready')
+      }
     })
 
     // Sidecar error — could be during setup or runtime
@@ -44,10 +55,20 @@ export default function App() {
     })
 
     // Check if port already set (HMR / reload)
-    window.electronAPI?.getPort().then(port => {
+    window.electronAPI?.getPort().then(async (port) => {
       if (port) {
         setPort(port)
-        setSetupPhase('ready')
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/api/onboarding/status`)
+          const data = await res.json()
+          if (data.onboarding_complete) {
+            setSetupPhase('ready')
+          } else {
+            setSetupPhase('onboarding')
+          }
+        } catch {
+          setSetupPhase('ready')
+        }
       }
     })
   }, [])
@@ -64,6 +85,11 @@ export default function App() {
     const t = setInterval(fetchStatus, 8000)
     return () => clearInterval(t)
   }, [port])
+
+  // Show onboarding wizard for first-launch setup
+  if (setupPhase === 'onboarding') {
+    return <OnboardingWizard port={port} onComplete={() => setSetupPhase('ready')} />
+  }
 
   // Show setup screen until ready
   if (setupPhase !== 'ready') {

--- a/macos-app/src/renderer/src/App.jsx
+++ b/macos-app/src/renderer/src/App.jsx
@@ -1,18 +1,55 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useChatStore } from './store/chatStore'
 import { useMarketClock } from './hooks/useMarketClock'
 import Sidebar from './components/Sidebar'
 import ChatArea from './components/Chat/ChatArea'
 import InputBar from './components/Input/InputBar'
+import SetupScreen from './components/SetupScreen'
 
 export default function App() {
   const { setPort, setSidecarError, setBrokerStatuses } = useChatStore()
   const port = useChatStore((s) => s.port)
 
+  // Setup phase state machine
+  const [setupPhase, setSetupPhase] = useState('initializing')
+  // 'initializing' | 'progress' | 'python_missing' | 'error' | 'ready'
+  const [setupData, setSetupData] = useState(null)
+
   useEffect(() => {
-    window.electronAPI?.onSidecarReady(({ port }) => setPort(port))
-    window.electronAPI?.onSidecarError(({ message }) => setSidecarError(message))
-    window.electronAPI?.getPort().then(port => { if (port) setPort(port) })
+    // Setup progress events
+    window.electronAPI?.onSetupProgress((data) => {
+      setSetupPhase('progress')
+      setSetupData(data)
+    })
+
+    // Python not found
+    window.electronAPI?.onSetupPythonMissing((data) => {
+      setSetupPhase('python_missing')
+      setSetupData(data)
+    })
+
+    // Sidecar ready — setup complete
+    window.electronAPI?.onSidecarReady(({ port }) => {
+      setPort(port)
+      setSetupPhase('ready')
+    })
+
+    // Sidecar error — could be during setup or runtime
+    window.electronAPI?.onSidecarError(({ message, details }) => {
+      setSidecarError(message)
+      if (setupPhase !== 'ready') {
+        setSetupPhase('error')
+        setSetupData({ message, details })
+      }
+    })
+
+    // Check if port already set (HMR / reload)
+    window.electronAPI?.getPort().then(port => {
+      if (port) {
+        setPort(port)
+        setSetupPhase('ready')
+      }
+    })
   }, [])
 
   // Poll /api/status every 8s once sidecar is up
@@ -28,30 +65,30 @@ export default function App() {
     return () => clearInterval(t)
   }, [port])
 
+  // Show setup screen until ready
+  if (setupPhase !== 'ready') {
+    return <SetupScreen phase={setupPhase} data={setupData} />
+  }
+
   return (
     <div className="flex flex-col h-full bg-surface">
 
-      {/* ── Title bar — 52px, draggable ── */}
+      {/* Title bar */}
       <div className="drag flex items-center h-[52px] bg-panel border-b border-border flex-shrink-0">
-        {/* Traffic light spacer */}
         <div className="w-[76px] flex-shrink-0" />
-
-        {/* App name — centred */}
         <div className="flex-1 flex items-center justify-center gap-2 pointer-events-none">
           <span className="text-amber text-[15px]">◆</span>
           <span className="text-text text-[13px] font-semibold tracking-wide font-ui">
             India Trade
           </span>
         </div>
-
-        {/* Market status + API dot */}
         <div className="no-drag flex items-center gap-3 pr-4">
           <MarketBadge />
           <StatusDot />
         </div>
       </div>
 
-      {/* ── Main layout ── */}
+      {/* Main layout */}
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <div className="flex flex-col flex-1 overflow-hidden">
@@ -93,7 +130,7 @@ function StatusDot() {
         connected ? 'bg-green shadow-[0_0_6px_rgba(82,224,122,0.5)]' : 'bg-subtle'
       }`} />
       <span className="text-muted text-[11px] font-ui">
-        {sidecarError ? 'error' : connected ? 'connected' : 'starting…'}
+        {sidecarError ? 'error' : connected ? 'connected' : 'starting...'}
       </span>
     </div>
   )

--- a/macos-app/src/renderer/src/components/Onboarding/CompletionStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/CompletionStep.jsx
@@ -1,0 +1,91 @@
+export default function CompletionStep({ formData, onComplete, completing }) {
+  const providerNames = {
+    gemini: 'Google Gemini',
+    anthropic: 'Claude (Anthropic)',
+    openai: 'OpenAI',
+    ollama: 'Ollama (Local)',
+  }
+
+  const formatCurrency = (val) => {
+    return new Intl.NumberFormat('en-IN', {
+      style: 'currency',
+      currency: 'INR',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(val || 200000)
+  }
+
+  const items = [
+    {
+      label: 'AI Provider',
+      value: providerNames[formData.aiProvider] || formData.aiProvider || 'Not set',
+      ok: !!formData.aiProvider,
+    },
+    {
+      label: 'NewsAPI',
+      value: formData.newsApiSet ? 'Configured' : 'Not set',
+      ok: !!formData.newsApiSet,
+    },
+    {
+      label: 'Broker',
+      value: formData.brokerName
+        ? formData.brokerName.charAt(0).toUpperCase() + formData.brokerName.slice(1)
+        : 'Skipped',
+      ok: !!formData.brokerName,
+      skipped: !formData.brokerName,
+    },
+    {
+      label: 'Capital',
+      value: formatCurrency(formData.capital),
+      ok: true,
+    },
+    {
+      label: 'Risk',
+      value: `${formData.riskPct || 2}%`,
+      ok: true,
+    },
+    {
+      label: 'Mode',
+      value: formData.tradingMode === 'LIVE' ? 'Live' : 'Paper',
+      ok: true,
+    },
+  ]
+
+  return (
+    <div className="flex flex-col items-center flex-1 gap-6 animate-fade-slide">
+      <div className="text-center">
+        <span className="text-green text-4xl leading-none block mb-3">&#10003;</span>
+        <h2 className="text-text text-lg font-semibold font-ui">All Set</h2>
+        <p className="text-muted text-xs font-ui mt-1">
+          Here is a summary of your configuration
+        </p>
+      </div>
+
+      <div className="bg-panel border border-border rounded-lg p-4 max-w-md w-full space-y-3">
+        {items.map((item) => (
+          <div key={item.label} className="flex items-center justify-between">
+            <span className="text-muted text-sm font-ui">{item.label}</span>
+            <div className="flex items-center gap-2">
+              <span className={`text-sm font-mono ${item.ok ? 'text-text' : 'text-subtle'}`}>
+                {item.value}
+              </span>
+              <span className={`text-xs ${item.skipped ? 'text-subtle' : item.ok ? 'text-green' : 'text-red'}`}>
+                {item.skipped ? '\u2298' : item.ok ? '\u2713' : '\u2717'}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={onComplete}
+        disabled={completing}
+        className="mt-4 px-8 py-2.5 bg-amber text-surface font-ui font-semibold text-sm rounded-lg
+                   hover:brightness-110 transition-all active:scale-95
+                   disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {completing ? 'Saving...' : 'Start Trading'}
+      </button>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Onboarding/MarketDataStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/MarketDataStep.jsx
@@ -250,20 +250,26 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
                     {/* Broker header — click to expand */}
                     <button
                       onClick={() => setExpandedBroker(isExpanded ? null : id)}
-                      className="w-full flex items-center justify-between p-3 bg-elevated
-                                 hover:bg-elevated/80 transition-all text-left"
+                      className={`w-full flex items-center justify-between p-4 bg-elevated
+                                 hover:border-amber/50 transition-all text-left border-b
+                                 ${isExpanded ? 'border-amber/30' : 'border-transparent'}`}
                     >
-                      <div className="flex items-center gap-2">
-                        <span className="text-text text-sm font-semibold font-ui">{broker.name}</span>
-                        <span className={`text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded ${broker.badgeColor}`}>
-                          {broker.badge}
-                        </span>
-                        {isConfigured && <span className="text-green text-[10px] font-ui">Keys set</span>}
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-text text-sm font-semibold font-ui">{broker.name}</span>
+                          <span className={`text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded ${broker.badgeColor}`}>
+                            {broker.badge}
+                          </span>
+                          {isConfigured && <span className="text-green text-[10px] font-ui">Keys set</span>}
+                        </div>
+                        <span className="text-muted text-[11px] font-ui mt-0.5 block">{broker.desc}</span>
                       </div>
-                      <div className="flex items-center gap-2">
-                        <span className="text-muted text-[10px] font-ui">{broker.desc}</span>
-                        <span className="text-muted text-xs">{isExpanded ? '▾' : '▸'}</span>
-                      </div>
+                      <span className={`px-3 py-1.5 rounded-lg text-xs font-ui font-semibold transition-all
+                        ${isExpanded
+                          ? 'bg-amber/10 text-amber border border-amber/30'
+                          : 'bg-elevated text-muted border border-border hover:text-text'}`}>
+                        {isExpanded ? 'Hide' : 'Set Up'}
+                      </span>
                     </button>
 
                     {/* Expanded: setup guide + key inputs */}

--- a/macos-app/src/renderer/src/components/Onboarding/MarketDataStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/MarketDataStep.jsx
@@ -1,21 +1,79 @@
 import { useState, useEffect, useRef } from 'react'
 
+const BROKERS = {
+  fyers: {
+    name: 'Fyers',
+    badge: 'Free',
+    badgeColor: 'bg-green/20 text-green',
+    desc: 'Best options chain data — free API',
+    portalUrl: 'https://myapi.fyers.in',
+    portalLabel: 'myapi.fyers.in',
+    redirectUrl: 'http://127.0.0.1:8765/fyers/callback',
+    keys: [
+      { env: 'FYERS_APP_ID', label: 'App ID', placeholder: 'XXXX-100', secret: false },
+      { env: 'FYERS_SECRET_KEY', label: 'Secret Key', placeholder: 'Your secret key', secret: true },
+    ],
+    steps: [
+      'Create a free account at fyers.in (if you don\'t have one)',
+      'Go to myapi.fyers.in → Create App',
+      'Set the redirect URL exactly as shown below',
+      'Copy your App ID and Secret Key',
+    ],
+  },
+  zerodha: {
+    name: 'Zerodha',
+    badge: 'Free*',
+    badgeColor: 'bg-blue/20 text-blue',
+    desc: 'Order execution — free Personal plan',
+    portalUrl: 'https://developers.kite.trade',
+    portalLabel: 'developers.kite.trade',
+    redirectUrl: 'http://localhost:8765/zerodha/callback',
+    keys: [
+      { env: 'KITE_API_KEY', label: 'API Key', placeholder: 'Your API key', secret: false },
+      { env: 'KITE_API_SECRET', label: 'API Secret', placeholder: 'Your API secret', secret: true },
+    ],
+    steps: [
+      'Log in at developers.kite.trade',
+      'Create App → choose Personal (free) or Connect (Rs 500/mo)',
+      'Set the redirect URL exactly as shown below',
+      'Copy your API Key and API Secret',
+      'Register your static IP on your Zerodha profile (SEBI requirement)',
+    ],
+  },
+}
+
 export default function MarketDataStep({ formData, setFormData, onNext, port }) {
   const [newsKey, setNewsKey] = useState('')
   const [newsTesting, setNewsTesting] = useState(false)
   const [newsResult, setNewsResult] = useState(null)
   const [newsSaved, setNewsSaved] = useState(formData.newsApiSet || false)
-  const [brokerPolling, setBrokerPolling] = useState(null)
   const [brokerConnected, setBrokerConnected] = useState(formData.brokerName || '')
+  const [expandedBroker, setExpandedBroker] = useState(null)
+  const [brokerStatus, setBrokerStatus] = useState({})
+  const [brokerPolling, setBrokerPolling] = useState(null)
   const pollRef = useRef(null)
 
   const base = `http://127.0.0.1:${port}`
 
+  // Fetch broker status on mount
   useEffect(() => {
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current)
-    }
+    fetch(`${base}/api/status`)
+      .then(r => r.json())
+      .then(data => {
+        setBrokerStatus(data)
+        // Auto-detect already connected broker
+        for (const key of ['fyers', 'zerodha']) {
+          if (data[key]?.authenticated) {
+            setBrokerConnected(key)
+            setFormData(prev => ({ ...prev, brokerName: key }))
+          }
+        }
+      })
+      .catch(() => {})
+    return () => { if (pollRef.current) clearInterval(pollRef.current) }
   }, [])
+
+  // ── NewsAPI ──────────────────────────────────────────────────
 
   const handleTestNews = async () => {
     setNewsTesting(true)
@@ -35,7 +93,7 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
           body: JSON.stringify({ key: 'NEWSAPI_KEY', value: newsKey }),
         })
         setNewsSaved(true)
-        setFormData((prev) => ({ ...prev, newsApiSet: true }))
+        setFormData(prev => ({ ...prev, newsApiSet: true }))
       }
     } catch (err) {
       setNewsResult({ ok: false, error: err.message })
@@ -44,9 +102,35 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
     }
   }
 
-  const handleBrokerLogin = (broker) => {
-    setBrokerPolling(broker)
-    const url = `http://127.0.0.1:${port}/${broker}/login`
+  // ── Broker Setup ─────────────────────────────────────────────
+
+  const handleSaveBrokerKeys = async (brokerId) => {
+    const broker = BROKERS[brokerId]
+    const inputs = document.querySelectorAll(`[data-broker="${brokerId}"]`)
+    const values = {}
+    inputs.forEach(input => { values[input.dataset.key] = input.value })
+
+    // Validate all fields filled
+    for (const key of broker.keys) {
+      if (!values[key.env]?.trim()) return
+    }
+
+    // Save each key
+    for (const key of broker.keys) {
+      await fetch(`${base}/api/onboarding/credential`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: key.env, value: values[key.env].trim() }),
+      })
+    }
+
+    // Trigger OAuth login
+    handleBrokerLogin(brokerId)
+  }
+
+  const handleBrokerLogin = (brokerId) => {
+    setBrokerPolling(brokerId)
+    const url = `http://127.0.0.1:${port}/${brokerId}/login`
     if (window.electronAPI?.openExternal) {
       window.electronAPI.openExternal(url)
     } else {
@@ -58,26 +142,21 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
       try {
         const res = await fetch(`${base}/api/status`)
         const data = await res.json()
-        if (data[broker]?.authenticated) {
+        setBrokerStatus(data)
+        if (data[brokerId]?.authenticated) {
           clearInterval(pollRef.current)
           pollRef.current = null
           setBrokerPolling(null)
-          setBrokerConnected(broker)
-          setFormData((prev) => ({ ...prev, brokerName: broker }))
+          setBrokerConnected(brokerId)
+          setFormData(prev => ({ ...prev, brokerName: brokerId }))
         }
-      } catch {
-        // keep polling
-      }
+      } catch { /* keep polling */ }
     }, 2000)
   }
 
-  const handleGetFreeKey = () => {
-    const url = 'https://newsapi.org/register'
-    if (window.electronAPI?.openExternal) {
-      window.electronAPI.openExternal(url)
-    } else {
-      window.open(url, '_blank')
-    }
+  const openExternal = (url) => {
+    if (window.electronAPI?.openExternal) window.electronAPI.openExternal(url)
+    else window.open(url, '_blank')
   }
 
   const canProceed = newsSaved
@@ -86,13 +165,12 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
     <div className="flex flex-col flex-1 gap-6 animate-fade-slide">
       <div className="text-center">
         <h2 className="text-text text-lg font-semibold font-ui">Market Data</h2>
-        <p className="text-muted text-xs font-ui mt-1">
-          Connect news and broker data sources
-        </p>
+        <p className="text-muted text-xs font-ui mt-1">Connect news and broker data sources</p>
       </div>
 
-      <div className="max-w-lg mx-auto w-full space-y-6">
-        {/* NewsAPI Section */}
+      <div className="max-w-xl mx-auto w-full space-y-4 overflow-y-auto flex-1">
+
+        {/* ── NewsAPI ─────────────────────────────────────────── */}
         <div className="bg-panel border border-border rounded-lg p-4 space-y-3">
           <div className="flex items-center justify-between">
             <div>
@@ -109,10 +187,7 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
                   type="password"
                   placeholder="Enter NewsAPI key"
                   value={newsKey}
-                  onChange={(e) => {
-                    setNewsKey(e.target.value)
-                    setNewsResult(null)
-                  }}
+                  onChange={(e) => { setNewsKey(e.target.value); setNewsResult(null) }}
                   className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2
                              text-text text-sm font-mono placeholder:text-subtle
                              focus:outline-none focus:border-amber"
@@ -128,8 +203,8 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
                 </button>
               </div>
               <button
-                onClick={handleGetFreeKey}
-                className="text-amber text-[11px] font-ui hover:underline"
+                onClick={() => openExternal('https://newsapi.org/register')}
+                className="text-amber text-[11px] font-ui hover:underline cursor-pointer"
               >
                 Get a free key at newsapi.org &rarr;
               </button>
@@ -142,12 +217,12 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
           )}
         </div>
 
-        {/* Broker Section */}
+        {/* ── Broker Section ──────────────────────────────────── */}
         <div className="bg-panel border border-border rounded-lg p-4 space-y-3">
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-text text-sm font-semibold font-ui">Broker (Optional)</h3>
-              <p className="text-muted text-[11px] font-ui">Connect for live market data and execution</p>
+              <p className="text-muted text-[11px] font-ui">Connect for live market data and trading</p>
             </div>
             {brokerConnected && (
               <span className="text-green text-xs font-ui font-semibold capitalize">
@@ -158,60 +233,132 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
 
           <div className="bg-elevated border border-border rounded-lg p-3">
             <p className="text-muted text-[11px] font-ui leading-relaxed">
-              Without a broker, you get delayed data and paper trading.
-              Connect a broker for real-time data and live execution.
+              Without a broker, you get 15-min delayed data and paper trading only.
+              A broker gives you <span className="text-text">live quotes, options chain, and real order execution</span>.
             </p>
           </div>
 
           {!brokerConnected && (
-            <div className="grid grid-cols-2 gap-2">
-              <button
-                onClick={() => handleBrokerLogin('fyers')}
-                disabled={brokerPolling === 'fyers'}
-                className="flex flex-col items-start gap-1 p-3 rounded-lg border border-border
-                           bg-elevated hover:border-subtle transition-all text-left
-                           disabled:opacity-60"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-text text-sm font-semibold font-ui">Fyers</span>
-                  <span className="text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded bg-green/20 text-green">
-                    Free
-                  </span>
-                </div>
-                <span className="text-muted text-[10px] font-ui">Best options data</span>
-                {brokerPolling === 'fyers' && (
-                  <span className="text-amber text-[10px] font-ui animate-pulse">
-                    Waiting for login...
-                  </span>
-                )}
-              </button>
+            <div className="space-y-2">
+              {Object.entries(BROKERS).map(([id, broker]) => {
+                const isExpanded = expandedBroker === id
+                const isConfigured = brokerStatus[id]?.configured
+                const isPolling = brokerPolling === id
 
-              <button
-                onClick={() => handleBrokerLogin('zerodha')}
-                disabled={brokerPolling === 'zerodha'}
-                className="flex flex-col items-start gap-1 p-3 rounded-lg border border-border
-                           bg-elevated hover:border-subtle transition-all text-left
-                           disabled:opacity-60"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="text-text text-sm font-semibold font-ui">Zerodha</span>
-                  <span className="text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded bg-blue/20 text-blue">
-                    Paid
-                  </span>
-                </div>
-                <span className="text-muted text-[10px] font-ui">Free personal plan</span>
-                {brokerPolling === 'zerodha' && (
-                  <span className="text-amber text-[10px] font-ui animate-pulse">
-                    Waiting for login...
-                  </span>
-                )}
-              </button>
+                return (
+                  <div key={id} className="border border-border rounded-lg overflow-hidden">
+                    {/* Broker header — click to expand */}
+                    <button
+                      onClick={() => setExpandedBroker(isExpanded ? null : id)}
+                      className="w-full flex items-center justify-between p-3 bg-elevated
+                                 hover:bg-elevated/80 transition-all text-left"
+                    >
+                      <div className="flex items-center gap-2">
+                        <span className="text-text text-sm font-semibold font-ui">{broker.name}</span>
+                        <span className={`text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded ${broker.badgeColor}`}>
+                          {broker.badge}
+                        </span>
+                        {isConfigured && <span className="text-green text-[10px] font-ui">Keys set</span>}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-muted text-[10px] font-ui">{broker.desc}</span>
+                        <span className="text-muted text-xs">{isExpanded ? '▾' : '▸'}</span>
+                      </div>
+                    </button>
+
+                    {/* Expanded: setup guide + key inputs */}
+                    {isExpanded && (
+                      <div className="p-3 border-t border-border space-y-3 bg-panel">
+
+                        {/* Already configured — just connect */}
+                        {isConfigured ? (
+                          <div className="space-y-2">
+                            <p className="text-green text-xs font-ui">API keys configured. Click to authenticate.</p>
+                            <button
+                              onClick={() => handleBrokerLogin(id)}
+                              disabled={isPolling}
+                              className="px-4 py-2 bg-green/10 text-green border border-green/30 rounded-lg
+                                         text-sm font-ui font-semibold hover:bg-green/20 transition-all
+                                         disabled:opacity-40 w-full"
+                            >
+                              {isPolling ? 'Waiting for login...' : 'Connect'}
+                            </button>
+                          </div>
+                        ) : (
+                          <>
+                            {/* Step-by-step guide */}
+                            <div className="space-y-1.5">
+                              <p className="text-muted text-[10px] font-ui uppercase tracking-wider">Setup Guide</p>
+                              {broker.steps.map((step, i) => (
+                                <p key={i} className="text-muted text-[11px] font-ui flex gap-2">
+                                  <span className="text-amber flex-shrink-0">{i + 1}.</span>
+                                  <span>{step}</span>
+                                </p>
+                              ))}
+                            </div>
+
+                            {/* Open portal link */}
+                            <button
+                              onClick={() => openExternal(broker.portalUrl)}
+                              className="w-full px-3 py-2 bg-amber/10 text-amber border border-amber/30
+                                         rounded-lg text-xs font-ui font-semibold hover:bg-amber/20
+                                         transition-all cursor-pointer"
+                            >
+                              Open {broker.portalLabel} &rarr;
+                            </button>
+
+                            {/* Redirect URL — copyable */}
+                            <div>
+                              <p className="text-muted text-[10px] font-ui mb-1">Redirect URL (copy this exactly):</p>
+                              <CopyableCode text={broker.redirectUrl} />
+                            </div>
+
+                            {/* API key inputs */}
+                            <div className="space-y-2">
+                              {broker.keys.map((key) => (
+                                <input
+                                  key={key.env}
+                                  data-broker={id}
+                                  data-key={key.env}
+                                  type={key.secret ? 'password' : 'text'}
+                                  placeholder={key.label + ': ' + key.placeholder}
+                                  className="w-full bg-elevated border border-border rounded-lg px-3 py-2
+                                             text-text text-sm font-mono placeholder:text-subtle
+                                             focus:outline-none focus:border-amber"
+                                />
+                              ))}
+                            </div>
+
+                            {/* Save & Connect */}
+                            <button
+                              onClick={() => handleSaveBrokerKeys(id)}
+                              disabled={isPolling}
+                              className="w-full px-4 py-2 bg-green/10 text-green border border-green/30
+                                         rounded-lg text-sm font-ui font-semibold hover:bg-green/20
+                                         transition-all disabled:opacity-40"
+                            >
+                              {isPolling ? 'Waiting for login...' : 'Save & Connect'}
+                            </button>
+                          </>
+                        )}
+
+                        {isPolling && (
+                          <p className="text-amber text-[10px] font-ui animate-pulse text-center">
+                            Complete the login in your browser...
+                          </p>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           )}
         </div>
       </div>
 
-      <div className="flex justify-between max-w-lg mx-auto w-full mt-auto">
+      {/* Navigation */}
+      <div className="flex justify-between max-w-xl mx-auto w-full">
         {!brokerConnected && !brokerPolling && (
           <span className="text-muted text-[11px] font-ui self-center">
             You can connect a broker later from Settings
@@ -229,6 +376,33 @@ export default function MarketDataStep({ formData, setFormData, onNext, port }) 
           </button>
         </div>
       </div>
+    </div>
+  )
+}
+
+// ── Copyable code block ──────────────────────────────────────
+
+function CopyableCode({ text }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <code className="flex-1 bg-elevated text-amber text-[11px] font-mono px-3 py-2 rounded border border-border truncate">
+        {text}
+      </code>
+      <button
+        onClick={handleCopy}
+        className="text-muted hover:text-text text-xs px-2 py-2 border border-border rounded
+                   transition-colors cursor-pointer flex-shrink-0"
+      >
+        {copied ? 'Copied' : 'Copy'}
+      </button>
     </div>
   )
 }

--- a/macos-app/src/renderer/src/components/Onboarding/MarketDataStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/MarketDataStep.jsx
@@ -1,0 +1,234 @@
+import { useState, useEffect, useRef } from 'react'
+
+export default function MarketDataStep({ formData, setFormData, onNext, port }) {
+  const [newsKey, setNewsKey] = useState('')
+  const [newsTesting, setNewsTesting] = useState(false)
+  const [newsResult, setNewsResult] = useState(null)
+  const [newsSaved, setNewsSaved] = useState(formData.newsApiSet || false)
+  const [brokerPolling, setBrokerPolling] = useState(null)
+  const [brokerConnected, setBrokerConnected] = useState(formData.brokerName || '')
+  const pollRef = useRef(null)
+
+  const base = `http://127.0.0.1:${port}`
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [])
+
+  const handleTestNews = async () => {
+    setNewsTesting(true)
+    setNewsResult(null)
+    try {
+      const res = await fetch(`${base}/api/onboarding/test-newsapi`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: newsKey }),
+      })
+      const data = await res.json()
+      setNewsResult(data)
+      if (data.ok) {
+        await fetch(`${base}/api/onboarding/credential`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: 'NEWSAPI_KEY', value: newsKey }),
+        })
+        setNewsSaved(true)
+        setFormData((prev) => ({ ...prev, newsApiSet: true }))
+      }
+    } catch (err) {
+      setNewsResult({ ok: false, error: err.message })
+    } finally {
+      setNewsTesting(false)
+    }
+  }
+
+  const handleBrokerLogin = (broker) => {
+    setBrokerPolling(broker)
+    const url = `http://127.0.0.1:${port}/${broker}/login`
+    if (window.electronAPI?.openExternal) {
+      window.electronAPI.openExternal(url)
+    } else {
+      window.open(url, '_blank')
+    }
+
+    if (pollRef.current) clearInterval(pollRef.current)
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(`${base}/api/status`)
+        const data = await res.json()
+        if (data[broker]?.authenticated) {
+          clearInterval(pollRef.current)
+          pollRef.current = null
+          setBrokerPolling(null)
+          setBrokerConnected(broker)
+          setFormData((prev) => ({ ...prev, brokerName: broker }))
+        }
+      } catch {
+        // keep polling
+      }
+    }, 2000)
+  }
+
+  const handleGetFreeKey = () => {
+    const url = 'https://newsapi.org/register'
+    if (window.electronAPI?.openExternal) {
+      window.electronAPI.openExternal(url)
+    } else {
+      window.open(url, '_blank')
+    }
+  }
+
+  const canProceed = newsSaved
+
+  return (
+    <div className="flex flex-col flex-1 gap-6 animate-fade-slide">
+      <div className="text-center">
+        <h2 className="text-text text-lg font-semibold font-ui">Market Data</h2>
+        <p className="text-muted text-xs font-ui mt-1">
+          Connect news and broker data sources
+        </p>
+      </div>
+
+      <div className="max-w-lg mx-auto w-full space-y-6">
+        {/* NewsAPI Section */}
+        <div className="bg-panel border border-border rounded-lg p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-text text-sm font-semibold font-ui">NewsAPI</h3>
+              <p className="text-muted text-[11px] font-ui">Required for AI news analysis</p>
+            </div>
+            {newsSaved && <span className="text-green text-xs font-ui font-semibold">Configured</span>}
+          </div>
+
+          {!newsSaved && (
+            <>
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  placeholder="Enter NewsAPI key"
+                  value={newsKey}
+                  onChange={(e) => {
+                    setNewsKey(e.target.value)
+                    setNewsResult(null)
+                  }}
+                  className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2
+                             text-text text-sm font-mono placeholder:text-subtle
+                             focus:outline-none focus:border-amber"
+                />
+                <button
+                  onClick={handleTestNews}
+                  disabled={!newsKey || newsTesting}
+                  className="px-3 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
+                             text-xs font-ui font-semibold hover:bg-amber/20 transition-all
+                             disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {newsTesting ? 'Testing...' : 'Test'}
+                </button>
+              </div>
+              <button
+                onClick={handleGetFreeKey}
+                className="text-amber text-[11px] font-ui hover:underline"
+              >
+                Get a free key at newsapi.org &rarr;
+              </button>
+              {newsResult && (
+                <p className={`text-xs font-ui ${newsResult.ok ? 'text-green' : 'text-red'}`}>
+                  {newsResult.ok ? 'NewsAPI key is valid' : newsResult.error}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Broker Section */}
+        <div className="bg-panel border border-border rounded-lg p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-text text-sm font-semibold font-ui">Broker (Optional)</h3>
+              <p className="text-muted text-[11px] font-ui">Connect for live market data and execution</p>
+            </div>
+            {brokerConnected && (
+              <span className="text-green text-xs font-ui font-semibold capitalize">
+                {brokerConnected} connected
+              </span>
+            )}
+          </div>
+
+          <div className="bg-elevated border border-border rounded-lg p-3">
+            <p className="text-muted text-[11px] font-ui leading-relaxed">
+              Without a broker, you get delayed data and paper trading.
+              Connect a broker for real-time data and live execution.
+            </p>
+          </div>
+
+          {!brokerConnected && (
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={() => handleBrokerLogin('fyers')}
+                disabled={brokerPolling === 'fyers'}
+                className="flex flex-col items-start gap-1 p-3 rounded-lg border border-border
+                           bg-elevated hover:border-subtle transition-all text-left
+                           disabled:opacity-60"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-text text-sm font-semibold font-ui">Fyers</span>
+                  <span className="text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded bg-green/20 text-green">
+                    Free
+                  </span>
+                </div>
+                <span className="text-muted text-[10px] font-ui">Best options data</span>
+                {brokerPolling === 'fyers' && (
+                  <span className="text-amber text-[10px] font-ui animate-pulse">
+                    Waiting for login...
+                  </span>
+                )}
+              </button>
+
+              <button
+                onClick={() => handleBrokerLogin('zerodha')}
+                disabled={brokerPolling === 'zerodha'}
+                className="flex flex-col items-start gap-1 p-3 rounded-lg border border-border
+                           bg-elevated hover:border-subtle transition-all text-left
+                           disabled:opacity-60"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-text text-sm font-semibold font-ui">Zerodha</span>
+                  <span className="text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded bg-blue/20 text-blue">
+                    Paid
+                  </span>
+                </div>
+                <span className="text-muted text-[10px] font-ui">Free personal plan</span>
+                {brokerPolling === 'zerodha' && (
+                  <span className="text-amber text-[10px] font-ui animate-pulse">
+                    Waiting for login...
+                  </span>
+                )}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-between max-w-lg mx-auto w-full mt-auto">
+        {!brokerConnected && !brokerPolling && (
+          <span className="text-muted text-[11px] font-ui self-center">
+            You can connect a broker later from Settings
+          </span>
+        )}
+        <div className="ml-auto">
+          <button
+            onClick={onNext}
+            disabled={!canProceed}
+            className="px-6 py-2 bg-amber text-surface font-ui font-semibold text-sm rounded-lg
+                       hover:brightness-110 transition-all active:scale-95
+                       disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Onboarding/OnboardingWizard.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/OnboardingWizard.jsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import StepIndicator from './StepIndicator'
+import WelcomeStep from './WelcomeStep'
+import ProviderStep from './ProviderStep'
+import MarketDataStep from './MarketDataStep'
+import TradingSettingsStep from './TradingSettingsStep'
+import CompletionStep from './CompletionStep'
+
+const TOTAL_STEPS = 5
+
+export default function OnboardingWizard({ port, onComplete }) {
+  const [step, setStep] = useState(0)
+  const [completing, setCompleting] = useState(false)
+  const [formData, setFormData] = useState({
+    aiProvider: '',
+    newsApiSet: false,
+    brokerName: '',
+    capital: 200000,
+    riskPct: 2,
+    tradingMode: 'PAPER',
+  })
+
+  const base = `http://127.0.0.1:${port}`
+
+  const handleComplete = async () => {
+    setCompleting(true)
+    try {
+      await fetch(`${base}/api/onboarding/complete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          capital: formData.capital || 200000,
+          risk_pct: formData.riskPct || 2,
+          trading_mode: formData.tradingMode || 'PAPER',
+        }),
+      })
+      onComplete()
+    } catch (err) {
+      console.error('Failed to complete onboarding:', err)
+      setCompleting(false)
+    }
+  }
+
+  const next = () => setStep((s) => Math.min(s + 1, TOTAL_STEPS - 1))
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
+        return <WelcomeStep onNext={next} />
+      case 1:
+        return (
+          <ProviderStep
+            formData={formData}
+            setFormData={setFormData}
+            onNext={next}
+            port={port}
+          />
+        )
+      case 2:
+        return (
+          <MarketDataStep
+            formData={formData}
+            setFormData={setFormData}
+            onNext={next}
+            port={port}
+          />
+        )
+      case 3:
+        return (
+          <TradingSettingsStep
+            formData={formData}
+            setFormData={setFormData}
+            onNext={next}
+          />
+        )
+      case 4:
+        return (
+          <CompletionStep
+            formData={formData}
+            onComplete={handleComplete}
+            completing={completing}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-surface">
+      {/* Draggable title bar */}
+      <div className="drag h-[52px] flex items-center justify-center flex-shrink-0 bg-panel border-b border-border">
+        <div className="w-[76px] flex-shrink-0" />
+        <div className="flex-1 flex items-center justify-center gap-2 pointer-events-none">
+          <span className="text-amber text-[15px]">&#9670;</span>
+          <span className="text-text text-[13px] font-semibold tracking-wide font-ui">
+            India Trade
+          </span>
+        </div>
+        <div className="w-[76px] flex-shrink-0" />
+      </div>
+
+      {/* Step indicator */}
+      <StepIndicator current={step} total={TOTAL_STEPS} />
+
+      {/* Step content */}
+      <div className="flex-1 flex flex-col px-8 pb-8 overflow-y-auto">
+        {renderStep()}
+      </div>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Onboarding/ProviderStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/ProviderStep.jsx
@@ -183,49 +183,16 @@ export default function ProviderStep({ formData, setFormData, onNext, port }) {
               )}
             </>
           ) : (
-            <div className="space-y-3">
-              {provider.setupHint && (
-                <div className="bg-elevated border border-border rounded-lg px-3 py-2">
-                  <code className="text-amber text-xs font-mono">{provider.setupHint}</code>
-                </div>
-              )}
-              {provider.id === 'claude_subscription' ? (
-                <button
-                  onClick={async () => {
-                    // For Claude subscription, just save the provider — no test needed
-                    await fetch(`${base}/api/onboarding/credential`, {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ key: 'AI_PROVIDER', value: 'claude_subscription' }),
-                    })
-                    setSaved(true)
-                    setFormData((prev) => ({ ...prev, aiProvider: 'claude_subscription' }))
-                    setTestResult({ ok: true, message: 'Claude subscription selected' })
-                  }}
-                  disabled={saved}
-                  className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
-                             text-sm font-ui font-semibold hover:bg-amber/20 transition-all
-                             disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  {saved ? 'Selected' : 'Use Claude Subscription'}
-                </button>
-              ) : (
-                <button
-                  onClick={handleTest}
-                  disabled={testing}
-                  className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
-                             text-sm font-ui font-semibold hover:bg-amber/20 transition-all
-                             disabled:opacity-40 disabled:cursor-not-allowed"
-                >
-                  {testing ? 'Testing...' : 'Test Connection'}
-                </button>
-              )}
-              {testResult && (
-                <p className={`text-xs font-ui ${testResult.ok ? 'text-green' : 'text-red'}`}>
-                  {testResult.ok ? testResult.message : testResult.error}
-                </p>
-              )}
-            </div>
+            <SetupRunner
+              provider={provider}
+              base={base}
+              onComplete={() => {
+                setSaved(true)
+                setFormData((prev) => ({ ...prev, aiProvider: provider.id }))
+                setTestResult({ ok: true, message: `${provider.name} configured` })
+              }}
+              saved={saved}
+            />
           )}
         </div>
       )}
@@ -241,6 +208,187 @@ export default function ProviderStep({ formData, setFormData, onNext, port }) {
           Next
         </button>
       </div>
+    </div>
+  )
+}
+
+// ── Built-in setup runner for Ollama / Claude subscription ─────
+
+function SetupRunner({ provider, base, onComplete, saved }) {
+  const [steps, setSteps] = useState([])       // [{label, status, output}]
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState(null)
+
+  const addStep = (label, status = 'pending') => {
+    setSteps(prev => [...prev, { label, status, output: '' }])
+    return prev => prev.length // index
+  }
+
+  const updateStep = (index, update) => {
+    setSteps(prev => prev.map((s, i) => i === index ? { ...s, ...update } : s))
+  }
+
+  const callSetup = async (step) => {
+    const res = await fetch(`${base}/api/onboarding/setup-provider`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: provider.id, step }),
+    })
+    return res.json()
+  }
+
+  const saveProvider = async () => {
+    await fetch(`${base}/api/onboarding/credential`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: 'AI_PROVIDER', value: provider.id }),
+    })
+  }
+
+  const runSetup = async () => {
+    setRunning(true)
+    setError(null)
+    setSteps([])
+
+    try {
+      if (provider.id === 'ollama') {
+        // Step 1: Check
+        setSteps([{ label: 'Checking if Ollama is installed...', status: 'running', output: '' }])
+        const check = await callSetup('check')
+
+        if (!check.installed) {
+          updateStep(0, { status: 'done', output: 'Not installed' })
+          // Step 2: Install
+          setSteps(prev => [...prev, { label: 'Installing Ollama via Homebrew...', status: 'running', output: '' }])
+          const install = await callSetup('install')
+          if (!install.ok) {
+            updateStep(1, { status: 'error', output: install.error })
+            if (install.download_url) {
+              setError({ message: install.error, downloadUrl: install.download_url })
+            }
+            setRunning(false)
+            return
+          }
+          updateStep(1, { status: 'done', output: install.output || 'Installed' })
+        } else {
+          updateStep(0, { status: 'done', output: check.message })
+        }
+
+        // Step 3: Start if needed
+        if (!check.running) {
+          setSteps(prev => [...prev, { label: 'Starting Ollama server...', status: 'running', output: '' }])
+          const start = await callSetup('start')
+          const idx = steps.length // approximate
+          setSteps(prev => prev.map((s, i) => i === prev.length - 1 ? { ...s, status: start.ok ? 'done' : 'error', output: start.message || start.error } : s))
+          if (!start.ok) { setRunning(false); return }
+        }
+
+        // Step 4: Pull model
+        const recheck = await callSetup('check')
+        if (!recheck.models || recheck.models.length === 0) {
+          setSteps(prev => [...prev, { label: 'Downloading llama3.1 (~4GB)...', status: 'running', output: 'This may take a few minutes' }])
+          const pull = await callSetup('pull_model')
+          setSteps(prev => prev.map((s, i) => i === prev.length - 1 ? { ...s, status: pull.ok ? 'done' : 'error', output: pull.ok ? 'Model ready' : pull.error } : s))
+          if (!pull.ok) { setRunning(false); return }
+        }
+
+        await saveProvider()
+        setSteps(prev => [...prev, { label: 'Ollama configured', status: 'done', output: '' }])
+        onComplete()
+
+      } else if (provider.id === 'claude_subscription') {
+        // Step 1: Check
+        setSteps([{ label: 'Checking for Claude CLI...', status: 'running', output: '' }])
+        const check = await callSetup('check')
+
+        if (!check.installed) {
+          updateStep(0, { status: 'done', output: 'Not installed' })
+          // Step 2: Install
+          setSteps(prev => [...prev, { label: 'Installing Claude CLI via npm...', status: 'running', output: '' }])
+          const install = await callSetup('install')
+          if (!install.ok) {
+            updateStep(1, { status: 'error', output: install.error })
+            setRunning(false)
+            return
+          }
+          updateStep(1, { status: 'done', output: 'Claude CLI installed' })
+
+          if (install.needs_login) {
+            setSteps(prev => [...prev, {
+              label: 'Run "claude login" in your terminal to authenticate',
+              status: 'waiting',
+              output: 'Open a terminal window and run: claude login'
+            }])
+          }
+        } else {
+          updateStep(0, { status: 'done', output: check.message })
+        }
+
+        await saveProvider()
+        setSteps(prev => [...prev, { label: 'Claude subscription configured', status: 'done', output: '' }])
+        onComplete()
+      }
+    } catch (err) {
+      setError({ message: err.message })
+    }
+    setRunning(false)
+  }
+
+  if (saved) {
+    return (
+      <div className="space-y-2">
+        <p className="text-green text-xs font-ui">Setup complete</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Setup steps output */}
+      {steps.length > 0 && (
+        <div className="bg-elevated border border-border rounded-lg p-3 space-y-2 max-h-48 overflow-y-auto">
+          {steps.map((step, i) => (
+            <div key={i} className="flex items-start gap-2 text-xs font-mono">
+              <span className="flex-shrink-0 mt-0.5">
+                {step.status === 'running' ? '...' :
+                 step.status === 'done' ? <span className="text-green">ok</span> :
+                 step.status === 'waiting' ? <span className="text-amber">!</span> :
+                 step.status === 'error' ? <span className="text-red">x</span> :
+                 <span className="text-muted">-</span>}
+              </span>
+              <div>
+                <span className="text-text">{step.label}</span>
+                {step.output && (
+                  <p className="text-muted text-[10px] mt-0.5">{step.output}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Error with download link */}
+      {error?.downloadUrl && (
+        <button
+          onClick={() => window.electronAPI?.openExternal(error.downloadUrl)}
+          className="text-xs text-amber underline font-ui cursor-pointer"
+        >
+          Download Ollama manually from ollama.com
+        </button>
+      )}
+
+      {/* Run button */}
+      {!saved && (
+        <button
+          onClick={runSetup}
+          disabled={running}
+          className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
+                     text-sm font-ui font-semibold hover:bg-amber/20 transition-all
+                     disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {running ? 'Setting up...' : steps.length > 0 ? 'Retry Setup' : 'Set Up Automatically'}
+        </button>
+      )}
     </div>
   )
 }

--- a/macos-app/src/renderer/src/components/Onboarding/ProviderStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/ProviderStep.jsx
@@ -1,0 +1,206 @@
+import { useState } from 'react'
+
+const PROVIDERS = [
+  {
+    id: 'gemini',
+    name: 'Google Gemini',
+    badge: 'Free',
+    badgeColor: 'bg-green/20 text-green',
+    desc: 'Free tier at aistudio.google.com',
+    keyEnv: 'GEMINI_API_KEY',
+    needsKey: true,
+  },
+  {
+    id: 'anthropic',
+    name: 'Claude API',
+    badge: 'API',
+    badgeColor: 'bg-blue/20 text-blue',
+    desc: 'Anthropic Claude - pay per token',
+    keyEnv: 'ANTHROPIC_API_KEY',
+    needsKey: true,
+  },
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    badge: 'API',
+    badgeColor: 'bg-green/20 text-green',
+    desc: 'GPT-4o and compatible endpoints',
+    keyEnv: 'OPENAI_API_KEY',
+    needsKey: true,
+  },
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    badge: 'Free',
+    badgeColor: 'bg-green/20 text-green',
+    desc: 'Local models - no API key needed',
+    keyEnv: null,
+    needsKey: false,
+  },
+]
+
+export default function ProviderStep({ formData, setFormData, onNext, port }) {
+  const [selected, setSelected] = useState(formData.aiProvider || '')
+  const [apiKey, setApiKey] = useState('')
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState(null)
+  const [saved, setSaved] = useState(false)
+
+  const base = `http://127.0.0.1:${port}`
+
+  const provider = PROVIDERS.find((p) => p.id === selected)
+
+  const handleTest = async () => {
+    if (!provider) return
+    setTesting(true)
+    setTestResult(null)
+    try {
+      const res = await fetch(`${base}/api/onboarding/test-provider`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          provider: provider.id,
+          api_key: apiKey,
+          model: '',
+        }),
+      })
+      const data = await res.json()
+      setTestResult(data)
+      if (data.ok) {
+        // Save AI_PROVIDER
+        await fetch(`${base}/api/onboarding/credential`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: 'AI_PROVIDER', value: provider.id }),
+        })
+        // Save the API key if applicable
+        if (provider.keyEnv && apiKey) {
+          await fetch(`${base}/api/onboarding/credential`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ key: provider.keyEnv, value: apiKey }),
+          })
+        }
+        setSaved(true)
+        setFormData((prev) => ({ ...prev, aiProvider: provider.id }))
+      }
+    } catch (err) {
+      setTestResult({ ok: false, error: err.message })
+    } finally {
+      setTesting(false)
+    }
+  }
+
+  const handleSelect = (id) => {
+    setSelected(id)
+    setApiKey('')
+    setTestResult(null)
+    setSaved(false)
+  }
+
+  const canProceed = saved || formData.aiProvider
+
+  return (
+    <div className="flex flex-col flex-1 gap-6 animate-fade-slide">
+      <div className="text-center">
+        <h2 className="text-text text-lg font-semibold font-ui">Choose AI Provider</h2>
+        <p className="text-muted text-xs font-ui mt-1">
+          Powers market analysis, strategy generation, and trade signals
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 max-w-lg mx-auto w-full">
+        {PROVIDERS.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => handleSelect(p.id)}
+            className={`relative flex flex-col items-start gap-1.5 p-4 rounded-lg border transition-all text-left
+              ${
+                selected === p.id
+                  ? 'border-amber bg-amber/5'
+                  : 'border-border bg-panel hover:border-subtle'
+              }`}
+          >
+            <div className="flex items-center gap-2 w-full">
+              <span className="text-text text-sm font-semibold font-ui">{p.name}</span>
+              <span className={`text-[10px] font-ui font-semibold px-1.5 py-0.5 rounded ${p.badgeColor}`}>
+                {p.badge}
+              </span>
+            </div>
+            <span className="text-muted text-[11px] font-ui leading-snug">{p.desc}</span>
+          </button>
+        ))}
+      </div>
+
+      {selected && provider && (
+        <div className="max-w-lg mx-auto w-full space-y-3">
+          {provider.needsKey ? (
+            <>
+              <div className="flex gap-2">
+                <input
+                  type="password"
+                  placeholder={`Enter ${provider.name} API key`}
+                  value={apiKey}
+                  onChange={(e) => {
+                    setApiKey(e.target.value)
+                    setTestResult(null)
+                    setSaved(false)
+                  }}
+                  className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2
+                             text-text text-sm font-mono placeholder:text-subtle
+                             focus:outline-none focus:border-amber"
+                />
+                <button
+                  onClick={handleTest}
+                  disabled={!apiKey || testing}
+                  className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
+                             text-sm font-ui font-semibold hover:bg-amber/20 transition-all
+                             disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {testing ? 'Testing...' : 'Test Key'}
+                </button>
+              </div>
+              {testResult && (
+                <p className={`text-xs font-ui ${testResult.ok ? 'text-green' : 'text-red'}`}>
+                  {testResult.ok ? testResult.message : testResult.error}
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="space-y-3">
+              <p className="text-muted text-xs font-ui">
+                Make sure Ollama is running locally (ollama serve)
+              </p>
+              <button
+                onClick={handleTest}
+                disabled={testing}
+                className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
+                           text-sm font-ui font-semibold hover:bg-amber/20 transition-all
+                           disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {testing ? 'Testing...' : 'Test Connection'}
+              </button>
+              {testResult && (
+                <p className={`text-xs font-ui ${testResult.ok ? 'text-green' : 'text-red'}`}>
+                  {testResult.ok ? testResult.message : testResult.error}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex justify-end max-w-lg mx-auto w-full mt-auto">
+        <button
+          onClick={onNext}
+          disabled={!canProceed}
+          className="px-6 py-2 bg-amber text-surface font-ui font-semibold text-sm rounded-lg
+                     hover:brightness-110 transition-all active:scale-95
+                     disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Onboarding/ProviderStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/ProviderStep.jsx
@@ -8,6 +8,7 @@ const PROVIDERS = [
     badgeColor: 'bg-green/20 text-green',
     desc: 'Free tier at aistudio.google.com',
     keyEnv: 'GEMINI_API_KEY',
+    keyLabel: 'Gemini API key',
     needsKey: true,
   },
   {
@@ -15,9 +16,21 @@ const PROVIDERS = [
     name: 'Claude API',
     badge: 'API',
     badgeColor: 'bg-blue/20 text-blue',
-    desc: 'Anthropic Claude - pay per token',
+    desc: 'Anthropic Claude — pay per token',
     keyEnv: 'ANTHROPIC_API_KEY',
+    keyLabel: 'Anthropic API key',
     needsKey: true,
+  },
+  {
+    id: 'claude_subscription',
+    name: 'Claude Pro/Max',
+    badge: 'Free*',
+    badgeColor: 'bg-blue/20 text-blue',
+    desc: 'Uses your Claude subscription — no API key',
+    keyEnv: null,
+    keyLabel: null,
+    needsKey: false,
+    setupHint: 'Requires: npm i -g @anthropic-ai/claude-code && claude login',
   },
   {
     id: 'openai',
@@ -26,6 +39,7 @@ const PROVIDERS = [
     badgeColor: 'bg-green/20 text-green',
     desc: 'GPT-4o and compatible endpoints',
     keyEnv: 'OPENAI_API_KEY',
+    keyLabel: 'OpenAI API key',
     needsKey: true,
   },
   {
@@ -33,9 +47,11 @@ const PROVIDERS = [
     name: 'Ollama',
     badge: 'Free',
     badgeColor: 'bg-green/20 text-green',
-    desc: 'Local models - no API key needed',
+    desc: 'Local models — no API key needed',
     keyEnv: null,
+    keyLabel: null,
     needsKey: false,
+    setupHint: 'Requires: brew install ollama && ollama pull llama3.1',
   },
 ]
 
@@ -109,7 +125,7 @@ export default function ProviderStep({ formData, setFormData, onNext, port }) {
         </p>
       </div>
 
-      <div className="grid grid-cols-2 gap-3 max-w-lg mx-auto w-full">
+      <div className="grid grid-cols-2 gap-3 max-w-xl mx-auto w-full">
         {PROVIDERS.map((p) => (
           <button
             key={p.id}
@@ -168,18 +184,42 @@ export default function ProviderStep({ formData, setFormData, onNext, port }) {
             </>
           ) : (
             <div className="space-y-3">
-              <p className="text-muted text-xs font-ui">
-                Make sure Ollama is running locally (ollama serve)
-              </p>
-              <button
-                onClick={handleTest}
-                disabled={testing}
-                className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
-                           text-sm font-ui font-semibold hover:bg-amber/20 transition-all
-                           disabled:opacity-40 disabled:cursor-not-allowed"
-              >
-                {testing ? 'Testing...' : 'Test Connection'}
-              </button>
+              {provider.setupHint && (
+                <div className="bg-elevated border border-border rounded-lg px-3 py-2">
+                  <code className="text-amber text-xs font-mono">{provider.setupHint}</code>
+                </div>
+              )}
+              {provider.id === 'claude_subscription' ? (
+                <button
+                  onClick={async () => {
+                    // For Claude subscription, just save the provider — no test needed
+                    await fetch(`${base}/api/onboarding/credential`, {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ key: 'AI_PROVIDER', value: 'claude_subscription' }),
+                    })
+                    setSaved(true)
+                    setFormData((prev) => ({ ...prev, aiProvider: 'claude_subscription' }))
+                    setTestResult({ ok: true, message: 'Claude subscription selected' })
+                  }}
+                  disabled={saved}
+                  className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
+                             text-sm font-ui font-semibold hover:bg-amber/20 transition-all
+                             disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {saved ? 'Selected' : 'Use Claude Subscription'}
+                </button>
+              ) : (
+                <button
+                  onClick={handleTest}
+                  disabled={testing}
+                  className="px-4 py-2 bg-amber/10 text-amber border border-amber/30 rounded-lg
+                             text-sm font-ui font-semibold hover:bg-amber/20 transition-all
+                             disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {testing ? 'Testing...' : 'Test Connection'}
+                </button>
+              )}
               {testResult && (
                 <p className={`text-xs font-ui ${testResult.ok ? 'text-green' : 'text-red'}`}>
                   {testResult.ok ? testResult.message : testResult.error}

--- a/macos-app/src/renderer/src/components/Onboarding/StepIndicator.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/StepIndicator.jsx
@@ -1,0 +1,17 @@
+export default function StepIndicator({ current, total = 5 }) {
+  return (
+    <div className="flex items-center gap-2 justify-center py-4">
+      {Array.from({ length: total }, (_, i) => {
+        let cls = 'w-2 h-2 rounded-full transition-all duration-300'
+        if (i < current) {
+          cls += ' bg-green'
+        } else if (i === current) {
+          cls += ' bg-amber w-3 h-3'
+        } else {
+          cls += ' bg-subtle'
+        }
+        return <span key={i} className={cls} />
+      })}
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Onboarding/TradingSettingsStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/TradingSettingsStep.jsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+
+export default function TradingSettingsStep({ formData, setFormData, onNext }) {
+  const [capital, setCapital] = useState(formData.capital || 200000)
+  const [riskPct, setRiskPct] = useState(formData.riskPct || 2)
+  const [mode, setMode] = useState(formData.tradingMode || 'PAPER')
+
+  const handleNext = () => {
+    setFormData((prev) => ({
+      ...prev,
+      capital,
+      riskPct,
+      tradingMode: mode,
+    }))
+    onNext()
+  }
+
+  return (
+    <div className="flex flex-col flex-1 gap-6 animate-fade-slide">
+      <div className="text-center">
+        <h2 className="text-text text-lg font-semibold font-ui">Trading Settings</h2>
+        <p className="text-muted text-xs font-ui mt-1">
+          Configure your capital and risk parameters
+        </p>
+      </div>
+
+      <div className="max-w-md mx-auto w-full space-y-5">
+        {/* Capital */}
+        <div className="space-y-2">
+          <label className="text-text text-sm font-ui font-semibold block">
+            Trading Capital (INR)
+          </label>
+          <input
+            type="number"
+            value={capital}
+            onChange={(e) => setCapital(Number(e.target.value) || 0)}
+            min={0}
+            step={10000}
+            className="w-full bg-elevated border border-border rounded-lg px-3 py-2.5
+                       text-text text-sm font-mono
+                       focus:outline-none focus:border-amber"
+          />
+          <p className="text-muted text-[11px] font-ui">
+            Total capital allocated for trading. Used for position sizing.
+          </p>
+        </div>
+
+        {/* Risk */}
+        <div className="space-y-2">
+          <label className="text-text text-sm font-ui font-semibold block">
+            Risk Per Trade (%)
+          </label>
+          <input
+            type="number"
+            value={riskPct}
+            onChange={(e) => setRiskPct(Number(e.target.value) || 0)}
+            min={0.1}
+            max={10}
+            step={0.5}
+            className="w-full bg-elevated border border-border rounded-lg px-3 py-2.5
+                       text-text text-sm font-mono
+                       focus:outline-none focus:border-amber"
+          />
+          <p className="text-muted text-[11px] font-ui">
+            Maximum percentage of capital risked per trade. 1-2% recommended.
+          </p>
+        </div>
+
+        {/* Trading Mode */}
+        <div className="space-y-2">
+          <label className="text-text text-sm font-ui font-semibold block">
+            Trading Mode
+          </label>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setMode('PAPER')}
+              className={`flex-1 py-2.5 rounded-lg border text-sm font-ui font-semibold transition-all
+                ${
+                  mode === 'PAPER'
+                    ? 'border-amber bg-amber/10 text-amber'
+                    : 'border-border bg-elevated text-muted hover:border-subtle'
+                }`}
+            >
+              Paper Trading
+            </button>
+            <button
+              onClick={() => setMode('LIVE')}
+              className={`flex-1 py-2.5 rounded-lg border text-sm font-ui font-semibold transition-all
+                ${
+                  mode === 'LIVE'
+                    ? 'border-red bg-red/10 text-red'
+                    : 'border-border bg-elevated text-muted hover:border-subtle'
+                }`}
+            >
+              Live Trading
+            </button>
+          </div>
+          {mode === 'LIVE' && (
+            <p className="text-red text-[11px] font-ui">
+              Live mode executes real trades with real money. Make sure your broker is connected and you understand the risks.
+            </p>
+          )}
+          {mode === 'PAPER' && (
+            <p className="text-muted text-[11px] font-ui">
+              Paper mode simulates trades without real money. Recommended for getting started.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-end max-w-md mx-auto w-full mt-auto">
+        <button
+          onClick={handleNext}
+          className="px-6 py-2 bg-amber text-surface font-ui font-semibold text-sm rounded-lg
+                     hover:brightness-110 transition-all active:scale-95"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Onboarding/WelcomeStep.jsx
+++ b/macos-app/src/renderer/src/components/Onboarding/WelcomeStep.jsx
@@ -1,0 +1,21 @@
+export default function WelcomeStep({ onNext }) {
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 gap-6 animate-fade-slide">
+      <span className="text-amber text-6xl leading-none">&#9670;</span>
+      <h1 className="text-text text-2xl font-semibold font-ui tracking-wide">
+        Welcome to India Trade
+      </h1>
+      <p className="text-muted text-sm font-ui max-w-md text-center leading-relaxed">
+        AI-powered trading terminal for Indian markets.
+        NSE, BSE, and F&amp;O with real-time data, AI analysis, and automated strategies.
+      </p>
+      <button
+        onClick={onNext}
+        className="mt-4 px-8 py-2.5 bg-amber text-surface font-ui font-semibold text-sm rounded-lg
+                   hover:brightness-110 transition-all active:scale-95"
+      >
+        Get Started
+      </button>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/SetupScreen.jsx
+++ b/macos-app/src/renderer/src/components/SetupScreen.jsx
@@ -1,0 +1,172 @@
+import { useState } from 'react'
+
+export default function SetupScreen({ phase, data }) {
+  const [showDetails, setShowDetails] = useState(false)
+
+  return (
+    <div className="h-screen w-screen bg-[#0d0d0d] flex flex-col items-center justify-center px-8 text-center select-none"
+         style={{ WebkitAppRegion: 'drag' }}>
+
+      {/* Logo */}
+      <div className="mb-8">
+        <span className="text-4xl">◆</span>
+        <h1 className="text-text text-xl font-semibold mt-2">India Trade</h1>
+      </div>
+
+      {/* Progress state */}
+      {(phase === 'initializing' || phase === 'progress') && (
+        <ProgressView data={data} />
+      )}
+
+      {/* Python missing */}
+      {phase === 'python_missing' && (
+        <PythonMissingView data={data} />
+      )}
+
+      {/* Error */}
+      {phase === 'error' && (
+        <ErrorView data={data} showDetails={showDetails} setShowDetails={setShowDetails} />
+      )}
+    </div>
+  )
+}
+
+// ── Progress ─────────────────────────────────────────────────────
+
+function ProgressView({ data }) {
+  const message = data?.message ?? 'Starting up...'
+  const percent = data?.percent ?? null
+
+  return (
+    <div className="max-w-md w-full space-y-4" style={{ WebkitAppRegion: 'no-drag' }}>
+      <p className="text-muted text-sm font-ui">{message}</p>
+
+      {/* Progress bar */}
+      <div className="w-full bg-border rounded-full h-1.5 overflow-hidden">
+        {percent != null ? (
+          <div
+            className="bg-amber h-full rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${percent}%` }}
+          />
+        ) : (
+          <div className="bg-amber h-full rounded-full w-1/3 animate-pulse" />
+        )}
+      </div>
+
+      {percent != null && (
+        <p className="text-muted text-xs font-mono">{percent}%</p>
+      )}
+
+      <p className="text-muted/50 text-xs font-ui">
+        {data?.stage === 'installing_deps'
+          ? 'This only happens on first launch (~2 min)'
+          : ''}
+      </p>
+    </div>
+  )
+}
+
+// ── Python Missing ───────────────────────────────────────────────
+
+function PythonMissingView({ data }) {
+  const [copied, setCopied] = useState(false)
+
+  function copyBrewCommand() {
+    navigator.clipboard.writeText(data?.brewCommand ?? 'brew install python@3.12')
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="max-w-lg w-full space-y-6" style={{ WebkitAppRegion: 'no-drag' }}>
+      <div>
+        <p className="text-amber text-lg font-semibold">Python 3.11+ Required</p>
+        <p className="text-muted text-sm font-ui mt-2">
+          India Trade needs Python to run its analysis engine. Install it using one of the options below, then click Retry.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3">
+        {/* Option 1: python.org */}
+        <button
+          onClick={() => window.electronAPI?.openExternal(data?.installUrl ?? 'https://www.python.org/downloads/')}
+          className="bg-panel border border-border rounded-lg p-4 text-left hover:border-amber/50 transition-colors cursor-pointer"
+        >
+          <p className="text-text text-sm font-semibold">Download from python.org</p>
+          <p className="text-muted text-xs mt-1">Official installer — works on all Macs</p>
+        </button>
+
+        {/* Option 2: Homebrew */}
+        <div className="bg-panel border border-border rounded-lg p-4">
+          <p className="text-text text-sm font-semibold">Install with Homebrew</p>
+          <div className="flex items-center gap-2 mt-2">
+            <code className="flex-1 bg-elevated text-amber text-xs font-mono px-3 py-2 rounded">
+              {data?.brewCommand ?? 'brew install python@3.12'}
+            </code>
+            <button
+              onClick={copyBrewCommand}
+              className="text-muted hover:text-text text-xs px-2 py-2 border border-border rounded transition-colors cursor-pointer"
+            >
+              {copied ? '✓' : 'Copy'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <button
+        onClick={() => window.electronAPI?.retrySetup()}
+        className="w-full bg-amber/10 border border-amber/30 text-amber text-sm font-ui py-2.5 rounded-lg
+                   hover:bg-amber/20 transition-colors cursor-pointer"
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+// ── Error ────────────────────────────────────────────────────────
+
+function ErrorView({ data, showDetails, setShowDetails }) {
+  return (
+    <div className="max-w-lg w-full space-y-4" style={{ WebkitAppRegion: 'no-drag' }}>
+      <div>
+        <p className="text-red text-lg font-semibold">Setup Failed</p>
+        <p className="text-muted text-sm font-ui mt-2">{data?.message ?? 'An unknown error occurred.'}</p>
+      </div>
+
+      {data?.details && (
+        <div>
+          <button
+            onClick={() => setShowDetails(!showDetails)}
+            className="text-muted text-xs font-ui hover:text-text transition-colors cursor-pointer"
+          >
+            {showDetails ? '▼ Hide details' : '▶ Show details'}
+          </button>
+          {showDetails && (
+            <pre className="mt-2 bg-panel border border-border rounded-lg p-3 text-xs font-mono text-red/80
+                           max-h-48 overflow-y-auto whitespace-pre-wrap">
+              {data.details}
+            </pre>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={() => window.electronAPI?.retrySetup()}
+          className="flex-1 bg-amber/10 border border-amber/30 text-amber text-sm font-ui py-2.5 rounded-lg
+                     hover:bg-amber/20 transition-colors cursor-pointer"
+        >
+          Retry
+        </button>
+        <button
+          onClick={() => window.electronAPI?.resetVenv()}
+          className="flex-1 bg-red/10 border border-red/30 text-red text-sm font-ui py-2.5 rounded-lg
+                     hover:bg-red/20 transition-colors cursor-pointer"
+        >
+          Reset Environment
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/macos-app/src/renderer/src/components/Sidebar/BrokerPanel.jsx
+++ b/macos-app/src/renderer/src/components/Sidebar/BrokerPanel.jsx
@@ -60,10 +60,28 @@ export default function BrokerPanel({ onClose }) {
   const [error, setError] = useState(null)
   const [saving, setSaving] = useState(false)
 
+  const [successBroker, setSuccessBroker] = useState(null)
   const base = `http://127.0.0.1:${port}`
+  const pollRef = { current: null }
 
-  function openLogin(loginPath) {
-    window.electronAPI?.openExternal(`${base}${loginPath}`)
+  function openLoginAndPoll(broker) {
+    window.electronAPI?.openExternal(`${base}${broker.loginPath}`)
+    // Poll for auth completion
+    if (pollRef.current) clearInterval(pollRef.current)
+    pollRef.current = setInterval(async () => {
+      try {
+        const res = await fetch(`${base}/api/status`)
+        const data = await res.json()
+        setBrokerStatuses(data)
+        if (data[broker.key]?.authenticated) {
+          clearInterval(pollRef.current)
+          pollRef.current = null
+          setExpandedBroker(null)
+          setSuccessBroker(broker.name)
+          setTimeout(() => onClose(), 1500)
+        }
+      } catch {}
+    }, 2000)
   }
 
   async function disconnect(brokerKey) {
@@ -104,7 +122,7 @@ export default function BrokerPanel({ onClose }) {
       // Refresh status then login
       const res = await fetch(`${base}/api/status`)
       setBrokerStatuses(await res.json())
-      openLogin(broker.loginPath)
+      openLoginAndPoll(broker)
     } catch (e) {
       setError(e.message)
     }
@@ -157,7 +175,7 @@ export default function BrokerPanel({ onClose }) {
                   </button>
                 ) : status.configured ? (
                   <button
-                    onClick={() => openLogin(broker.loginPath)}
+                    onClick={() => openLoginAndPoll(broker)}
                     className="text-[11px] font-ui px-2.5 py-1 rounded-md border border-green/30
                                text-green hover:bg-green/10 transition-colors cursor-pointer"
                   >
@@ -236,10 +254,17 @@ export default function BrokerPanel({ onClose }) {
 
       {/* Footer */}
       <div className="px-4 py-3 border-t border-border flex-shrink-0 space-y-1.5">
+        {successBroker && (
+          <p className="text-green text-sm font-ui font-semibold text-center py-2">
+            {successBroker} connected successfully
+          </p>
+        )}
         {error && <p className="text-red text-[10px] font-ui">Error: {error}</p>}
-        <p className="text-subtle text-[10px] font-ui leading-relaxed">
-          Login opens your browser. OAuth completes automatically.
-        </p>
+        {!successBroker && (
+          <p className="text-subtle text-[10px] font-ui leading-relaxed">
+            Login opens your browser. OAuth completes automatically.
+          </p>
+        )}
       </div>
     </div>
     </div>

--- a/macos-app/src/renderer/src/components/Sidebar/BrokerPanel.jsx
+++ b/macos-app/src/renderer/src/components/Sidebar/BrokerPanel.jsx
@@ -3,34 +3,51 @@ import { useChatStore } from '../../store/chatStore'
 
 const BROKERS = [
   {
+    key:      'fyers',
+    name:     'Fyers',
+    color:    'text-[#fed7aa]',
+    loginPath: '/fyers/login',
+    portalUrl: 'https://myapi.fyers.in',
+    portalLabel: 'myapi.fyers.in',
+    redirectUrl: 'http://127.0.0.1:8765/fyers/callback',
+    keys: [
+      { env: 'FYERS_APP_ID', label: 'App ID', placeholder: 'XXXX-100', secret: false },
+      { env: 'FYERS_SECRET_KEY', label: 'Secret Key', placeholder: 'Secret key', secret: true },
+    ],
+  },
+  {
     key:      'zerodha',
     name:     'Zerodha',
     color:    'text-[#387ed1]',
     loginPath: '/zerodha/login',
-  },
-  {
-    key:      'groww',
-    name:     'Groww',
-    color:    'text-[#00c48c]',
-    loginPath: '/groww/login',
+    portalUrl: 'https://developers.kite.trade',
+    portalLabel: 'developers.kite.trade',
+    redirectUrl: 'http://localhost:8765/zerodha/callback',
+    keys: [
+      { env: 'KITE_API_KEY', label: 'API Key', placeholder: 'API key', secret: false },
+      { env: 'KITE_API_SECRET', label: 'API Secret', placeholder: 'API secret', secret: true },
+    ],
   },
   {
     key:      'angel_one',
     name:     'Angel One',
     color:    'text-[#f6882a]',
     loginPath: '/angelone/login',
+    keys: [],
   },
   {
     key:      'upstox',
     name:     'Upstox',
     color:    'text-[#c4b5fd]',
     loginPath: '/upstox/login',
+    keys: [],
   },
   {
-    key:      'fyers',
-    name:     'Fyers',
-    color:    'text-[#fed7aa]',
-    loginPath: '/fyers/login',
+    key:      'groww',
+    name:     'Groww',
+    color:    'text-[#00c48c]',
+    loginPath: '/groww/login',
+    keys: [],
   },
 ]
 
@@ -39,24 +56,26 @@ export default function BrokerPanel({ onClose }) {
   const brokerStatuses    = useChatStore((s) => s.brokerStatuses)
   const setBrokerStatuses = useChatStore((s) => s.setBrokerStatuses)
   const [disconnecting, setDisconnecting] = useState(null)
+  const [expandedBroker, setExpandedBroker] = useState(null)
   const [error, setError] = useState(null)
+  const [saving, setSaving] = useState(false)
+
+  const base = `http://127.0.0.1:${port}`
 
   function openLogin(loginPath) {
-    const url = `http://127.0.0.1:${port}${loginPath}`
-    window.electronAPI?.openExternal(url)
+    window.electronAPI?.openExternal(`${base}${loginPath}`)
   }
 
   async function disconnect(brokerKey) {
     setDisconnecting(brokerKey)
     setError(null)
     try {
-      const r = await fetch(`http://127.0.0.1:${port}/api/broker/${brokerKey}`, { method: 'DELETE' })
+      const r = await fetch(`${base}/api/broker/${brokerKey}`, { method: 'DELETE' })
       if (!r.ok) {
         const body = await r.json().catch(() => ({}))
         throw new Error(body.detail ?? `HTTP ${r.status}`)
       }
-      // Refresh status immediately
-      const res  = await fetch(`http://127.0.0.1:${port}/api/status`)
+      const res  = await fetch(`${base}/api/status`)
       const data = await res.json()
       setBrokerStatuses(data)
     } catch (e) {
@@ -65,73 +84,148 @@ export default function BrokerPanel({ onClose }) {
     setDisconnecting(null)
   }
 
+  async function saveKeysAndLogin(broker) {
+    setSaving(true)
+    setError(null)
+    try {
+      const inputs = document.querySelectorAll(`[data-broker-panel="${broker.key}"]`)
+      for (const input of inputs) {
+        if (!input.value.trim()) {
+          setError(`Please fill in all fields for ${broker.name}`)
+          setSaving(false)
+          return
+        }
+        await fetch(`${base}/api/onboarding/credential`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ key: input.dataset.key, value: input.value.trim() }),
+        })
+      }
+      // Refresh status then login
+      const res = await fetch(`${base}/api/status`)
+      setBrokerStatuses(await res.json())
+      openLogin(broker.loginPath)
+    } catch (e) {
+      setError(e.message)
+    }
+    setSaving(false)
+  }
+
   return (
     <div className="absolute inset-0 z-50 flex flex-col bg-panel border-r border-border">
 
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
-        <p className="text-text text-[13px] font-semibold font-ui">Connect Broker</p>
+        <p className="text-text text-[13px] font-semibold font-ui">Brokers</p>
         <button
           onClick={onClose}
-          className="text-muted hover:text-text text-lg transition-colors leading-none"
+          className="text-muted hover:text-text text-lg transition-colors leading-none cursor-pointer"
         >
-          ✕
+          &times;
         </button>
       </div>
 
       {/* Broker list */}
       <div className="flex-1 overflow-y-auto px-3 py-3 space-y-2">
-        {BROKERS.map(({ key, name, color, loginPath }) => {
-          const status = brokerStatuses[key] ?? { configured: false, authenticated: false }
+        {BROKERS.map((broker) => {
+          const status = brokerStatuses[broker.key] ?? { configured: false, authenticated: false }
+          const isExpanded = expandedBroker === broker.key
 
           return (
-            <div
-              key={key}
-              className="bg-elevated rounded-lg border border-border p-3"
-            >
-              <div className="flex items-center justify-between">
+            <div key={broker.key} className="bg-elevated rounded-lg border border-border overflow-hidden">
+              {/* Broker row */}
+              <div className="flex items-center justify-between p-3">
                 <div className="flex items-center gap-2">
                   <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
                     status.authenticated
                       ? 'bg-green shadow-[0_0_6px_rgba(82,224,122,0.4)]'
                       : status.configured ? 'bg-amber/50' : 'bg-subtle'
                   }`} />
-                  <span className={`text-[13px] font-semibold font-ui ${color}`}>{name}</span>
+                  <span className={`text-[13px] font-semibold font-ui ${broker.color}`}>{broker.name}</span>
                 </div>
 
-                {/* Action */}
                 {status.authenticated ? (
                   <button
-                    onClick={() => disconnect(key)}
-                    disabled={disconnecting === key}
+                    onClick={() => disconnect(broker.key)}
+                    disabled={disconnecting === broker.key}
                     className="text-[11px] font-ui px-2.5 py-1 rounded-md border border-red/30
-                               text-red hover:bg-red/10 transition-colors disabled:opacity-40"
+                               text-red hover:bg-red/10 transition-colors disabled:opacity-40 cursor-pointer"
                   >
-                    {disconnecting === key ? '…' : 'Disconnect'}
+                    {disconnecting === broker.key ? '...' : 'Disconnect'}
                   </button>
                 ) : status.configured ? (
                   <button
-                    onClick={() => openLogin(loginPath)}
-                    className="text-[11px] font-ui px-2.5 py-1 rounded-md border border-blue/40
-                               text-blue hover:bg-blue/10 transition-colors"
+                    onClick={() => openLogin(broker.loginPath)}
+                    className="text-[11px] font-ui px-2.5 py-1 rounded-md border border-green/30
+                               text-green hover:bg-green/10 transition-colors cursor-pointer"
                   >
-                    Login →
+                    Connect
+                  </button>
+                ) : broker.keys.length > 0 ? (
+                  <button
+                    onClick={() => setExpandedBroker(isExpanded ? null : broker.key)}
+                    className={`text-[11px] font-ui px-2.5 py-1 rounded-md border transition-colors cursor-pointer
+                      ${isExpanded ? 'border-amber/30 text-amber bg-amber/10' : 'border-border text-muted hover:text-text'}`}
+                  >
+                    {isExpanded ? 'Hide' : 'Set Up'}
                   </button>
                 ) : (
-                  <span className="text-subtle text-[10px] font-ui">Not configured</span>
+                  <span className="text-subtle text-[10px] font-ui">Coming soon</span>
                 )}
               </div>
 
-              {/* Sub-status */}
-              {!status.authenticated && status.configured && (
-                <p className="text-muted text-[10px] font-ui mt-1">
-                  Credentials found — click Login to authenticate
-                </p>
-              )}
-              {!status.configured && (
-                <p className="text-subtle text-[10px] font-ui mt-1">
-                  Add API keys to <span className="font-mono">.env</span> to enable
-                </p>
+              {/* Expanded setup */}
+              {isExpanded && (
+                <div className="p-3 border-t border-border space-y-3">
+                  {/* Portal link */}
+                  <button
+                    onClick={() => window.electronAPI?.openExternal(broker.portalUrl)}
+                    className="w-full text-left text-amber text-[11px] font-ui hover:underline cursor-pointer"
+                  >
+                    Create app at {broker.portalLabel} &rarr;
+                  </button>
+
+                  {/* Redirect URL */}
+                  <div>
+                    <p className="text-muted text-[10px] font-ui mb-1">Redirect URL (set this in your broker app):</p>
+                    <div className="flex items-center gap-1">
+                      <code className="flex-1 bg-panel text-amber text-[10px] font-mono px-2 py-1.5 rounded border border-border truncate">
+                        {broker.redirectUrl}
+                      </code>
+                      <button
+                        onClick={() => navigator.clipboard.writeText(broker.redirectUrl)}
+                        className="text-muted hover:text-text text-[10px] px-1.5 py-1.5 border border-border rounded cursor-pointer"
+                      >
+                        Copy
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Key inputs */}
+                  {broker.keys.map((key) => (
+                    <input
+                      key={key.env}
+                      data-broker-panel={broker.key}
+                      data-key={key.env}
+                      type={key.secret ? 'password' : 'text'}
+                      placeholder={key.label}
+                      className="w-full bg-panel border border-border rounded-lg px-3 py-2
+                                 text-text text-xs font-mono placeholder:text-subtle
+                                 focus:outline-none focus:border-amber"
+                    />
+                  ))}
+
+                  {/* Save & Connect */}
+                  <button
+                    onClick={() => saveKeysAndLogin(broker)}
+                    disabled={saving}
+                    className="w-full px-3 py-2 bg-green/10 text-green border border-green/30
+                               rounded-lg text-xs font-ui font-semibold hover:bg-green/20
+                               transition-all disabled:opacity-40 cursor-pointer"
+                  >
+                    {saving ? 'Saving...' : 'Save & Connect'}
+                  </button>
+                </div>
               )}
             </div>
           )
@@ -140,11 +234,9 @@ export default function BrokerPanel({ onClose }) {
 
       {/* Footer */}
       <div className="px-4 py-3 border-t border-border flex-shrink-0 space-y-1.5">
-        {error && (
-          <p className="text-red text-[10px] font-ui">⚠ {error}</p>
-        )}
+        {error && <p className="text-red text-[10px] font-ui">Error: {error}</p>}
         <p className="text-subtle text-[10px] font-ui leading-relaxed">
-          Login opens your browser. OAuth completes there; the app reconnects automatically.
+          Login opens your browser. OAuth completes automatically.
         </p>
       </div>
     </div>

--- a/macos-app/src/renderer/src/components/Sidebar/BrokerPanel.jsx
+++ b/macos-app/src/renderer/src/components/Sidebar/BrokerPanel.jsx
@@ -112,7 +112,9 @@ export default function BrokerPanel({ onClose }) {
   }
 
   return (
-    <div className="absolute inset-0 z-50 flex flex-col bg-panel border-r border-border">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
+    <div className="w-[480px] max-h-[80vh] flex flex-col bg-panel border border-border rounded-xl shadow-2xl"
+         onClick={(e) => e.stopPropagation()}>
 
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
@@ -239,6 +241,7 @@ export default function BrokerPanel({ onClose }) {
           Login opens your browser. OAuth completes automatically.
         </p>
       </div>
+    </div>
     </div>
   )
 }

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -1,0 +1,237 @@
+"""
+tests/test_onboarding.py
+─────────────────────────
+Tests for onboarding API endpoints (#135).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Ensure clean env for each test
+    for key in (
+        "AI_PROVIDER",
+        "NEWSAPI_KEY",
+        "ONBOARDING_COMPLETE",
+        "TOTAL_CAPITAL",
+        "DEFAULT_RISK_PCT",
+        "TRADING_MODE",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    # Mock keychain to avoid picking up real credentials
+    monkeypatch.setattr("config.credentials._kr_get", lambda key: None)
+
+    from web.api import app
+
+    return TestClient(app)
+
+
+# ── /api/onboarding/status ────────────────────────────────────
+
+
+class TestOnboardingStatus:
+    def test_incomplete_when_no_provider(self, client, monkeypatch):
+        monkeypatch.delenv("AI_PROVIDER", raising=False)
+        monkeypatch.delenv("ONBOARDING_COMPLETE", raising=False)
+        r = client.get("/api/onboarding/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["onboarding_complete"] is False
+        assert d["ai_provider"] == ""
+
+    def test_complete_when_provider_set(self, client, monkeypatch):
+        monkeypatch.setenv("AI_PROVIDER", "gemini")
+        r = client.get("/api/onboarding/status")
+        assert r.status_code == 200
+        d = r.json()
+        assert d["onboarding_complete"] is True
+        assert d["ai_provider"] == "gemini"
+
+    def test_defaults_for_capital_and_risk(self, client, monkeypatch):
+        monkeypatch.delenv("TOTAL_CAPITAL", raising=False)
+        monkeypatch.delenv("DEFAULT_RISK_PCT", raising=False)
+        r = client.get("/api/onboarding/status")
+        d = r.json()
+        assert d["capital"] == "200000"
+        assert d["risk_pct"] == "2"
+        assert d["trading_mode"] == "PAPER"
+
+    def test_newsapi_key_detected(self, client, monkeypatch):
+        monkeypatch.setenv("NEWSAPI_KEY", "test123")
+        r = client.get("/api/onboarding/status")
+        assert r.json()["newsapi_key_set"] is True
+
+    def test_newsapi_key_missing(self, client, monkeypatch):
+        monkeypatch.delenv("NEWSAPI_KEY", raising=False)
+        r = client.get("/api/onboarding/status")
+        assert r.json()["newsapi_key_set"] is False
+
+
+# ── /api/onboarding/credential ────────────────────────────────
+
+
+class TestOnboardingCredential:
+    def test_sets_credential_in_env(self, client):
+        r = client.post(
+            "/api/onboarding/credential",
+            json={"key": "AI_PROVIDER", "value": "anthropic"},
+        )
+        assert r.status_code == 200
+        assert r.json()["ok"] is True
+        assert os.environ.get("AI_PROVIDER") == "anthropic"
+
+    def test_sets_api_key(self, client):
+        r = client.post(
+            "/api/onboarding/credential",
+            json={"key": "GEMINI_API_KEY", "value": "test_key_123"},
+        )
+        assert r.status_code == 200
+        assert os.environ.get("GEMINI_API_KEY") == "test_key_123"
+
+
+# ── /api/onboarding/test-provider ─────────────────────────────
+
+
+class TestOnboardingTestProvider:
+    def test_unknown_provider_returns_error(self, client):
+        r = client.post(
+            "/api/onboarding/test-provider",
+            json={"provider": "nonexistent", "api_key": "x"},
+        )
+        assert r.status_code == 200
+        assert r.json()["ok"] is False
+        assert "Unknown" in r.json()["error"]
+
+    @patch("httpx.AsyncClient.get")
+    def test_ollama_check_when_running(self, mock_get, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": [{"name": "llama3.1"}, {"name": "mistral"}]}
+        mock_get.return_value = mock_response
+        r = client.post(
+            "/api/onboarding/test-provider",
+            json={"provider": "ollama"},
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is True
+        assert "2 model" in d["message"]
+
+
+# ── /api/onboarding/test-newsapi ──────────────────────────────
+
+
+class TestOnboardingTestNewsAPI:
+    @patch("httpx.AsyncClient.get")
+    def test_valid_key(self, mock_get, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"status": "ok"}
+        mock_get.return_value = mock_response
+        r = client.post(
+            "/api/onboarding/test-newsapi",
+            json={"key": "valid_key_123"},
+        )
+        assert r.status_code == 200
+        assert r.json()["ok"] is True
+
+    @patch("httpx.AsyncClient.get")
+    def test_invalid_key(self, mock_get, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"status": "error"}
+        mock_get.return_value = mock_response
+        r = client.post(
+            "/api/onboarding/test-newsapi",
+            json={"key": "bad_key"},
+        )
+        assert r.status_code == 200
+        assert r.json()["ok"] is False
+
+
+# ── /api/onboarding/complete ──────────────────────────────────
+
+
+class TestOnboardingComplete:
+    def test_saves_settings(self, client, monkeypatch, tmp_path):
+        # Mock the home dir for .env writing
+        monkeypatch.setenv("AI_PROVIDER", "gemini")
+        monkeypatch.setenv("NEWSAPI_KEY", "test")
+
+        r = client.post(
+            "/api/onboarding/complete",
+            json={"capital": 500000, "risk_pct": 3, "trading_mode": "LIVE"},
+        )
+        assert r.status_code == 200
+        assert r.json()["ok"] is True
+        assert os.environ.get("TOTAL_CAPITAL") == "500000"
+        assert os.environ.get("DEFAULT_RISK_PCT") in ("3", "3.0")
+        assert os.environ.get("TRADING_MODE") == "LIVE"
+        assert os.environ.get("ONBOARDING_COMPLETE") == "1"
+
+    def test_default_values(self, client, monkeypatch):
+        r = client.post("/api/onboarding/complete", json={})
+        assert r.status_code == 200
+        assert os.environ.get("TOTAL_CAPITAL") == "200000"
+        assert os.environ.get("DEFAULT_RISK_PCT") == "2"
+        assert os.environ.get("TRADING_MODE") == "PAPER"
+
+
+# ── /api/onboarding/setup-provider ────────────────────────────
+
+
+class TestOnboardingSetupProvider:
+    @patch("shutil.which")
+    def test_ollama_check_not_installed(self, mock_which, client):
+        mock_which.return_value = None
+        r = client.post(
+            "/api/onboarding/setup-provider",
+            json={"provider": "ollama", "step": "check"},
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["installed"] is False
+        assert d["next_step"] == "install"
+
+    @patch("shutil.which")
+    def test_ollama_install_no_brew(self, mock_which, client):
+        mock_which.return_value = None
+        r = client.post(
+            "/api/onboarding/setup-provider",
+            json={"provider": "ollama", "step": "install"},
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["ok"] is False
+        assert "Homebrew not found" in d["error"]
+
+    @patch("shutil.which")
+    def test_claude_sub_check_not_installed(self, mock_which, client):
+        mock_which.return_value = None
+        r = client.post(
+            "/api/onboarding/setup-provider",
+            json={"provider": "claude_subscription", "step": "check"},
+        )
+        assert r.status_code == 200
+        d = r.json()
+        assert d["installed"] is False
+        assert d["next_step"] == "install"
+
+    def test_unknown_provider(self, client):
+        r = client.post(
+            "/api/onboarding/setup-provider",
+            json={"provider": "badprovider", "step": "check"},
+        )
+        assert r.status_code == 200
+        assert r.json()["ok"] is False

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -40,15 +40,18 @@ class TestRiskProfiles:
 
 
 class TestTraderAgentInit:
-    def test_default_capital(self):
+    def test_default_capital(self, monkeypatch):
+        monkeypatch.delenv("TOTAL_CAPITAL", raising=False)
         t = TraderAgent()
         assert t.capital == 200000
 
-    def test_custom_capital(self):
+    def test_custom_capital(self, monkeypatch):
+        monkeypatch.delenv("TOTAL_CAPITAL", raising=False)
         t = TraderAgent(capital=500000)
         assert t.capital == 500000
 
-    def test_default_profile_is_neutral(self):
+    def test_default_profile_is_neutral(self, monkeypatch):
+        monkeypatch.delenv("TOTAL_CAPITAL", raising=False)
         t = TraderAgent()
         assert t.profile.name == "Neutral"
 

--- a/web/api.py
+++ b/web/api.py
@@ -54,6 +54,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from dotenv import load_dotenv
 
 load_dotenv(Path(__file__).parent.parent / ".env")
+load_dotenv(Path.home() / ".trading_platform" / ".env", override=False)
 from config.credentials import load_all as _load_keychain
 
 _load_keychain()
@@ -902,6 +903,196 @@ async def api_status(request: Request):
         "upstox": {"configured": _has_upstox(), "authenticated": _upstox_auth()},
         "fyers": {"configured": _has_fyers(), "authenticated": _fyers_auth()},
     }
+
+
+# ── Onboarding API ───────────────────────────────────────────
+
+from pydantic import BaseModel
+
+
+@app.get("/api/onboarding/status")
+async def onboarding_status():
+    import os
+    from config.credentials import _kr_get
+
+    ai_provider = os.environ.get("AI_PROVIDER") or _kr_get("AI_PROVIDER") or ""
+    newsapi = bool(os.environ.get("NEWSAPI_KEY") or _kr_get("NEWSAPI_KEY"))
+    onboarding_done = bool(os.environ.get("ONBOARDING_COMPLETE") or _kr_get("ONBOARDING_COMPLETE"))
+
+    # Check broker status
+    broker_connected = False
+    try:
+        from brokers.session import get_broker
+
+        get_broker()
+        broker_connected = True
+    except Exception:
+        pass
+
+    return {
+        "onboarding_complete": onboarding_done or bool(ai_provider),
+        "ai_provider": ai_provider,
+        "newsapi_key_set": newsapi,
+        "broker_connected": broker_connected,
+        "capital": os.environ.get("TOTAL_CAPITAL", "200000"),
+        "risk_pct": os.environ.get("DEFAULT_RISK_PCT", "2"),
+        "trading_mode": os.environ.get("TRADING_MODE", "PAPER"),
+    }
+
+
+class CredentialRequest(BaseModel):
+    key: str
+    value: str
+
+
+@app.post("/api/onboarding/credential")
+async def onboarding_set_credential(req: CredentialRequest):
+    from config.credentials import set_credential
+
+    set_credential(req.key, req.value)
+    return {"ok": True, "key": req.key}
+
+
+class TestProviderRequest(BaseModel):
+    provider: str
+    api_key: str = ""
+    model: str = ""
+
+
+@app.post("/api/onboarding/test-provider")
+async def onboarding_test_provider(req: TestProviderRequest):
+    import httpx
+
+    try:
+        if req.provider == "gemini":
+            url = f"https://generativelanguage.googleapis.com/v1beta/models?key={req.api_key}"
+            async with httpx.AsyncClient() as client:
+                r = await client.get(url, timeout=10)
+                if r.status_code == 200:
+                    return {"ok": True, "message": "Gemini API key is valid"}
+                return {"ok": False, "error": f"Invalid key (HTTP {r.status_code})"}
+
+        elif req.provider == "anthropic":
+            async with httpx.AsyncClient() as client:
+                r = await client.post(
+                    "https://api.anthropic.com/v1/messages",
+                    headers={
+                        "x-api-key": req.api_key,
+                        "anthropic-version": "2023-06-01",
+                        "content-type": "application/json",
+                    },
+                    json={
+                        "model": "claude-haiku-4-5-20251001",
+                        "max_tokens": 10,
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
+                    timeout=15,
+                )
+                if r.status_code == 200:
+                    return {"ok": True, "message": "Anthropic API key is valid"}
+                return {"ok": False, "error": f"Invalid key (HTTP {r.status_code})"}
+
+        elif req.provider == "openai":
+            base = (
+                req.model
+                if req.model and req.model.startswith("http")
+                else "https://api.openai.com/v1"
+            )
+            async with httpx.AsyncClient() as client:
+                r = await client.get(
+                    f"{base}/models",
+                    headers={"Authorization": f"Bearer {req.api_key}"},
+                    timeout=10,
+                )
+                if r.status_code == 200:
+                    return {"ok": True, "message": "OpenAI API key is valid"}
+                return {"ok": False, "error": f"Invalid key (HTTP {r.status_code})"}
+
+        elif req.provider == "ollama":
+            async with httpx.AsyncClient() as client:
+                r = await client.get("http://localhost:11434/api/tags", timeout=5)
+                if r.status_code == 200:
+                    models = r.json().get("models", [])
+                    return {
+                        "ok": True,
+                        "message": f"Ollama running with {len(models)} models",
+                    }
+                return {"ok": False, "error": "Ollama not running. Run: ollama serve"}
+
+        else:
+            return {"ok": False, "error": f"Unknown provider: {req.provider}"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+class TestNewsAPIRequest(BaseModel):
+    key: str
+
+
+@app.post("/api/onboarding/test-newsapi")
+async def onboarding_test_newsapi(req: TestNewsAPIRequest):
+    import httpx
+
+    try:
+        async with httpx.AsyncClient() as client:
+            r = await client.get(
+                f"https://newsapi.org/v2/top-headlines?country=in&pageSize=1&apiKey={req.key}",
+                timeout=10,
+            )
+            if r.status_code == 200 and r.json().get("status") == "ok":
+                return {"ok": True}
+            return {"ok": False, "error": f"Invalid key (HTTP {r.status_code})"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
+class OnboardingCompleteRequest(BaseModel):
+    capital: int = 200000
+    risk_pct: float = 2
+    trading_mode: str = "PAPER"
+
+
+@app.post("/api/onboarding/complete")
+async def onboarding_complete(req: OnboardingCompleteRequest):
+    import os
+    from config.credentials import set_credential
+    from pathlib import Path
+
+    set_credential("TOTAL_CAPITAL", str(req.capital))
+    set_credential("DEFAULT_RISK_PCT", str(req.risk_pct))
+    set_credential("TRADING_MODE", req.trading_mode)
+    set_credential("ONBOARDING_COMPLETE", "1")
+
+    # Also write to ~/.trading_platform/.env as backup for packaged mode
+    env_path = Path.home() / ".trading_platform" / ".env"
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    if env_path.exists():
+        lines = env_path.read_text().splitlines()
+
+    # Update or append each key
+    for key, val in [
+        ("TOTAL_CAPITAL", str(req.capital)),
+        ("DEFAULT_RISK_PCT", str(req.risk_pct)),
+        ("TRADING_MODE", req.trading_mode),
+        ("ONBOARDING_COMPLETE", "1"),
+        ("AI_PROVIDER", os.environ.get("AI_PROVIDER", "")),
+        ("NEWSAPI_KEY", os.environ.get("NEWSAPI_KEY", "")),
+    ]:
+        if not val:
+            continue
+        found = False
+        for i, line in enumerate(lines):
+            if line.startswith(f"{key}="):
+                lines[i] = f"{key}={val}"
+                found = True
+                break
+        if not found:
+            lines.append(f"{key}={val}")
+
+    env_path.write_text("\n".join(lines) + "\n")
+
+    return {"ok": True}
 
 
 _BROKER_SESSION_FILES = {

--- a/web/api.py
+++ b/web/api.py
@@ -1025,6 +1025,170 @@ async def onboarding_test_provider(req: TestProviderRequest):
         return {"ok": False, "error": str(e)}
 
 
+class SetupProviderRequest(BaseModel):
+    provider: str
+    step: str = "check"  # check | install | pull_model
+
+
+@app.post("/api/onboarding/setup-provider")
+async def onboarding_setup_provider(req: SetupProviderRequest):
+    """Run setup commands for Ollama or Claude subscription."""
+    import shutil
+    import subprocess
+
+    try:
+        if req.provider == "ollama":
+            if req.step == "check":
+                # Check if ollama is installed
+                ollama_path = shutil.which("ollama")
+                if ollama_path:
+                    # Check if running
+                    try:
+                        import httpx
+
+                        async with httpx.AsyncClient() as client:
+                            r = await client.get("http://localhost:11434/api/tags", timeout=3)
+                            models = r.json().get("models", [])
+                            return {
+                                "ok": True,
+                                "installed": True,
+                                "running": True,
+                                "models": [m["name"] for m in models],
+                                "message": f"Ollama running with {len(models)} model(s)",
+                            }
+                    except Exception:
+                        return {
+                            "ok": True,
+                            "installed": True,
+                            "running": False,
+                            "models": [],
+                            "message": "Ollama installed but not running. Starting...",
+                            "next_step": "start",
+                        }
+                return {
+                    "ok": True,
+                    "installed": False,
+                    "running": False,
+                    "models": [],
+                    "message": "Ollama not installed",
+                    "next_step": "install",
+                }
+
+            elif req.step == "install":
+                brew_path = shutil.which("brew")
+                if not brew_path:
+                    return {
+                        "ok": False,
+                        "error": "Homebrew not found. Install Ollama manually from https://ollama.com/download",
+                        "download_url": "https://ollama.com/download",
+                    }
+                result = subprocess.run(
+                    [brew_path, "install", "ollama"],
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                )
+                if result.returncode == 0:
+                    return {
+                        "ok": True,
+                        "message": "Ollama installed successfully",
+                        "output": result.stdout[-500:],
+                        "next_step": "start",
+                    }
+                return {
+                    "ok": False,
+                    "error": f"Install failed: {result.stderr[-500:]}",
+                }
+
+            elif req.step == "start":
+                # Start ollama serve in background
+                subprocess.Popen(
+                    ["ollama", "serve"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                import asyncio
+
+                await asyncio.sleep(2)
+                return {"ok": True, "message": "Ollama started", "next_step": "pull_model"}
+
+            elif req.step == "pull_model":
+                result = subprocess.run(
+                    ["ollama", "pull", "llama3.1"],
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+                if result.returncode == 0:
+                    return {
+                        "ok": True,
+                        "message": "Model llama3.1 downloaded",
+                        "output": result.stdout[-500:],
+                    }
+                return {
+                    "ok": False,
+                    "error": f"Pull failed: {result.stderr[-500:]}",
+                }
+
+        elif req.provider == "claude_subscription":
+            if req.step == "check":
+                claude_path = shutil.which("claude")
+                if claude_path:
+                    # Check if logged in by running claude --version
+                    result = subprocess.run(
+                        [claude_path, "--version"],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    return {
+                        "ok": True,
+                        "installed": True,
+                        "message": f"Claude CLI found: {result.stdout.strip()}",
+                    }
+                # Check if npm is available
+                npm_path = shutil.which("npm")
+                return {
+                    "ok": True,
+                    "installed": False,
+                    "npm_available": bool(npm_path),
+                    "message": "Claude CLI not installed",
+                    "next_step": "install",
+                }
+
+            elif req.step == "install":
+                npm_path = shutil.which("npm")
+                if not npm_path:
+                    return {
+                        "ok": False,
+                        "error": "npm not found. Install Node.js from https://nodejs.org first.",
+                    }
+                result = subprocess.run(
+                    [npm_path, "i", "-g", "@anthropic-ai/claude-code"],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+                if result.returncode == 0:
+                    return {
+                        "ok": True,
+                        "message": "Claude CLI installed. Run 'claude login' in your terminal to authenticate.",
+                        "output": result.stdout[-500:],
+                        "needs_login": True,
+                    }
+                return {
+                    "ok": False,
+                    "error": f"Install failed: {result.stderr[-500:]}",
+                }
+
+        return {"ok": False, "error": f"Unknown provider: {req.provider}"}
+
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": "Command timed out"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
 class TestNewsAPIRequest(BaseModel):
     key: str
 

--- a/web/api.py
+++ b/web/api.py
@@ -934,9 +934,9 @@ async def onboarding_status():
         "ai_provider": ai_provider,
         "newsapi_key_set": newsapi,
         "broker_connected": broker_connected,
-        "capital": os.environ.get("TOTAL_CAPITAL", "200000"),
-        "risk_pct": os.environ.get("DEFAULT_RISK_PCT", "2"),
-        "trading_mode": os.environ.get("TRADING_MODE", "PAPER"),
+        "capital": os.environ.get("TOTAL_CAPITAL") or _kr_get("TOTAL_CAPITAL") or "200000",
+        "risk_pct": os.environ.get("DEFAULT_RISK_PCT") or _kr_get("DEFAULT_RISK_PCT") or "2",
+        "trading_mode": os.environ.get("TRADING_MODE") or _kr_get("TRADING_MODE") or "PAPER",
     }
 
 


### PR DESCRIPTION
## Summary

Makes the macOS app fully self-contained: a user downloads the DMG, opens it, and a guided wizard walks them through setup — no terminal, no .env editing, no manual Python installation.

**11 commits, 2 specs, 17 tests.**

---

## What's new

### Python Bootstrap (#134)
- App auto-detects Python 3.11+ on the system (homebrew, /usr/local, PATH)
- Creates venv at `~/.trading_platform/venv/`, installs from bundled wheel
- SetupScreen shows progress: "Checking for Python..." → "Creating environment..." → "Installing dependencies..."
- If Python missing: shows install instructions (python.org + brew command)
- Dev mode unchanged — uses repo `.venv` if it exists
- Version stamping: app updates trigger dep reinstall automatically

### Onboarding Wizard (#135)
5-step guided setup for new users:
1. **Welcome** — app logo + "Get Started"
2. **AI Provider** — pick Gemini/Claude/OpenAI/Ollama, enter key, test it. Built-in setup runner for Ollama (brew install + model pull) and Claude subscription (npm install CLI)
3. **Market Data** — NewsAPI key (mandatory) + broker setup (skippable). Broker cards show step-by-step guide: create app on portal, copy redirect URL, enter API keys, Save & Connect
4. **Trading Settings** — capital, risk %, paper/live mode
5. **Completion** — summary + "Start Trading"

Credentials saved to OS keychain (no .env editing). Backup written to `~/.trading_platform/.env` for packaged mode.

### Broker Panel Upgrade (#138)
- Opens as centered 480px modal (not cramped sidebar)
- Unconfigured brokers show "Set Up" → expands to: portal link, copyable redirect URL, key inputs, "Save & Connect"
- Auto-closes with success message after OAuth completes
- Already configured brokers show "Connect" button

### DMG Packaging
- Python wheel bundled in app via `extraResources`
- `npm run build` creates arm64 + x64 DMGs (~107MB each)
- Wheel at `Contents/Resources/python-pkg/` for packaged-mode bootstrap

---

## Backend endpoints added
| Endpoint | Purpose |
|----------|---------|
| `GET /api/onboarding/status` | Check if onboarding is complete |
| `POST /api/onboarding/credential` | Save key to keychain + env |
| `POST /api/onboarding/test-provider` | Validate AI provider API key |
| `POST /api/onboarding/test-newsapi` | Validate NewsAPI key |
| `POST /api/onboarding/setup-provider` | Run Ollama/Claude setup commands |
| `POST /api/onboarding/complete` | Save settings, write backup .env |

## New files
- `src/main/pythonBootstrap.js` — Python detection, venv, pip install
- `src/renderer/src/components/SetupScreen.jsx` — bootstrap progress UI
- `src/renderer/src/components/Onboarding/*.jsx` — 7 wizard components
- `docs/specs/134-python-bootstrap.md` — spec
- `docs/specs/135-onboarding-wizard.md` — spec
- `tests/test_onboarding.py` — 17 tests

## Test plan
- [x] Dev mode works unchanged (uses repo .venv)
- [x] Bootstrap: removed .venv, app created venv + installed deps automatically
- [x] Onboarding: cleared keychain + .env, full wizard appeared
- [x] AI provider: tested Claude Pro/Max selection
- [x] Broker setup: Fyers + Zerodha connected via onboarding guide
- [x] Subsequent launch: skips wizard, goes straight to chat
- [x] BrokerPanel: modal opens, Set Up expands, Save & Connect works
- [x] DMG build: wheel bundled in app bundle
- [x] 17 Python tests passing
- [x] 53 Vitest tests passing