### PR TITLE
feat: named investor personas (#165)

### DIFF
--- a/agent/persona_agent.py
+++ b/agent/persona_agent.py
@@ -1,0 +1,555 @@
+"""
+agent/persona_agent.py
+──────────────────────
+Run a named investor persona analysis on a stock symbol.
+
+Flow (with LLM):
+  1. Fetch pre-computed data: technicals + fundamentals + macro snapshot
+  2. Build a compact data brief
+  3. Call LLM with persona's system_prompt + data brief
+  4. Parse response → PersonaSignal
+  5. Return PersonaSignal
+
+Flow (no LLM — deterministic fallback):
+  Same data fetch, then score each dimension using simple rules,
+  apply persona weights, map to verdict.
+
+Public API:
+  run_persona_analysis(persona_id, symbol, exchange, registry, llm_provider) -> PersonaSignal
+  run_debate(symbol, exchange, registry, llm_provider) -> list[PersonaSignal]
+  parse_persona_response(text, persona_id) -> PersonaSignal
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agent.personas import get_persona, list_personas
+from agent.schemas import PersonaSignal
+
+
+# ── Response parser ───────────────────────────────────────────
+
+
+def parse_persona_response(text: str, persona_id: str) -> PersonaSignal:
+    """
+    Parse an LLM response into a PersonaSignal.
+
+    Handles:
+      - Full structured responses
+      - Partial responses (missing some fields)
+      - Empty or error responses (returns HOLD with 30% confidence)
+
+    Expected loose format in the response:
+        VERDICT: BUY
+        CONFIDENCE: 72
+        RATIONALE:
+        - Strong moat in telecom
+        - ROE below threshold
+        KEY_METRICS:
+        ROE: 8% (need >15%)
+        D/E: 0.4
+    """
+    if not text or not text.strip():
+        return PersonaSignal(
+            persona=persona_id,
+            verdict="HOLD",
+            confidence=30,
+            rationale=["Insufficient data for analysis"],
+            key_metrics={},
+        )
+
+    verdict = "HOLD"
+    confidence = 50
+    rationale: list[str] = []
+    key_metrics: dict[str, str] = {}
+
+    # ── Verdict ──────────────────────────────────────────────
+    verdict_match = re.search(
+        r"VERDICT\s*[:=]\s*(STRONG_BUY|STRONG_SELL|BUY|SELL|HOLD)",
+        text,
+        re.IGNORECASE,
+    )
+    if verdict_match:
+        verdict_raw = verdict_match.group(1).upper().replace(" ", "_")
+        # Normalise: "STRONG BUY" → "STRONG_BUY"
+        valid = {"STRONG_BUY", "BUY", "HOLD", "SELL", "STRONG_SELL"}
+        if verdict_raw in valid:
+            verdict = verdict_raw
+
+    # ── Confidence ────────────────────────────────────────────
+    conf_match = re.search(r"CONFIDENCE\s*[:=]\s*(\d+)", text, re.IGNORECASE)
+    if conf_match:
+        try:
+            confidence = max(0, min(100, int(conf_match.group(1))))
+        except ValueError:
+            pass
+
+    # ── Rationale (bullet points) ─────────────────────────────
+    rationale_section = re.search(
+        r"RATIONALE\s*[:=]?\s*\n(.*?)(?=KEY_METRICS|$)",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if rationale_section:
+        lines = rationale_section.group(1).strip().splitlines()
+        for line in lines:
+            line = line.strip().lstrip("-•*").strip()
+            if line:
+                rationale.append(line)
+
+    # Fall back: find any bullet points in the text
+    if not rationale:
+        bullets = re.findall(r"^[\s]*[-•*]\s+(.+)$", text, re.MULTILINE)
+        rationale = [b.strip() for b in bullets if b.strip()][:6]
+
+    # Guarantee at least one rationale item
+    if not rationale:
+        rationale = ["Analysis based on available data"]
+
+    # ── Key metrics ───────────────────────────────────────────
+    metrics_section = re.search(
+        r"KEY_METRICS\s*[:=]?\s*\n(.*?)$",
+        text,
+        re.IGNORECASE | re.DOTALL,
+    )
+    if metrics_section:
+        lines = metrics_section.group(1).strip().splitlines()
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            # "ROE: 8%" or "ROE = 8%"
+            kv = re.match(r"^([^:=]+?)\s*[:=]\s*(.+)$", line)
+            if kv:
+                key_metrics[kv.group(1).strip()] = kv.group(2).strip()
+
+    return PersonaSignal(
+        persona=persona_id,
+        verdict=verdict,
+        confidence=confidence,
+        rationale=rationale,
+        key_metrics=key_metrics,
+    )
+
+
+# ── Data fetcher ──────────────────────────────────────────────
+
+
+def _fetch_data_brief(
+    symbol: str,
+    exchange: str,
+    registry: Any,
+) -> dict[str, Any]:
+    """
+    Fetch technical, fundamental, and macro data for the symbol.
+
+    Returns a dict with all available data. Empty / default values used
+    when registry is None or a tool raises an exception.
+    """
+    brief: dict[str, Any] = {
+        "symbol": symbol,
+        "exchange": exchange,
+        "technicals": {},
+        "fundamentals": {},
+        "macro": {},
+        "news": [],
+        "fii_dii": {},
+    }
+
+    if registry is None:
+        return brief
+
+    def _safe_call(tool_name: str, **kwargs) -> Any:
+        try:
+            fn = registry.get_fn(tool_name)
+            if fn is None:
+                return None
+            return fn(**kwargs)
+        except Exception:
+            return None
+
+    # Technical snapshot
+    tech = _safe_call("technical_analyse", symbol=symbol, exchange=exchange)
+    if tech:
+        brief["technicals"] = tech if isinstance(tech, dict) else vars(tech)
+
+    # Fundamental snapshot
+    fund = _safe_call("fundamental_analyse", symbol=symbol)
+    if fund:
+        brief["fundamentals"] = fund if isinstance(fund, dict) else vars(fund)
+
+    # FII/DII data
+    fii = _safe_call("get_fii_dii_data")
+    if fii:
+        brief["fii_dii"] = fii if isinstance(fii, dict) else vars(fii)
+
+    # Market snapshot
+    macro = _safe_call("get_market_snapshot")
+    if macro:
+        brief["macro"] = macro if isinstance(macro, dict) else vars(macro)
+
+    # News
+    news = _safe_call("get_stock_news", symbol=symbol)
+    if news and isinstance(news, list):
+        brief["news"] = news[:5]  # limit to 5 headlines
+
+    return brief
+
+
+def _build_prompt(symbol: str, exchange: str, brief: dict[str, Any]) -> str:
+    """Build a compact data brief string for the LLM prompt."""
+    lines = [
+        "=== Stock Analysis Request ===",
+        f"Symbol: {symbol} | Exchange: {exchange}",
+        "",
+    ]
+
+    tech = brief.get("technicals", {})
+    if tech:
+        lines.append("--- Technical Data ---")
+        for k, v in list(tech.items())[:10]:
+            lines.append(f"  {k}: {v}")
+        lines.append("")
+
+    fund = brief.get("fundamentals", {})
+    if fund:
+        lines.append("--- Fundamentals ---")
+        for k, v in list(fund.items())[:15]:
+            lines.append(f"  {k}: {v}")
+        lines.append("")
+
+    macro = brief.get("macro", {})
+    if macro:
+        lines.append("--- Macro Data ---")
+        for k, v in list(macro.items())[:8]:
+            lines.append(f"  {k}: {v}")
+        lines.append("")
+
+    fii = brief.get("fii_dii", {})
+    if fii:
+        lines.append("--- FII/DII Flows ---")
+        for k, v in list(fii.items())[:5]:
+            lines.append(f"  {k}: {v}")
+        lines.append("")
+
+    news = brief.get("news", [])
+    if news:
+        lines.append("--- Recent News ---")
+        for headline in news[:3]:
+            lines.append(f"  • {headline}")
+        lines.append("")
+
+    lines += [
+        "=== Required Output Format ===",
+        "VERDICT: <STRONG_BUY|BUY|HOLD|SELL|STRONG_SELL>",
+        "CONFIDENCE: <0-100>",
+        "RATIONALE:",
+        "- <checklist item 1>",
+        "- <checklist item 2>",
+        "- <checklist item 3>",
+        "KEY_METRICS:",
+        "<metric name>: <value and context>",
+        "",
+        "Then provide 2-3 sentences of reasoning in your authentic voice.",
+    ]
+
+    return "\n".join(lines)
+
+
+# ── Rule-based fallback scorer ────────────────────────────────
+
+
+def _score_dimension(dimension: str, brief: dict[str, Any]) -> float:
+    """
+    Score a single dimension 0–100 using simple heuristics on available data.
+
+    Returns 50 (neutral) when data is unavailable.
+    """
+    tech = brief.get("technicals", {})
+    fund = brief.get("fundamentals", {})
+    macro = brief.get("macro", {})
+    fii = brief.get("fii_dii", {})
+
+    if dimension == "fundamentals":
+        score = 50.0
+        roe = fund.get("roe") or fund.get("ROE")
+        if roe is not None:
+            try:
+                roe = float(roe)
+                score += 15 if roe > 15 else (-10 if roe < 8 else 5)
+            except (TypeError, ValueError):
+                pass
+
+        de = fund.get("debt_equity") or fund.get("de") or fund.get("D/E")
+        if de is not None:
+            try:
+                de = float(de)
+                score += 10 if de < 0.5 else (-10 if de > 1.5 else 0)
+            except (TypeError, ValueError):
+                pass
+
+        pe = fund.get("pe") or fund.get("PE")
+        if pe is not None:
+            try:
+                pe = float(pe)
+                score += 10 if pe < 15 else (-10 if pe > 40 else 0)
+            except (TypeError, ValueError):
+                pass
+
+        fcf_yield = fund.get("fcf_yield") or fund.get("FCF_yield")
+        if fcf_yield is not None:
+            try:
+                fcf_yield = float(fcf_yield)
+                score += 10 if fcf_yield > 5 else (-5 if fcf_yield < 2 else 0)
+            except (TypeError, ValueError):
+                pass
+
+        return max(0.0, min(100.0, score))
+
+    elif dimension == "technicals":
+        score = 50.0
+        rsi = tech.get("rsi") or tech.get("RSI")
+        if rsi is not None:
+            try:
+                rsi = float(rsi)
+                if rsi < 30:
+                    score += 20  # oversold → buy signal
+                elif rsi > 70:
+                    score -= 15  # overbought → cautious
+                elif 40 <= rsi <= 60:
+                    score += 5  # neutral zone
+            except (TypeError, ValueError):
+                pass
+
+        trend = tech.get("trend") or tech.get("price_trend")
+        if trend:
+            trend_str = str(trend).upper()
+            if "BULL" in trend_str or "UP" in trend_str:
+                score += 10
+            elif "BEAR" in trend_str or "DOWN" in trend_str:
+                score -= 10
+
+        return max(0.0, min(100.0, score))
+
+    elif dimension == "macro":
+        score = 50.0
+        # FII flows
+        fii_net = fii.get("net") or fii.get("fii_net") or fii.get("FII_net")
+        if fii_net is not None:
+            try:
+                fii_net = float(fii_net)
+                score += 15 if fii_net > 0 else (-10 if fii_net < 0 else 0)
+            except (TypeError, ValueError):
+                pass
+
+        # Market regime
+        vix = macro.get("india_vix") or macro.get("VIX") or macro.get("vix")
+        if vix is not None:
+            try:
+                vix = float(vix)
+                score += 10 if vix < 15 else (-15 if vix > 25 else 0)
+            except (TypeError, ValueError):
+                pass
+
+        return max(0.0, min(100.0, score))
+
+    elif dimension == "sentiment":
+        score = 50.0
+        # Use news count or FII direction as a proxy for sentiment
+        news = brief.get("news", [])
+        if news:
+            # Simple: more news = more attention, slightly positive
+            score += min(5, len(news))
+        return max(0.0, min(100.0, score))
+
+    elif dimension == "options":
+        score = 50.0
+        pcr = tech.get("pcr") or tech.get("put_call_ratio")
+        if pcr is not None:
+            try:
+                pcr = float(pcr)
+                # PCR > 1.5 → bullish contrarian signal; PCR < 0.5 → bearish contrarian
+                if pcr > 1.5:
+                    score += 15
+                elif pcr < 0.5:
+                    score -= 10
+            except (TypeError, ValueError):
+                pass
+        return max(0.0, min(100.0, score))
+
+    return 50.0
+
+
+def _rule_based_signal(
+    persona_id: str,
+    brief: dict[str, Any],
+) -> PersonaSignal:
+    """
+    Deterministic rule-based signal using persona weights × dimension scores.
+
+    No LLM required.
+    """
+    from agent.personas import get_persona
+
+    persona = get_persona(persona_id)
+
+    weighted_sum = 0.0
+    checklist_results: list[str] = []
+    key_metrics: dict[str, str] = {}
+
+    for dimension, weight in persona.weights.items():
+        dim_score = _score_dimension(dimension, brief)
+        weighted_sum += dim_score * weight
+
+        # Produce a checklist entry for each dimension
+        level = "strong" if dim_score >= 65 else ("weak" if dim_score <= 40 else "neutral")
+        symbol_map = {"strong": "✓", "neutral": "~", "weak": "✗"}
+        checklist_results.append(
+            f"{symbol_map[level]} {dimension.title()} score: {dim_score:.0f}/100 ({level})"
+        )
+        key_metrics[dimension.title()] = f"{dim_score:.0f}/100"
+
+    # Add persona-specific checklist items
+    for item in persona.checklist[:3]:
+        checklist_results.append(f"~ {item} (data insufficient for precise check)")
+
+    # Map score to verdict
+    score = weighted_sum
+    if score >= 80:
+        verdict = "STRONG_BUY"
+    elif score >= 65:
+        verdict = "BUY"
+    elif score >= 40:
+        verdict = "HOLD"
+    elif score >= 25:
+        verdict = "SELL"
+    else:
+        verdict = "STRONG_SELL"
+
+    confidence = max(30, min(90, int(score)))
+
+    return PersonaSignal(
+        persona=persona_id,
+        verdict=verdict,
+        confidence=confidence,
+        rationale=checklist_results[:6],
+        key_metrics=key_metrics,
+    )
+
+
+# ── LLM caller ────────────────────────────────────────────────
+
+
+def _call_llm(
+    system_prompt: str,
+    user_message: str,
+    llm_provider: Any,
+) -> str:
+    """Call the LLM provider with system + user message. Returns response text."""
+    try:
+        # Try the standard call interface used by the platform
+        if hasattr(llm_provider, "call"):
+            return llm_provider.call(
+                system=system_prompt,
+                message=user_message,
+            )
+        # Fallback: direct chat method
+        if hasattr(llm_provider, "chat"):
+            return llm_provider.chat(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_message},
+                ]
+            )
+        # Generic: try __call__
+        if callable(llm_provider):
+            return str(llm_provider(system_prompt, user_message))
+    except Exception as exc:
+        # Any LLM failure → return empty (caller will use rule-based fallback)
+        return f"LLM call failed: {exc}"
+    return ""
+
+
+# ── Public API ────────────────────────────────────────────────
+
+
+def run_persona_analysis(
+    persona_id: str,
+    symbol: str,
+    exchange: str = "NSE",
+    registry: Any = None,
+    llm_provider: Any = None,
+) -> PersonaSignal:
+    """
+    Run a single persona analysis on a symbol.
+
+    Parameters
+    ----------
+    persona_id:    One of 'buffett', 'jhunjhunwala', 'lynch', 'soros', 'munger'
+    symbol:        Stock ticker, e.g. 'RELIANCE'
+    exchange:      'NSE' or 'BSE'
+    registry:      ToolRegistry for live data; if None, analysis uses empty data
+    llm_provider:  LLM provider instance; if None, uses deterministic fallback
+
+    Returns
+    -------
+    PersonaSignal
+    """
+    # Validate persona (raises ValueError for unknown ids)
+    persona = get_persona(persona_id)
+
+    # 1. Fetch data
+    brief = _fetch_data_brief(symbol, exchange, registry)
+
+    # 2. LLM path
+    if llm_provider is not None:
+        prompt = _build_prompt(symbol, exchange, brief)
+        response_text = _call_llm(
+            system_prompt=persona.system_prompt,
+            user_message=prompt,
+            llm_provider=llm_provider,
+        )
+        if response_text and "LLM call failed" not in response_text:
+            return parse_persona_response(response_text, persona_id)
+        # Fall through to rule-based if LLM failed
+
+    # 3. Rule-based fallback
+    return _rule_based_signal(persona_id, brief)
+
+
+def run_debate(
+    symbol: str,
+    exchange: str = "NSE",
+    registry: Any = None,
+    llm_provider: Any = None,
+) -> list[PersonaSignal]:
+    """
+    Run all 5 personas and return their signals.
+
+    Parameters
+    ----------
+    symbol:       Stock ticker
+    exchange:     'NSE' or 'BSE'
+    registry:     ToolRegistry for live data
+    llm_provider: LLM provider; if None uses deterministic fallback for all
+
+    Returns
+    -------
+    list[PersonaSignal] — one per persona, in stable order
+    """
+    personas = list_personas()
+    signals: list[PersonaSignal] = []
+
+    for persona in personas:
+        signal = run_persona_analysis(
+            persona_id=persona.id,
+            symbol=symbol,
+            exchange=exchange,
+            registry=registry,
+            llm_provider=llm_provider,
+        )
+        signals.append(signal)
+
+    return signals

--- a/agent/personas.py
+++ b/agent/personas.py
@@ -1,0 +1,295 @@
+"""
+agent/personas.py
+─────────────────
+Named investor persona definitions.
+
+Each InvestorPersona encodes a legendary investor's philosophy as:
+  - checklist: the specific criteria they care about
+  - weights:   how much each data dimension matters to them
+  - system_prompt: the LLM persona voice (injected as system message)
+
+PERSONAS keyed by short id: buffett, jhunjhunwala, lynch, soros, munger
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class InvestorPersona:
+    """Represents a named investor's analytical style and philosophy."""
+
+    id: str
+    """Short lowercase identifier — 'buffett', 'jhunjhunwala', 'lynch', 'soros', 'munger'."""
+
+    name: str
+    """Full display name — 'Warren Buffett'."""
+
+    style: str
+    """Investment style — 'value' | 'growth-value' | 'garp' | 'macro' | 'quality'."""
+
+    checklist: list[str]
+    """Specific criteria this persona evaluates. Must have ≥5 items."""
+
+    weights: dict[str, float]
+    """
+    Dimension weights summing to 1.0.
+    Keys: 'fundamentals', 'technicals', 'macro', 'sentiment', 'options'
+    Not all keys required — only those relevant to this persona.
+    """
+
+    system_prompt: str
+    """Full LLM system prompt placing the model in this persona's shoes."""
+
+
+# ── Persona definitions ──────────────────────────────────────
+
+
+PERSONAS: dict[str, InvestorPersona] = {
+    "buffett": InvestorPersona(
+        id="buffett",
+        name="Warren Buffett",
+        style="value",
+        checklist=[
+            "ROE > 15% consistently over 5 years",
+            "Debt/Equity < 0.5 (low leverage)",
+            "FCF yield > 5% (strong cash generation)",
+            "Durable competitive moat (brand, network effects, cost advantage)",
+            "Pricing power — can raise prices without losing customers",
+            "Understandable business within circle of competence",
+            "Management quality and capital allocation track record",
+            "Shareholder-friendly: buybacks or dividends, not empire building",
+        ],
+        weights={
+            "fundamentals": 0.65,
+            "macro": 0.10,
+            "technicals": 0.05,
+            "sentiment": 0.10,
+            "options": 0.10,
+        },
+        system_prompt=(
+            "You are Warren Buffett, the Oracle of Omaha. You analyse stocks through the lens "
+            "of long-term value investing, as practised at Berkshire Hathaway. "
+            "\n\n"
+            "Your philosophy:\n"
+            "- You only invest in businesses you thoroughly understand — your 'circle of "
+            "competence'. If you can't explain the business model in plain English, you pass.\n"
+            "- You think of buying a stock as buying a piece of a business, not a trading chip. "
+            "Your typical holding horizon is 10 years or more.\n"
+            "- 'Mr. Market' is there to serve you, not to guide you. When the market is fearful, "
+            "you look for opportunities; when it is greedy, you are cautious.\n"
+            "- You demand a 'margin of safety' — buying at a significant discount to intrinsic "
+            "value, so even if you're somewhat wrong, you won't lose much.\n"
+            "- High-quality businesses with durable moats (Jio-like telecom reach, brand like "
+            "Asian Paints) are worth paying a fair price for.\n"
+            "- You are deeply sceptical of capital-intensive businesses that require constant "
+            "reinvestment just to stay in place.\n"
+            "- ROE, FCF yield, and low debt are your primary checkpoints.\n"
+            "\n"
+            "Communication style:\n"
+            "- Measured, folksy, occasionally self-deprecating.\n"
+            "- Use folksy analogies — 'you don't need to know a man's exact weight to know he's "
+            "fat'.\n"
+            "- Reference Berkshire Hathaway when relevant.\n"
+            "- Avoid jargon. Speak as if explaining to a sensible Midwesterner.\n"
+            "- Always conclude with a plain-English verdict and your key concern or enthusiasm.\n"
+        ),
+    ),
+    "jhunjhunwala": InvestorPersona(
+        id="jhunjhunwala",
+        name="Rakesh Jhunjhunwala",
+        style="growth-value",
+        checklist=[
+            "Strong India macro tailwind (consumption, infrastructure, demographics)",
+            "Earnings trajectory positive over 3-year horizon",
+            "Promoter quality — skin in the game, clean track record",
+            "Sectoral leadership — #1 or #2 player in a growing sector",
+            "Reasonable PE relative to earnings growth (PEG < 1.5 acceptable for India leaders)",
+            "India domestic consumption story — catering to rising middle class",
+            "Management bandwidth to execute at scale",
+        ],
+        weights={
+            "fundamentals": 0.40,
+            "macro": 0.30,
+            "technicals": 0.20,
+            "sentiment": 0.10,
+        },
+        system_prompt=(
+            "You are Rakesh Jhunjhunwala — 'Big Bull', India's most celebrated stock market "
+            "investor. You built a fortune betting on India's long-term economic growth story "
+            "before most people believed in it.\n\n"
+            "Your philosophy:\n"
+            "- 'Mera Bharat Mahan' — India is on an unstoppable growth path. You always start "
+            "with the macro: is India's economy working in this sector's favour?\n"
+            "- You prefer growth companies — businesses expanding earnings at 20-25%+ — but you "
+            "also demand reasonable valuations. You are not a pure growth investor; you want "
+            "value within growth.\n"
+            "- You focus on the next 10 years of Indian growth, not the next 10 weeks.\n"
+            "- Promoter quality matters enormously to you. A founder with skin in the game, "
+            "who has built a business honestly, earns your trust.\n"
+            "- You do not fear volatility. You have seen market crashes and bought aggressively "
+            "during them. Corrections are opportunities.\n"
+            "- Sectoral tailwinds are crucial: whether it's IT, banking, aviation, retail, or "
+            "defence — you want to be in sectors that India's structural growth will lift.\n"
+            "\n"
+            "Communication style:\n"
+            "- Direct, confident, optimistic about India.\n"
+            "- Enthusiastic — you genuinely love markets.\n"
+            "- Reference India's growth story and demographics when relevant.\n"
+            "- Do not hedge excessively — you take strong views.\n"
+            "- End with a clear buy/hold/sell and the central India macro thesis driving it.\n"
+        ),
+    ),
+    "lynch": InvestorPersona(
+        id="lynch",
+        name="Peter Lynch",
+        style="garp",
+        checklist=[
+            "PEG ratio < 1.0 (growth at a reasonable price)",
+            "Business explainable in one sentence — the 'cocktail party' test",
+            "Consistent earnings growth over 3-5 years (not lumpy or one-off)",
+            "Low institutional ownership — opportunity before the herd arrives",
+            "Identifiable earnings catalyst in the next 12-18 months",
+            "Reasonable debt load — not leveraged to the hilt",
+            "Category leadership — 'stalwart', 'fast grower', or 'turnaround' clearly identified",
+        ],
+        weights={
+            "fundamentals": 0.50,
+            "technicals": 0.20,
+            "sentiment": 0.20,
+            "macro": 0.10,
+        },
+        system_prompt=(
+            "You are Peter Lynch, legendary manager of the Fidelity Magellan Fund, who delivered "
+            "29% annual returns over 13 years. Your investment philosophy is grounded in common "
+            "sense and accessible research.\n\n"
+            "Your philosophy:\n"
+            "- 'Invest in what you know.' The best stock ideas come from everyday life — "
+            "products you use, stores that are always crowded, services you can't live without.\n"
+            "- The PEG ratio is your north star: price-to-earnings divided by growth rate. "
+            "A PEG below 1.0 is attractive; above 2.0 is expensive.\n"
+            "- You classify companies: Slow Growers (stalwarts), Fast Growers, Cyclicals, "
+            "Turnarounds, Asset Plays. Each requires a different analysis.\n"
+            "- If you can't describe why you own a stock in 2 minutes — the 'cocktail party test' "
+            "— you shouldn't own it. Complex financial engineering is a red flag.\n"
+            "- You distrust companies with high institutional ownership. The real opportunity "
+            "is in underfollowed stocks before big money arrives.\n"
+            "- Earnings growth consistency matters more than a flashy quarter.\n"
+            "\n"
+            "Communication style:\n"
+            "- Plain-speaking, practical, slightly self-deprecating.\n"
+            "- Use everyday analogies — 'I found this company at a mall', 'my wife noticed...'\n"
+            "- Explain if this is a Fast Grower, Stalwart, Turnaround, or Cyclical.\n"
+            "- Always check: can this business be explained to a 10-year-old?\n"
+            "- Give the PEG ratio and whether you find it compelling.\n"
+        ),
+    ),
+    "soros": InvestorPersona(
+        id="soros",
+        name="George Soros",
+        style="macro",
+        checklist=[
+            "Reflexivity thesis: does rising price itself improve the fundamental outlook?",
+            "INR/USD trend — currency risk or tailwind for this sector",
+            "FII flow momentum — are foreign institutions buying or selling India?",
+            "Rate cycle position — RBI easing or tightening, impact on multiples",
+            "Global risk-on / risk-off regime — EM appetite",
+            "India VIX regime — fear vs. complacency",
+            "Boom-bust cycle stage — early boom, late boom, or bust?",
+        ],
+        weights={
+            "macro": 0.50,
+            "sentiment": 0.25,
+            "technicals": 0.20,
+            "fundamentals": 0.05,
+        },
+        system_prompt=(
+            "You are George Soros, the legendary macro investor known for the theory of "
+            "reflexivity and for 'Breaking the Bank of England' in 1992. You see financial "
+            "markets as a complex adaptive system where perceptions and reality interact.\n\n"
+            "Your philosophy:\n"
+            "- Reflexivity: Market participants' biased views affect the fundamentals they are "
+            "trying to predict. A rising stock attracts more capital, which funds expansion, "
+            "which justifies the price rise — until it doesn't.\n"
+            "- You look for 'boom-bust' sequences: identify the prevailing bias, determine "
+            "whether it is self-reinforcing, and position accordingly — but exit before the bust.\n"
+            "- Macro flows dominate: FII flows, currency trends, central bank policy, and global "
+            "risk appetite matter far more to you than a company's P/E ratio.\n"
+            "- You are contrarian at extremes — when the consensus is overwhelmingly bullish or "
+            "bearish, you look the other way.\n"
+            "- India VIX and FII data are your primary instruments for gauging regime.\n"
+            "\n"
+            "Communication style:\n"
+            "- Abstract, philosophical, occasionally opaque.\n"
+            "- Reference 'reflexivity', 'boom-bust', and 'prevailing bias' frequently.\n"
+            "- Focus on the narrative momentum rather than the fundamental details.\n"
+            "- Do not pretend to know exact price targets — you deal in regimes, not levels.\n"
+            "- End with your read on the current boom-bust stage and whether the reflexive "
+            "loop is still self-reinforcing.\n"
+        ),
+    ),
+    "munger": InvestorPersona(
+        id="munger",
+        name="Charlie Munger",
+        style="quality",
+        checklist=[
+            "Inversion: what could go catastrophically wrong? (always ask this first)",
+            "Sustainable competitive advantage — not just current, but durable over 10+ years",
+            "Management incentives aligned with shareholders (not just lip service)",
+            "Accounting quality — no aggressive revenue recognition, low accruals",
+            "Insider buying (not selling) — management putting their own money in",
+            "Business model durability — not reliant on commodity pricing or regulation",
+            "Avoid complexity: if you need a PhD to understand the business model, avoid it",
+        ],
+        weights={
+            "fundamentals": 0.55,
+            "macro": 0.15,
+            "technicals": 0.10,
+            "sentiment": 0.20,
+        },
+        system_prompt=(
+            "You are Charlie Munger, Warren Buffett's long-time partner at Berkshire Hathaway "
+            "and one of the greatest investors of the 20th century. You are known for applying "
+            "mental models from multiple disciplines — psychology, physics, economics, biology "
+            "— to investment analysis.\n\n"
+            "Your philosophy:\n"
+            "- Inversion first. Always ask: 'Tell me where I'll die, so I never go there.' "
+            "Before considering why to buy, exhaustively consider what could go wrong.\n"
+            "- A 'latticework of mental models' drawn from many disciplines gives you an "
+            "edge over investors who use only financial tools.\n"
+            "- Quality of the business matters more than the price. You'd rather buy a "
+            "wonderful business at a fair price than a fair business at a wonderful price.\n"
+            "- Management incentives are everything. Badly designed incentive structures "
+            "reliably produce bad outcomes. Always check how management is paid.\n"
+            "- Accounting quality is paramount — you are deeply suspicious of companies "
+            "with complex structures, frequent one-off charges, or aggressive revenue recognition.\n"
+            "- You despise commodity businesses, complex financial engineering, and anything "
+            "that requires constant reinvention to survive.\n"
+            "\n"
+            "Communication style:\n"
+            "- Pithy, direct, occasionally scathing.\n"
+            "- Start by inverting — 'The first question is what could go wrong.'\n"
+            "- Use mental models explicitly: 'second-order effects', 'Lollapalooza effect', "
+            "'incentive-caused bias'.\n"
+            "- Be cynical about management unless proven otherwise.\n"
+            "- Keep sentences short and declarative. No waffling.\n"
+        ),
+    ),
+}
+
+
+def get_persona(persona_id: str) -> InvestorPersona:
+    """Return the InvestorPersona for a given id.
+
+    Raises ValueError for unknown ids.
+    """
+    persona = PERSONAS.get(persona_id.lower())
+    if persona is None:
+        valid = ", ".join(sorted(PERSONAS.keys()))
+        raise ValueError(f"Unknown persona '{persona_id}'. Valid options: {valid}")
+    return persona
+
+
+def list_personas() -> list[InvestorPersona]:
+    """Return all defined personas in a stable order."""
+    order = ["buffett", "jhunjhunwala", "lynch", "soros", "munger"]
+    return [PERSONAS[k] for k in order if k in PERSONAS]

--- a/app/commands/persona.py
+++ b/app/commands/persona.py
@@ -1,0 +1,338 @@
+"""
+app/commands/persona.py
+───────────────────────
+CLI command handler for named investor persona analysis.
+
+Commands:
+  persona list                  — show all personas table
+  persona <id> <SYMBOL>         — single persona analysis
+  debate <SYMBOL>               — all 5 personas + consensus table
+
+Output delegates to agent/persona_agent.py for the analysis logic
+and renders results with Rich tables.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+from rich import box
+
+from agent.personas import get_persona, list_personas
+from agent.persona_agent import run_persona_analysis, run_debate
+from agent.schemas import PersonaSignal
+
+console = Console()
+
+# Verdict → Rich colour
+_VERDICT_COLOUR = {
+    "STRONG_BUY": "bold green",
+    "BUY": "green",
+    "HOLD": "yellow",
+    "SELL": "red",
+    "STRONG_SELL": "bold red",
+}
+
+
+def _verdict_styled(verdict: str) -> str:
+    colour = _VERDICT_COLOUR.get(verdict, "white")
+    return f"[{colour}]{verdict}[/{colour}]"
+
+
+# ── persona list ──────────────────────────────────────────────
+
+
+def _cmd_persona_list() -> None:
+    table = Table(
+        title="Named Investor Personas",
+        show_header=True,
+        header_style="bold cyan",
+        box=box.SIMPLE_HEAVY,
+        padding=(0, 1),
+    )
+    table.add_column("ID", style="bold", width=14)
+    table.add_column("Name", width=22)
+    table.add_column("Style", width=14)
+    table.add_column("Top Focus", width=44)
+
+    focus_map = {
+        "buffett": "ROE >15%, FCF yield >5%, durable moat, low D/E",
+        "jhunjhunwala": "India macro, earnings trajectory, promoter quality",
+        "lynch": "PEG <1.0, explainable business, low institutional ownership",
+        "soros": "Reflexivity, FII flows, INR trend, boom-bust regime",
+        "munger": "Inversion, management incentives, accounting quality",
+    }
+
+    for persona in list_personas():
+        table.add_row(
+            persona.id,
+            persona.name,
+            persona.style,
+            focus_map.get(persona.id, ""),
+        )
+
+    console.print()
+    console.print(table)
+    console.print(
+        "[dim]Usage: persona <id> <SYMBOL>   e.g. persona buffett RELIANCE[/dim]\n"
+        "[dim]       debate <SYMBOL>          e.g. debate INFY[/dim]\n"
+    )
+
+
+# ── persona <id> <SYMBOL> ─────────────────────────────────────
+
+
+def _cmd_single_persona(
+    persona_id: str,
+    symbol: str,
+    exchange: str,
+    registry: Any,
+    llm_provider: Any,
+) -> None:
+    try:
+        persona = get_persona(persona_id)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        return
+
+    console.print(f"\n[dim]Analysing {exchange}:{symbol} as {persona.name}...[/dim]")
+
+    try:
+        signal = run_persona_analysis(
+            persona_id=persona_id,
+            symbol=symbol,
+            exchange=exchange,
+            registry=registry,
+            llm_provider=llm_provider,
+        )
+    except Exception as e:
+        console.print(f"[red]Persona analysis failed:[/red] {e}")
+        return
+
+    # ── Header ────────────────────────────────────────────────
+    console.print()
+    console.rule(
+        f"[bold]{persona.name} on {exchange}:{symbol}[/bold]",
+        style="cyan",
+    )
+
+    # ── Signal ────────────────────────────────────────────────
+    verdict_str = _verdict_styled(signal.verdict)
+    console.print(f"  Signal     : {verdict_str}  ({signal.confidence}% confidence)")
+
+    # ── Checklist ─────────────────────────────────────────────
+    if signal.rationale:
+        console.print("  Checklist  :")
+        for item in signal.rationale:
+            console.print(f"    {item}")
+
+    # ── Key metrics ───────────────────────────────────────────
+    if signal.key_metrics:
+        console.print("  Key Metrics:")
+        for k, v in signal.key_metrics.items():
+            console.print(f"    [dim]{k:<12}[/dim]: {v}")
+
+    console.print()
+
+
+# ── debate <SYMBOL> ───────────────────────────────────────────
+
+
+def _cmd_debate(
+    symbol: str,
+    exchange: str,
+    registry: Any,
+    llm_provider: Any,
+) -> None:
+    console.print(f"\n[dim]Running investor debate on {exchange}:{symbol}...[/dim]")
+
+    try:
+        signals = run_debate(
+            symbol=symbol,
+            exchange=exchange,
+            registry=registry,
+            llm_provider=llm_provider,
+        )
+    except Exception as e:
+        console.print(f"[red]Debate failed:[/red] {e}")
+        return
+
+    if not signals:
+        console.print("[dim]No signals returned.[/dim]")
+        return
+
+    # ── Header ────────────────────────────────────────────────
+    console.print()
+    console.rule(
+        f"[bold]Investor Debate: {exchange}:{symbol}[/bold]",
+        style="cyan",
+    )
+
+    # ── Debate table ──────────────────────────────────────────
+    table = Table(
+        show_header=True,
+        header_style="bold cyan",
+        box=box.SIMPLE_HEAVY,
+        padding=(0, 1),
+    )
+    table.add_column("Persona", width=18)
+    table.add_column("Signal", width=12)
+    table.add_column("Confidence", justify="right", width=12)
+    table.add_column("Key Factor", width=36)
+
+    name_map = {p.id: p.name for p in list_personas()}
+
+    for signal in signals:
+        persona_name = name_map.get(signal.persona, signal.persona.title())
+        top_factor = ""
+        if signal.key_metrics:
+            # Pick first key metric as the "key factor" display
+            k, v = next(iter(signal.key_metrics.items()))
+            top_factor = f"{k}: {v}"
+        elif signal.rationale:
+            # Use first rationale item, strip leading check marks
+            top_factor = signal.rationale[0].lstrip("✓✗~— ").strip()
+            if len(top_factor) > 34:
+                top_factor = top_factor[:31] + "..."
+
+        table.add_row(
+            persona_name,
+            _verdict_styled(signal.verdict),
+            f"{signal.confidence}%",
+            top_factor,
+        )
+
+    console.print(table)
+
+    # ── Consensus ─────────────────────────────────────────────
+    _print_consensus(signals, name_map)
+    console.print()
+
+
+def _print_consensus(signals: list[PersonaSignal], name_map: dict[str, str]) -> None:
+    """Compute and print the consensus verdict line."""
+    # Bucket verdicts
+    buy_verdicts = {"STRONG_BUY", "BUY"}
+    sell_verdicts = {"STRONG_SELL", "SELL"}
+
+    buy_camp: list[str] = []
+    sell_camp: list[str] = []
+    hold_camp: list[str] = []
+
+    for sig in signals:
+        name = name_map.get(sig.persona, sig.persona.title())
+        if sig.verdict in buy_verdicts:
+            buy_camp.append(name)
+        elif sig.verdict in sell_verdicts:
+            sell_camp.append(name)
+        else:
+            hold_camp.append(name)
+
+    # Plurality wins
+    counts = {
+        "BUY": len(buy_camp),
+        "HOLD": len(hold_camp),
+        "SELL": len(sell_camp),
+    }
+    consensus = max(counts, key=lambda k: counts[k])
+    count = counts[consensus]
+
+    consensus_str = _verdict_styled(consensus)
+    parts = [f"  Consensus  : {consensus_str} ({count}/{len(signals)})"]
+
+    if consensus == "HOLD":
+        if buy_camp:
+            parts.append(f"  — BUY camp: {', '.join(buy_camp)}")
+        if sell_camp:
+            parts.append(f"  — SELL camp: {', '.join(sell_camp)}")
+    elif consensus == "BUY":
+        if hold_camp or sell_camp:
+            dissenters = hold_camp + sell_camp
+            parts.append(f"  — Cautious: {', '.join(dissenters)}")
+    elif consensus == "SELL":
+        if hold_camp or buy_camp:
+            dissenters = hold_camp + buy_camp
+            parts.append(f"  — Bullish holdouts: {', '.join(dissenters)}")
+
+    for part in parts:
+        console.print(part)
+
+
+# ── Main dispatcher ───────────────────────────────────────────
+
+
+def run(args: list[str], registry: Any = None, llm_provider: Any = None) -> None:
+    """
+    Dispatch persona commands.
+
+    Called with:
+      args = ["list"]                       → show all personas
+      args = ["buffett", "RELIANCE"]        → single persona
+      args = ["buffett", "NSE:RELIANCE"]    → explicit exchange
+    """
+    if not args or args[0].lower() == "list":
+        _cmd_persona_list()
+        return
+
+    if len(args) < 2:
+        console.print(
+            "[red]Usage:[/red]\n"
+            "  [cyan]persona list[/cyan]                   — all personas\n"
+            "  [cyan]persona <id> <SYMBOL>[/cyan]          — e.g. persona buffett RELIANCE\n"
+            "  [cyan]persona <id> NSE:<SYMBOL>[/cyan]      — explicit exchange\n"
+        )
+        return
+
+    persona_id = args[0].lower()
+    symbol_arg = args[1].upper()
+
+    # Parse optional exchange prefix: "NSE:RELIANCE"
+    if ":" in symbol_arg:
+        exchange, symbol = symbol_arg.split(":", 1)
+    else:
+        exchange = "NSE"
+        symbol = symbol_arg
+
+    _cmd_single_persona(
+        persona_id=persona_id,
+        symbol=symbol,
+        exchange=exchange,
+        registry=registry,
+        llm_provider=llm_provider,
+    )
+
+
+def run_debate_command(
+    args: list[str],
+    registry: Any = None,
+    llm_provider: Any = None,
+) -> None:
+    """
+    Dispatch the debate command.
+
+    Called with:
+      args = ["RELIANCE"]            → debate on NSE:RELIANCE
+      args = ["NSE:RELIANCE"]        → explicit exchange
+    """
+    if not args:
+        console.print(
+            "[red]Usage: debate <SYMBOL>[/red]\n[dim]  debate RELIANCE\n  debate NSE:RELIANCE[/dim]"
+        )
+        return
+
+    symbol_arg = args[0].upper()
+
+    if ":" in symbol_arg:
+        exchange, symbol = symbol_arg.split(":", 1)
+    else:
+        exchange = "NSE"
+        symbol = symbol_arg
+
+    _cmd_debate(
+        symbol=symbol,
+        exchange=exchange,
+        registry=registry,
+        llm_provider=llm_provider,
+    )

--- a/app/repl.py
+++ b/app/repl.py
@@ -79,6 +79,8 @@ COMMANDS = [
     "alerts",
     "audit",
     "backtest",
+    "persona",
+    "debate",
     "clear",
     "deep-analyze",
     "drift",
@@ -1623,6 +1625,26 @@ def run_repl(broker: BrokerAPI) -> None:
                         )
                         console.print("[dim]Falling back to standard analysis...[/dim]")
                         agent.run_multi_agent_analysis(symbol)
+
+            elif command == "persona":
+                from app.commands.persona import run as persona_run
+
+                agent = get_agent()
+                persona_run(
+                    args=args,
+                    registry=getattr(agent, "_registry", None),
+                    llm_provider=getattr(agent, "_provider", None),
+                )
+
+            elif command == "debate":
+                from app.commands.persona import run_debate_command
+
+                agent = get_agent()
+                run_debate_command(
+                    args=args,
+                    registry=getattr(agent, "_registry", None),
+                    llm_provider=getattr(agent, "_provider", None),
+                )
 
             elif command == "quick":
                 # Quick scan: single-agent, 1 LLM call, 3-5s

--- a/specs/165-named-investor-personas.md
+++ b/specs/165-named-investor-personas.md
@@ -1,0 +1,129 @@
+# Spec: Named Investor Personas (#165)
+
+## Overview
+
+Add 5 named investor personas to the trading CLI — each representing a legendary investor's
+philosophy. Users can ask any persona to evaluate a stock or run a "debate" with all 5 personas
+producing their signals side-by-side.
+
+## Personas
+
+| ID             | Name                  | Style           |
+|----------------|-----------------------|-----------------|
+| buffett        | Warren Buffett        | value           |
+| jhunjhunwala   | Rakesh Jhunjhunwala   | growth-value    |
+| lynch          | Peter Lynch           | garp            |
+| soros          | George Soros          | macro           |
+| munger         | Charlie Munger        | quality         |
+
+## Data Model
+
+`PersonaSignal` — lives in `agent/schemas.py`:
+
+```python
+class PersonaSignal(BaseModel):
+    persona: str                   # persona id
+    verdict: Literal["STRONG_BUY","BUY","HOLD","SELL","STRONG_SELL"]
+    confidence: int                # 0-100
+    rationale: list[str]           # checklist items (pass/fail/partial)
+    key_metrics: dict[str, str]    # {"ROE": "8% (need >15%)", ...}
+```
+
+`InvestorPersona` — lives in `agent/personas.py`:
+
+```python
+@dataclass
+class InvestorPersona:
+    id: str
+    name: str
+    style: str
+    checklist: list[str]           # ≥5 items each
+    weights: dict[str, float]      # must sum to 1.0
+    system_prompt: str
+```
+
+## Files
+
+1. `agent/schemas.py` — `PersonaSignal(BaseModel)` Pydantic model
+2. `agent/personas.py` — `InvestorPersona` dataclass + `PERSONAS` dict + helpers
+3. `agent/persona_agent.py` — `run_persona_analysis()` + `run_debate()`
+4. `app/commands/persona.py` — CLI `run()` handler
+5. `app/repl.py` — wire in `persona` and `debate` commands
+6. `tests/test_personas.py` — tests (no LLM required)
+
+## Persona Weights
+
+| Persona      | fundamentals | macro | technicals | sentiment | options |
+|--------------|-------------|-------|------------|-----------|---------|
+| buffett      | 0.65        | 0.10  | 0.05       | 0.10      | 0.10    |
+| jhunjhunwala | 0.40        | 0.30  | 0.20       | 0.10      | —       |
+| lynch        | 0.50        | 0.10  | 0.20       | 0.20      | —       |
+| soros        | 0.05        | 0.50  | 0.20       | 0.25      | —       |
+| munger       | 0.55        | 0.15  | 0.10       | 0.20      | —       |
+
+Note: jhunjhunwala, lynch, soros, munger do not use options; their weights sum to 1.0 over
+the four categories they use.
+
+## Rule-Based Fallback (no LLM)
+
+When `llm_provider=None`, `run_persona_analysis()` uses a deterministic scoring approach:
+
+1. Fetch data via registry tools (or use empty defaults if registry is also None)
+2. Score each dimension (fundamentals, macro, technicals, sentiment, options) 0–100
+3. Weighted sum → overall score
+4. Map score to verdict: ≥80 STRONG_BUY, ≥65 BUY, ≥40 HOLD, ≥25 SELL, <25 STRONG_SELL
+5. Confidence = score (capped 0-100)
+
+## CLI Usage
+
+```
+persona list                    — list all 5 personas
+persona buffett RELIANCE        — single persona on NSE:RELIANCE
+persona buffett NSE:RELIANCE    — explicit exchange
+debate RELIANCE                 — all 5 personas + consensus
+```
+
+## Terminal Output
+
+Single persona (`persona buffett RELIANCE`):
+```
+━━━ Warren Buffett on NSE:RELIANCE ━━━━━━━━━━━━━━━━━
+Signal     : HOLD  (58% confidence)
+Checklist  :
+  ✓ Strong competitive moat (Jio telecom + retail)
+  ✗ ROE 8% — below 15% threshold
+  ✗ FCF yield 2.1% — want > 5%
+  ~ PE 28x: not cheap enough for uncertainty
+Key Metrics:
+  ROE    : 8% (threshold: >15%)
+  D/E    : 0.4 (ok)
+Reasoning  : [2-3 sentences in Buffett's voice]
+```
+
+Debate (`debate RELIANCE`):
+```
+━━━ Investor Debate: NSE:RELIANCE ━━━━━━━━━━━━━━━━━
+┌──────────────────┬────────────┬────────────┬──────────────────────┐
+│ Persona          │ Signal     │ Confidence │ Key Factor           │
+├──────────────────┼────────────┼────────────┼──────────────────────┤
+│ Buffett          │ HOLD       │ 58%        │ ROE below threshold  │
+│ Jhunjhunwala     │ BUY        │ 75%        │ India growth story   │
+│ Lynch            │ BUY        │ 68%        │ PEG < 1.2, clear biz │
+│ Soros            │ HOLD       │ 52%        │ FII flows mixed      │
+│ Munger           │ HOLD       │ 61%        │ Complexity concerns  │
+└──────────────────┴────────────┴────────────┴──────────────────────┘
+Consensus  : HOLD (3/5) — BUY camp: Jhunjhunwala, Lynch
+```
+
+## Testing Requirements
+
+All tests in `tests/test_personas.py`, no LLM required:
+
+- All 5 personas defined in PERSONAS dict
+- Each has non-empty checklist (≥5 items), weights summing to 1.0, non-empty system_prompt
+- `get_persona("buffett")` returns InvestorPersona with correct id
+- `get_persona("invalid")` raises ValueError
+- `list_personas()` returns exactly 5 items
+- `PersonaSignal` validates correctly (verdict enum, confidence 0-100)
+- Deterministic fallback (no LLM, no registry) returns valid PersonaSignal
+- `parse_persona_response` handles valid, partial, and empty text

--- a/tests/test_personas.py
+++ b/tests/test_personas.py
@@ -1,0 +1,563 @@
+"""
+tests/test_personas.py
+──────────────────────
+Tests for the named investor personas feature (#165).
+
+All tests are deterministic — no LLM or network calls required.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent.personas import (
+    PERSONAS,
+    InvestorPersona,
+    get_persona,
+    list_personas,
+)
+from agent.schemas import PersonaSignal
+from agent.persona_agent import (
+    parse_persona_response,
+    run_persona_analysis,
+    _rule_based_signal,
+    _score_dimension,
+)
+
+
+# ── Persona definitions ───────────────────────────────────────
+
+
+class TestPersonaDefinitions:
+    """Validate that all 5 personas are correctly defined."""
+
+    EXPECTED_IDS = {"buffett", "jhunjhunwala", "lynch", "soros", "munger"}
+
+    def test_all_five_personas_defined(self):
+        assert set(PERSONAS.keys()) == self.EXPECTED_IDS
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_checklist_has_at_least_five_items(self, persona_id: str):
+        persona = PERSONAS[persona_id]
+        assert len(persona.checklist) >= 5, (
+            f"{persona_id}.checklist has {len(persona.checklist)} items — need ≥5"
+        )
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_weights_sum_to_one(self, persona_id: str):
+        persona = PERSONAS[persona_id]
+        total = sum(persona.weights.values())
+        assert abs(total - 1.0) < 1e-9, f"{persona_id}.weights sum to {total:.4f}, expected 1.0"
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_system_prompt_non_empty(self, persona_id: str):
+        persona = PERSONAS[persona_id]
+        assert persona.system_prompt.strip(), f"{persona_id}.system_prompt is empty"
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_system_prompt_has_meaningful_length(self, persona_id: str):
+        persona = PERSONAS[persona_id]
+        assert len(persona.system_prompt) >= 200, (
+            f"{persona_id}.system_prompt too short ({len(persona.system_prompt)} chars)"
+        )
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_all_weight_values_positive(self, persona_id: str):
+        persona = PERSONAS[persona_id]
+        for dim, w in persona.weights.items():
+            assert w > 0, f"{persona_id}.weights[{dim}] = {w}, must be > 0"
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_persona_is_dataclass_instance(self, persona_id: str):
+        persona = PERSONAS[persona_id]
+        assert isinstance(persona, InvestorPersona)
+
+    def test_buffett_weights(self):
+        p = PERSONAS["buffett"]
+        assert p.weights["fundamentals"] == pytest.approx(0.65)
+        assert p.weights["macro"] == pytest.approx(0.10)
+        assert p.weights["technicals"] == pytest.approx(0.05)
+
+    def test_soros_macro_dominant(self):
+        """Soros should have macro as largest weight."""
+        p = PERSONAS["soros"]
+        assert p.weights["macro"] == pytest.approx(0.50)
+        assert p.weights["macro"] == max(p.weights.values())
+
+    def test_jhunjhunwala_no_options(self):
+        """Jhunjhunwala does not use options dimension."""
+        p = PERSONAS["jhunjhunwala"]
+        assert "options" not in p.weights
+
+    def test_styles_are_correct(self):
+        assert PERSONAS["buffett"].style == "value"
+        assert PERSONAS["jhunjhunwala"].style == "growth-value"
+        assert PERSONAS["lynch"].style == "garp"
+        assert PERSONAS["soros"].style == "macro"
+        assert PERSONAS["munger"].style == "quality"
+
+
+# ── Helper functions ──────────────────────────────────────────
+
+
+class TestGetPersona:
+    def test_returns_correct_persona(self):
+        persona = get_persona("buffett")
+        assert isinstance(persona, InvestorPersona)
+        assert persona.id == "buffett"
+        assert persona.name == "Warren Buffett"
+
+    def test_case_insensitive(self):
+        persona = get_persona("BUFFETT")
+        assert persona.id == "buffett"
+
+    def test_raises_for_unknown_id(self):
+        with pytest.raises(ValueError, match="Unknown persona"):
+            get_persona("invalid_persona_xyz")
+
+    def test_raises_for_empty_string(self):
+        with pytest.raises(ValueError):
+            get_persona("")
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_all_known_ids_return_persona(self, persona_id: str):
+        persona = get_persona(persona_id)
+        assert persona.id == persona_id
+
+
+class TestListPersonas:
+    def test_returns_five_items(self):
+        personas = list_personas()
+        assert len(personas) == 5
+
+    def test_all_items_are_investor_persona(self):
+        for p in list_personas():
+            assert isinstance(p, InvestorPersona)
+
+    def test_stable_order(self):
+        order_a = [p.id for p in list_personas()]
+        order_b = [p.id for p in list_personas()]
+        assert order_a == order_b
+
+    def test_buffett_first(self):
+        """Buffett should be listed first by convention."""
+        assert list_personas()[0].id == "buffett"
+
+
+# ── PersonaSignal schema ──────────────────────────────────────
+
+
+class TestPersonaSignal:
+    def test_valid_signal_creation(self):
+        sig = PersonaSignal(
+            persona="buffett",
+            verdict="BUY",
+            confidence=75,
+            rationale=["Strong moat", "FCF positive"],
+            key_metrics={"ROE": "18%"},
+        )
+        assert sig.verdict == "BUY"
+        assert sig.confidence == 75
+
+    def test_all_verdict_values_accepted(self):
+        for verdict in ("STRONG_BUY", "BUY", "HOLD", "SELL", "STRONG_SELL"):
+            sig = PersonaSignal(
+                persona="test",
+                verdict=verdict,
+                confidence=50,
+                rationale=["item"],
+                key_metrics={},
+            )
+            assert sig.verdict == verdict
+
+    def test_invalid_verdict_raises(self):
+        with pytest.raises(ValidationError):
+            PersonaSignal(
+                persona="test",
+                verdict="STRONG_MAYBE",
+                confidence=50,
+                rationale=[],
+                key_metrics={},
+            )
+
+    def test_confidence_zero_accepted(self):
+        sig = PersonaSignal(
+            persona="test",
+            verdict="HOLD",
+            confidence=0,
+            rationale=[],
+            key_metrics={},
+        )
+        assert sig.confidence == 0
+
+    def test_confidence_100_accepted(self):
+        sig = PersonaSignal(
+            persona="test",
+            verdict="STRONG_BUY",
+            confidence=100,
+            rationale=[],
+            key_metrics={},
+        )
+        assert sig.confidence == 100
+
+    def test_confidence_below_zero_raises(self):
+        with pytest.raises(ValidationError):
+            PersonaSignal(
+                persona="test",
+                verdict="HOLD",
+                confidence=-1,
+                rationale=[],
+                key_metrics={},
+            )
+
+    def test_confidence_above_100_raises(self):
+        with pytest.raises(ValidationError):
+            PersonaSignal(
+                persona="test",
+                verdict="HOLD",
+                confidence=101,
+                rationale=[],
+                key_metrics={},
+            )
+
+    def test_empty_rationale_accepted(self):
+        sig = PersonaSignal(
+            persona="test",
+            verdict="HOLD",
+            confidence=50,
+            rationale=[],
+            key_metrics={},
+        )
+        assert sig.rationale == []
+
+    def test_key_metrics_can_be_empty(self):
+        sig = PersonaSignal(
+            persona="test",
+            verdict="HOLD",
+            confidence=50,
+            rationale=["item"],
+            key_metrics={},
+        )
+        assert sig.key_metrics == {}
+
+
+# ── parse_persona_response ────────────────────────────────────
+
+
+class TestParsePersonaResponse:
+    def test_full_valid_response(self):
+        text = """
+VERDICT: BUY
+CONFIDENCE: 72
+RATIONALE:
+- Strong moat in telecom
+- ROE above 15%
+- Low debt
+KEY_METRICS:
+ROE: 18% (above threshold)
+D/E: 0.3
+"""
+        sig = parse_persona_response(text, "buffett")
+        assert sig.verdict == "BUY"
+        assert sig.confidence == 72
+        assert len(sig.rationale) >= 1
+        assert sig.persona == "buffett"
+
+    def test_strong_buy_verdict(self):
+        text = "VERDICT: STRONG_BUY\nCONFIDENCE: 88\nRATIONALE:\n- Excellent business"
+        sig = parse_persona_response(text, "buffett")
+        assert sig.verdict == "STRONG_BUY"
+
+    def test_strong_sell_verdict(self):
+        text = "VERDICT: STRONG_SELL\nCONFIDENCE: 85\nRATIONALE:\n- Poor fundamentals"
+        sig = parse_persona_response(text, "soros")
+        assert sig.verdict == "STRONG_SELL"
+
+    def test_empty_text_returns_hold(self):
+        sig = parse_persona_response("", "buffett")
+        assert sig.verdict == "HOLD"
+        assert sig.confidence == 30
+
+    def test_none_like_text_returns_hold(self):
+        sig = parse_persona_response("   ", "lynch")
+        assert sig.verdict == "HOLD"
+
+    def test_partial_response_no_confidence(self):
+        text = "VERDICT: SELL\nThis stock looks bad."
+        sig = parse_persona_response(text, "munger")
+        assert sig.verdict == "SELL"
+        assert sig.confidence == 50  # default
+
+    def test_partial_response_no_verdict(self):
+        text = "CONFIDENCE: 65\nRATIONALE:\n- Item one\n- Item two"
+        sig = parse_persona_response(text, "jhunjhunwala")
+        assert sig.verdict == "HOLD"  # default
+        assert sig.confidence == 65
+
+    def test_confidence_clamped_to_100(self):
+        text = "VERDICT: BUY\nCONFIDENCE: 999\nRATIONALE:\n- bullet"
+        sig = parse_persona_response(text, "buffett")
+        assert sig.confidence == 100
+
+    def test_confidence_invalid_negative_falls_back_to_default(self):
+        # Negative confidence values can't be captured by \d+ regex,
+        # so the parser uses the default (50).
+        text = "VERDICT: SELL\nRATIONALE:\n- bullet"
+        sig = parse_persona_response(text, "buffett")
+        assert sig.confidence == 50  # default when no valid confidence present
+
+    def test_rationale_items_extracted(self):
+        text = """VERDICT: HOLD
+CONFIDENCE: 55
+RATIONALE:
+- First item
+- Second item
+- Third item"""
+        sig = parse_persona_response(text, "buffett")
+        assert len(sig.rationale) >= 3
+
+    def test_key_metrics_extracted(self):
+        text = """VERDICT: BUY
+CONFIDENCE: 70
+RATIONALE:
+- good
+KEY_METRICS:
+ROE: 20%
+PE: 18x"""
+        sig = parse_persona_response(text, "buffett")
+        assert "ROE" in sig.key_metrics
+        assert sig.key_metrics["ROE"] == "20%"
+
+    def test_persona_id_preserved(self):
+        text = "VERDICT: BUY\nCONFIDENCE: 60\nRATIONALE:\n- ok"
+        sig = parse_persona_response(text, "munger")
+        assert sig.persona == "munger"
+
+    def test_non_standard_response_with_bullets_and_explicit_verdict(self):
+        """Response with bullets and explicit VERDICT: key."""
+        text = """This stock looks interesting.
+VERDICT: BUY
+CONFIDENCE: 65
+RATIONALE:
+• Strong brand presence
+• Growing revenue
+• Reasonable PE"""
+        sig = parse_persona_response(text, "lynch")
+        assert sig.verdict == "BUY"
+        assert sig.confidence == 65
+        assert len(sig.rationale) >= 1
+
+    def test_non_standard_response_no_verdict_key_defaults_hold(self):
+        """Response without a VERDICT: key should default to HOLD."""
+        text = """This stock looks interesting.
+• Strong brand presence
+• Growing revenue
+I would rate this a BUY."""
+        sig = parse_persona_response(text, "lynch")
+        # No VERDICT: tag → defaults to HOLD
+        assert sig.verdict == "HOLD"
+        assert len(sig.rationale) >= 1
+
+
+# ── Deterministic fallback ────────────────────────────────────
+
+
+class TestRuleBasedFallback:
+    """Tests for run_persona_analysis with no LLM and no registry."""
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_returns_valid_persona_signal(self, persona_id: str):
+        sig = run_persona_analysis(
+            persona_id=persona_id,
+            symbol="RELIANCE",
+            exchange="NSE",
+            registry=None,
+            llm_provider=None,
+        )
+        assert isinstance(sig, PersonaSignal)
+        assert sig.persona == persona_id
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_verdict_is_valid_enum(self, persona_id: str):
+        sig = run_persona_analysis(
+            persona_id=persona_id,
+            symbol="TCS",
+            exchange="NSE",
+            registry=None,
+            llm_provider=None,
+        )
+        assert sig.verdict in ("STRONG_BUY", "BUY", "HOLD", "SELL", "STRONG_SELL")
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_confidence_in_valid_range(self, persona_id: str):
+        sig = run_persona_analysis(
+            persona_id=persona_id,
+            symbol="INFY",
+            exchange="NSE",
+            registry=None,
+            llm_provider=None,
+        )
+        assert 0 <= sig.confidence <= 100
+
+    @pytest.mark.parametrize("persona_id", ["buffett", "jhunjhunwala", "lynch", "soros", "munger"])
+    def test_rationale_is_list(self, persona_id: str):
+        sig = run_persona_analysis(
+            persona_id=persona_id,
+            symbol="HDFCBANK",
+            exchange="NSE",
+            registry=None,
+            llm_provider=None,
+        )
+        assert isinstance(sig.rationale, list)
+
+    def test_invalid_persona_raises(self):
+        with pytest.raises(ValueError, match="Unknown persona"):
+            run_persona_analysis(
+                persona_id="notapersona",
+                symbol="RELIANCE",
+            )
+
+    def test_no_data_defaults_to_hold_zone(self):
+        """With no data (registry=None), scores default to 50 → HOLD range."""
+        sig = run_persona_analysis(
+            persona_id="buffett",
+            symbol="RELIANCE",
+            registry=None,
+            llm_provider=None,
+        )
+        # With all-neutral data, weighted score ~50 → HOLD
+        assert sig.verdict == "HOLD"
+
+    def test_rule_based_signal_direct(self):
+        """_rule_based_signal works with empty brief."""
+        brief: dict = {
+            "symbol": "TEST",
+            "exchange": "NSE",
+            "technicals": {},
+            "fundamentals": {},
+            "macro": {},
+            "news": [],
+            "fii_dii": {},
+        }
+        sig = _rule_based_signal("buffett", brief)
+        assert isinstance(sig, PersonaSignal)
+        assert sig.verdict in ("STRONG_BUY", "BUY", "HOLD", "SELL", "STRONG_SELL")
+
+    def test_good_fundamentals_increase_score(self):
+        """Strong fundamentals should raise the score for Buffett."""
+        brief_weak: dict = {
+            "symbol": "TEST",
+            "exchange": "NSE",
+            "technicals": {},
+            "fundamentals": {"roe": 5, "debt_equity": 2.0, "pe": 80},
+            "macro": {},
+            "news": [],
+            "fii_dii": {},
+        }
+        brief_strong: dict = {
+            "symbol": "TEST",
+            "exchange": "NSE",
+            "technicals": {},
+            "fundamentals": {"roe": 25, "debt_equity": 0.2, "pe": 14, "fcf_yield": 8},
+            "macro": {},
+            "news": [],
+            "fii_dii": {},
+        }
+        sig_weak = _rule_based_signal("buffett", brief_weak)
+        sig_strong = _rule_based_signal("buffett", brief_strong)
+        assert sig_strong.confidence >= sig_weak.confidence
+
+
+# ── Dimension scorer ──────────────────────────────────────────
+
+
+class TestScoreDimension:
+    def test_neutral_data_returns_near_50(self):
+        brief: dict = {
+            "technicals": {},
+            "fundamentals": {},
+            "macro": {},
+            "fii_dii": {},
+            "news": [],
+        }
+        score = _score_dimension("fundamentals", brief)
+        assert score == pytest.approx(50.0)
+
+    def test_high_roe_increases_fundamentals_score(self):
+        brief: dict = {
+            "technicals": {},
+            "fundamentals": {"roe": 22},
+            "macro": {},
+            "fii_dii": {},
+            "news": [],
+        }
+        score = _score_dimension("fundamentals", brief)
+        assert score > 50.0
+
+    def test_oversold_rsi_increases_technicals_score(self):
+        brief: dict = {
+            "technicals": {"rsi": 25},
+            "fundamentals": {},
+            "macro": {},
+            "fii_dii": {},
+            "news": [],
+        }
+        score = _score_dimension("technicals", brief)
+        assert score > 50.0
+
+    def test_overbought_rsi_decreases_technicals_score(self):
+        brief: dict = {
+            "technicals": {"rsi": 80},
+            "fundamentals": {},
+            "macro": {},
+            "fii_dii": {},
+            "news": [],
+        }
+        score = _score_dimension("technicals", brief)
+        assert score < 50.0
+
+    def test_positive_fii_increases_macro_score(self):
+        brief: dict = {
+            "technicals": {},
+            "fundamentals": {},
+            "macro": {},
+            "fii_dii": {"net": 5000},
+            "news": [],
+        }
+        score = _score_dimension("macro", brief)
+        assert score > 50.0
+
+    def test_unknown_dimension_returns_50(self):
+        brief: dict = {
+            "technicals": {},
+            "fundamentals": {},
+            "macro": {},
+            "fii_dii": {},
+            "news": [],
+        }
+        score = _score_dimension("unknown_dimension_xyz", brief)
+        assert score == pytest.approx(50.0)
+
+    def test_score_always_in_range(self):
+        """Score must always be within 0-100 regardless of extreme inputs."""
+        briefs = [
+            {
+                "technicals": {"rsi": 1000},
+                "fundamentals": {"roe": -999},
+                "macro": {},
+                "fii_dii": {},
+                "news": [],
+            },
+            {
+                "technicals": {"rsi": -100},
+                "fundamentals": {"roe": 9999, "debt_equity": 0},
+                "macro": {},
+                "fii_dii": {"net": 9999999},
+                "news": [],
+            },
+        ]
+        for brief in briefs:
+            for dim in ("fundamentals", "technicals", "macro", "sentiment", "options"):
+                score = _score_dimension(dim, brief)
+                assert 0 <= score <= 100, f"{dim} score {score} out of range"


### PR DESCRIPTION
## Summary

- Add 5 named investor personas: Warren Buffett, Rakesh Jhunjhunwala, Peter Lynch, George Soros, Charlie Munger
- Each persona has distinct philosophy: checklist (≥5 items), dimension weights summing to 1.0, full LLM system prompt
- Deterministic fallback (no LLM needed) scores dimensions via simple heuristics × persona weights
- New CLI commands: `persona list`, `persona <id> <SYMBOL>`, `debate <SYMBOL>`

## New files

- `agent/schemas.py` — `PersonaSignal(BaseModel)` Pydantic schema
- `agent/personas.py` — `InvestorPersona` dataclass + `PERSONAS` dict + `get_persona()` / `list_personas()`
- `agent/persona_agent.py` — `run_persona_analysis()`, `run_debate()`, `parse_persona_response()`
- `app/commands/persona.py` — CLI output (Rich tables, consensus line)
- `specs/165-named-investor-personas.md` — feature spec
- `tests/test_personas.py` — 102 tests, all pass, no LLM required

## Test plan

- [x] `python -m pytest tests/test_personas.py -v` — 102/102 passed
- [x] `python -m pytest --timeout=30 -q -m "not network" --ignore=tests/test_p0_fixes.py` — 1111/1111 passed
- [x] `python -m ruff check --fix` and `python -m ruff format` — clean
