### PR TITLE
feat: route buy/sell/cancel and portfolio reads to correct broker (#178)

### DIFF
--- a/app/repl.py
+++ b/app/repl.py
@@ -2146,7 +2146,10 @@ def run_repl(broker: BrokerAPI) -> None:
                     console.print("[red]No broker connected. Run: broker connect[/red]")
                 else:
                     try:
-                        _orders = broker.get_orders()
+                        from brokers.session import get_execution_broker as _get_exec
+
+                        _exec_broker = _get_exec()
+                        _orders = _exec_broker.get_orders()
                         _open = [
                             o
                             for o in _orders
@@ -2164,7 +2167,7 @@ def run_repl(broker: BrokerAPI) -> None:
                             if _Confirm.ask("  Confirm?", default=False):
                                 for _o in _open:
                                     try:
-                                        broker.cancel_order(_o.order_id)
+                                        _exec_broker.cancel_order(_o.order_id)
                                         console.print(
                                             f"  [green]✓[/green] Cancelled {_o.symbol} {_o.order_id}"
                                         )
@@ -2173,7 +2176,7 @@ def run_repl(broker: BrokerAPI) -> None:
                         elif args:
                             _oid = args[0]
                             try:
-                                broker.cancel_order(_oid)
+                                _exec_broker.cancel_order(_oid)
                                 console.print(f"  [green]✓ Cancelled order {_oid}[/green]")
                             except Exception as _e:
                                 console.print(f"  [red]Cancel failed:[/red] {_e}")
@@ -2194,7 +2197,7 @@ def run_repl(broker: BrokerAPI) -> None:
                             elif _pick.lower() == "all":
                                 for _o in _open:
                                     try:
-                                        broker.cancel_order(_o.order_id)
+                                        _exec_broker.cancel_order(_o.order_id)
                                         console.print(f"  [green]✓[/green] Cancelled {_o.symbol}")
                                     except Exception as _e:
                                         console.print(f"  [red]✗[/red] {_e}")
@@ -2202,7 +2205,7 @@ def run_repl(broker: BrokerAPI) -> None:
                                 try:
                                     _idx = int(_pick) - 1
                                     _o = _open[_idx]
-                                    broker.cancel_order(_o.order_id)
+                                    _exec_broker.cancel_order(_o.order_id)
                                     console.print(
                                         f"  [green]✓ Cancelled {_o.symbol} {_o.order_id}[/green]"
                                     )
@@ -2273,6 +2276,7 @@ def run_repl(broker: BrokerAPI) -> None:
                     if _Confirm.ask("  Confirm?", default=False):
                         try:
                             from brokers.base import OrderRequest as _OR
+                            from brokers.session import get_execution_broker as _get_exec
 
                             _req = _OR(
                                 symbol=_sym,
@@ -2283,7 +2287,7 @@ def run_repl(broker: BrokerAPI) -> None:
                                 price=_limit,
                                 product="CNC",
                             )
-                            _resp = broker.place_order(_req)
+                            _resp = _get_exec().place_order(_req)
                             if _resp.status in ("OPEN", "COMPLETE", "PUT ORDER REQ RECEIVED"):
                                 console.print(
                                     f"  [green]✓ Order placed![/green]  ID: {_resp.order_id}  Status: {_resp.status}"

--- a/engine/alerts.py
+++ b/engine/alerts.py
@@ -515,14 +515,14 @@ class AlertManager:
         if not alert.conditions:
             return False
 
-        from brokers.session import get_broker
+        from brokers.session import get_data_broker
 
         for cond_dict in alert.conditions:
             cond = AlertCondition(**cond_dict) if isinstance(cond_dict, dict) else cond_dict
 
             if cond.condition_type == "PRICE":
                 try:
-                    broker = get_broker()
+                    broker = get_data_broker()
                     instrument = f"{alert.exchange}:{alert.symbol}"
                     ltp = broker.get_ltp(instrument)
                 except Exception:

--- a/engine/portfolio.py
+++ b/engine/portfolio.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 import re
 
-from brokers.session import get_broker
+from brokers.session import get_execution_broker
 from brokers.base import Holding, Position, Funds
 
 
@@ -99,7 +99,7 @@ def get_portfolio_summary() -> PortfolioSummary:
     Full live portfolio snapshot from the primary broker.
     Fetches holdings, positions, funds, computes Greeks for options positions.
     """
-    broker = get_broker()
+    broker = get_execution_broker()
     funds = broker.get_funds()
     holdings = broker.get_holdings()
     positions = broker.get_positions()
@@ -220,7 +220,7 @@ def get_multi_broker_summary() -> PortfolioSummary:
 
 def get_position_greeks() -> PortfolioGreeks:
     """Compute net Greeks across all F&O positions (primary broker)."""
-    broker = get_broker()
+    broker = get_execution_broker()
     positions = broker.get_positions()
     rows = _build_position_rows(positions)
     return _compute_net_greeks(rows)
@@ -228,7 +228,7 @@ def get_position_greeks() -> PortfolioGreeks:
 
 def risk_meter() -> RiskMeter:
     """Capital deployment and risk assessment (primary broker)."""
-    broker = get_broker()
+    broker = get_execution_broker()
     funds = broker.get_funds()
     holdings = broker.get_holdings()
     positions = broker.get_positions()

--- a/engine/risk_metrics.py
+++ b/engine/risk_metrics.py
@@ -321,9 +321,9 @@ def _get_daily_returns(symbol: str, days: int = 252) -> Optional[np.ndarray]:
 def _get_holdings() -> list[dict]:
     """Get current holdings from broker or return empty list."""
     try:
-        from brokers.session import get_broker
+        from brokers.session import get_execution_broker
 
-        broker = get_broker()
+        broker = get_execution_broker()
         holdings = broker.get_holdings()
         return [
             {"symbol": h.symbol, "value": h.last_price * h.quantity, "qty": h.quantity}

--- a/engine/simulator.py
+++ b/engine/simulator.py
@@ -99,9 +99,9 @@ class Simulator:
         if self._loaded:
             return
         try:
-            from brokers.session import get_broker
+            from brokers.session import get_execution_broker
 
-            broker = get_broker()
+            broker = get_execution_broker()
             self._holdings = broker.get_holdings()
             self._positions = broker.get_positions()
         except Exception:

--- a/specs/178-execution-broker-routing.md
+++ b/specs/178-execution-broker-routing.md
@@ -1,0 +1,51 @@
+# Spec: Execution Broker Routing (#178)
+
+## Problem
+
+When Fyers (data) + Zerodha (execution) are both connected, the CLI still
+routes all operations through the **primary broker** (whichever was connected
+first). This means:
+
+- `buy / sell / cancel` place orders via the wrong broker
+- `holdings / positions / funds / portfolio` read from the wrong broker
+- Alert LTP checks ignore the configured data broker
+
+## Solution
+
+Use `get_data_broker()` and `get_execution_broker()` from `brokers/session.py`
+(already exist from #129) at the call sites that were overlooked.
+
+## Routing rules
+
+| Operation | Broker |
+|-----------|--------|
+| Market quotes, LTP, options chains | `get_data_broker()` |
+| Holdings, positions, funds, orders | `get_execution_broker()` |
+| Order placement (buy / sell / cancel) | `get_execution_broker()` |
+| Account profile | primary (unchanged) |
+
+## Changes
+
+### `app/repl.py`
+- `buy` / `sell` commands: resolve broker via `get_execution_broker()` instead
+  of the `broker` local variable
+- `cancel` command: same
+
+### `engine/portfolio.py`
+- `get_portfolio_summary()`, `get_position_greeks()`, `risk_meter()`:
+  `get_broker()` → `get_execution_broker()`
+
+### `engine/risk_metrics.py`
+- `_get_holdings()`: `get_broker()` → `get_execution_broker()`
+
+### `engine/simulator.py`
+- `_load_portfolio()`: `get_broker()` → `get_execution_broker()`
+
+### `engine/alerts.py`
+- `_check_conditional_alert()` LTP path: `get_broker()` → `get_data_broker()`
+  (already falls back to `market.quotes.get_ltp` which uses `get_data_broker()`)
+
+## Fallback behaviour (single broker)
+
+`get_execution_broker()` and `get_data_broker()` already fall back to the
+primary broker when no role is assigned, so single-broker users see no change.

--- a/tests/test_execution_routing.py
+++ b/tests/test_execution_routing.py
@@ -1,0 +1,200 @@
+"""
+Tests for execution broker routing (#178).
+
+Verifies that data reads (holdings, positions, LTP) use get_data_broker() /
+get_execution_broker() rather than the primary broker, when dual-broker is
+configured.
+"""
+
+from __future__ import annotations
+
+import pytest
+import brokers.session as session_mod
+from brokers.mock import MockBrokerAPI
+
+
+@pytest.fixture(autouse=True)
+def reset_session():
+    """Isolate each test from global broker state."""
+    orig_brokers = session_mod._brokers.copy()
+    orig_primary = session_mod._primary_key
+    orig_roles = session_mod._broker_roles.copy()
+    yield
+    session_mod._brokers = orig_brokers
+    session_mod._primary_key = orig_primary
+    session_mod._broker_roles = orig_roles
+
+
+def _setup_dual(data_key="fyers", exec_key="zerodha"):
+    """Register two mock brokers with data/execution roles."""
+    data_broker = MockBrokerAPI()
+    exec_broker = MockBrokerAPI()
+    session_mod._brokers = {data_key: data_broker, exec_key: exec_broker}
+    session_mod._primary_key = data_key
+    session_mod._broker_roles = {data_key: "data", exec_key: "execution"}
+    return data_broker, exec_broker
+
+
+# ── get_data_broker / get_execution_broker ───────────────────
+
+
+class TestBrokerResolution:
+    def test_get_data_broker_returns_data_role(self):
+        from brokers.session import get_data_broker
+
+        data, _ = _setup_dual()
+        assert get_data_broker() is data
+
+    def test_get_execution_broker_returns_exec_role(self):
+        from brokers.session import get_execution_broker
+
+        _, exc = _setup_dual()
+        assert get_execution_broker() is exc
+
+    def test_single_broker_data_falls_back_to_primary(self):
+        from brokers.session import get_data_broker
+
+        mock = MockBrokerAPI()
+        session_mod._brokers = {"mock": mock}
+        session_mod._primary_key = "mock"
+        session_mod._broker_roles = {}
+        assert get_data_broker() is mock
+
+    def test_single_broker_execution_falls_back_to_primary(self):
+        from brokers.session import get_execution_broker
+
+        mock = MockBrokerAPI()
+        session_mod._brokers = {"mock": mock}
+        session_mod._primary_key = "mock"
+        session_mod._broker_roles = {}
+        assert get_execution_broker() is mock
+
+    def test_no_broker_raises(self):
+        from brokers.session import get_execution_broker
+
+        session_mod._brokers = {}
+        session_mod._primary_key = ""
+        with pytest.raises(RuntimeError):
+            get_execution_broker()
+
+
+# ── Portfolio reads use execution broker ─────────────────────
+
+
+class TestPortfolioUsesExecutionBroker:
+    def test_get_portfolio_summary_calls_execution_broker(self, monkeypatch):
+        from engine.portfolio import get_portfolio_summary
+
+        _, exec_broker = _setup_dual()
+
+        calls = []
+
+        def fake_get_holdings():
+            calls.append("holdings")
+            return []
+
+        def fake_get_positions():
+            calls.append("positions")
+            return []
+
+        def fake_get_funds():
+            from brokers.base import Funds
+
+            calls.append("funds")
+            return Funds(available_cash=0, used_margin=0, total_balance=0)
+
+        monkeypatch.setattr(exec_broker, "get_holdings", fake_get_holdings)
+        monkeypatch.setattr(exec_broker, "get_positions", fake_get_positions)
+        monkeypatch.setattr(exec_broker, "get_funds", fake_get_funds)
+
+        get_portfolio_summary()
+        assert "holdings" in calls
+        assert "funds" in calls
+
+    def test_risk_meter_calls_execution_broker(self, monkeypatch):
+        from engine.portfolio import risk_meter
+
+        _, exec_broker = _setup_dual()
+        calls = []
+
+        def fake_get_funds():
+            from brokers.base import Funds
+
+            calls.append("funds")
+            return Funds(available_cash=100000, used_margin=0, total_balance=100000)
+
+        monkeypatch.setattr(exec_broker, "get_holdings", lambda: [])
+        monkeypatch.setattr(exec_broker, "get_positions", lambda: [])
+        monkeypatch.setattr(exec_broker, "get_funds", fake_get_funds)
+
+        risk_meter()
+        assert "funds" in calls
+
+
+# ── Alert LTP check uses data broker ─────────────────────────
+
+
+class TestAlertUsesDataBroker:
+    def test_ltp_check_uses_data_broker(self, monkeypatch):
+        from engine.alerts import AlertManager, Alert
+
+        data_broker, _ = _setup_dual()
+        ltp_calls = []
+
+        def fake_get_ltp(instrument):
+            ltp_calls.append(instrument)
+            return 1500.0
+
+        monkeypatch.setattr(data_broker, "get_ltp", fake_get_ltp)
+
+        mgr = AlertManager()
+        alert = Alert(
+            id="a1",
+            alert_type="CONDITIONAL",
+            symbol="INFY",
+            exchange="NSE",
+            condition="ABOVE",
+            threshold=0.0,
+            conditions=[{"condition_type": "PRICE", "condition": "ABOVE", "threshold": 1000.0}],
+        )
+        result = mgr._check_conditional(alert)
+        assert result is True
+        assert len(ltp_calls) == 1
+
+
+# ── Role auto-assignment on register ─────────────────────────
+
+
+class TestAutoRoleAssignment:
+    def test_fyers_gets_data_role_on_register(self):
+        from brokers.session import register_broker
+
+        mock = MockBrokerAPI()
+        session_mod._brokers = {}
+        session_mod._primary_key = ""
+        session_mod._broker_roles = {}
+        register_broker("fyers", mock, primary=True)
+        assert session_mod._broker_roles.get("fyers") == "data"
+
+    def test_zerodha_gets_execution_role_on_register(self):
+        from brokers.session import register_broker
+
+        fyers = MockBrokerAPI()
+        zerodha = MockBrokerAPI()
+        session_mod._brokers = {}
+        session_mod._primary_key = ""
+        session_mod._broker_roles = {}
+        register_broker("fyers", fyers, primary=True)
+        register_broker("zerodha", zerodha, primary=False)
+        assert session_mod._broker_roles.get("zerodha") == "execution"
+
+    def test_both_role_assigned_when_only_one_broker(self):
+        from brokers.session import register_broker
+
+        mock = MockBrokerAPI()
+        session_mod._brokers = {}
+        session_mod._primary_key = ""
+        session_mod._broker_roles = {}
+        register_broker("mock", mock, primary=True)
+        # Single broker gets "both" role
+        assert session_mod._broker_roles.get("mock") in ("both", "data", "execution", None)


### PR DESCRIPTION
## Summary

In dual-broker mode (Fyers=data + Zerodha=execution), all order placement and portfolio reads were silently going through the **primary broker** instead of the correct one.

**Changes:**
- `app/repl.py`: `buy`, `sell`, `cancel` commands resolve via `get_execution_broker()` instead of the `broker` local variable
- `engine/portfolio.py`: `get_portfolio_summary()`, `get_position_greeks()`, `risk_meter()` use `get_execution_broker()` for holdings/positions/funds
- `engine/risk_metrics.py`: `_get_holdings()` uses `get_execution_broker()`
- `engine/simulator.py`: `_load_portfolio()` uses `get_execution_broker()`
- `engine/alerts.py`: conditional alert LTP check uses `get_data_broker()`

**Single-broker users unaffected** — both `get_execution_broker()` and `get_data_broker()` fall back to the primary broker when no role is assigned.

## Base branch
Stacked on top of `feat/multi-session-dual-broker` (#193) — merge that first.

## Test plan
- [x] `pytest tests/test_execution_routing.py` → 11 passed
- [x] `ruff check` + `ruff format --check` → clean
- [ ] Manual: login Fyers + connect Zerodha → run `buy INFY 1` → verify order goes to Zerodha
- [ ] Manual: run `portfolio` → verify holdings come from Zerodha

🤖 Generated with [Claude Code](https://claude.com/claude-code)